### PR TITLE
feat: vec index trait

### DIFF
--- a/alexandria/data_structures/src/tests/vec_test.cairo
+++ b/alexandria/data_structures/src/tests/vec_test.cairo
@@ -1,7 +1,6 @@
 // Core lib imports
 use array::ArrayTrait;
-use traits::Into;
-use traits::TryInto;
+use traits::{Index, Into, TryInto};
 use option::OptionTrait;
 use result::ResultTrait;
 use dict::Felt252DictTrait;
@@ -88,3 +87,20 @@ fn vec_set_test_expect_error() {
     vec.set(1, 2)
 }
 
+#[test]
+#[available_gas(2000000)]
+fn vec_index_trait_test() {
+    let mut vec = VecTrait::<u128>::new();
+    vec.push(42);
+    vec.push(0x1337);
+    assert(vec[0] == 42, 'vec[0] != 42');
+    assert(vec[1] == 0x1337, 'vec[1] != 0x1337');
+}
+
+#[test]
+#[available_gas(2000000)]
+#[should_panic(expected: ('Index out of bounds', ))]
+fn vec_index_trait_out_of_bounds_test() {
+    let mut vec = VecTrait::<u128>::new();
+    vec[0];
+}

--- a/alexandria/data_structures/src/vec.cairo
+++ b/alexandria/data_structures/src/vec.cairo
@@ -22,9 +22,9 @@ struct Vec<T> {
     len: usize,
 }
 
-impl DestructVec<
-    T, impl TDrop: Drop<T>, impl TFelt252DictValue: Felt252DictValue<T>
-> of Destruct<Vec<T>> {
+impl DestructVec<T,
+impl TDrop: Drop<T>,
+impl TFelt252DictValue: Felt252DictValue<T>> of Destruct<Vec<T>> {
     fn destruct(self: Vec<T>) nopanic {
         self.items.squash();
     }
@@ -40,9 +40,10 @@ trait VecTrait<T> {
     fn len(self: @Vec<T>) -> usize;
 }
 
-impl VecImpl<
-    T, impl TDrop: Drop<T>, impl TCopy: Copy<T>, impl TFelt252DictValue: Felt252DictValue<T>
-> of VecTrait<T> {
+impl VecImpl<T,
+impl TDrop: Drop<T>,
+impl TCopy: Copy<T>,
+impl TFelt252DictValue: Felt252DictValue<T>> of VecTrait<T> {
     /// Creates a new Vec instance.
     /// Returns
     /// * Vec The new vec instance.

--- a/alexandria/data_structures/src/vec.cairo
+++ b/alexandria/data_structures/src/vec.cairo
@@ -22,9 +22,9 @@ struct Vec<T> {
     len: usize,
 }
 
-impl DestructVec<T,
-impl TDrop: Drop<T>,
-impl TFelt252DictValue: Felt252DictValue<T>> of Destruct<Vec<T>> {
+impl DestructVec<
+    T, impl TDrop: Drop<T>, impl TFelt252DictValue: Felt252DictValue<T>
+> of Destruct<Vec<T>> {
     fn destruct(self: Vec<T>) nopanic {
         self.items.squash();
     }
@@ -40,10 +40,9 @@ trait VecTrait<T> {
     fn len(self: @Vec<T>) -> usize;
 }
 
-impl VecImpl<T,
-impl TDrop: Drop<T>,
-impl TCopy: Copy<T>,
-impl TFelt252DictValue: Felt252DictValue<T>> of VecTrait<T> {
+impl VecImpl<
+    T, impl TDrop: Drop<T>, impl TCopy: Copy<T>, impl TFelt252DictValue: Felt252DictValue<T>
+> of VecTrait<T> {
     /// Creates a new Vec instance.
     /// Returns
     /// * Vec The new vec instance.
@@ -115,9 +114,7 @@ impl TFelt252DictValue: Felt252DictValue<T>> of VecTrait<T> {
     }
 }
 
-impl VecIndex<T,
-impl VecTraitImpl: VecTrait<T>
-> of Index<Vec<T>, usize, T> {
+impl VecIndex<T, impl VecTraitImpl: VecTrait<T>> of Index<Vec<T>, usize, T> {
     #[inline(always)]
     fn index(ref self: Vec<T>, index: usize) -> T {
         self.at(index)

--- a/alexandria/data_structures/src/vec.cairo
+++ b/alexandria/data_structures/src/vec.cairo
@@ -15,7 +15,7 @@
 // Core lib imports
 use dict::Felt252DictTrait;
 use option::OptionTrait;
-use traits::Into;
+use traits::{Index, Into};
 
 struct Vec<T> {
     items: Felt252Dict<T>,
@@ -112,5 +112,14 @@ impl TFelt252DictValue: Felt252DictValue<T>> of VecTrait<T> {
     /// * usize The length of the vec.
     fn len(self: @Vec<T>) -> usize {
         *(self.len)
+    }
+}
+
+impl VecIndex<T,
+impl VecTraitImpl: VecTrait<T>
+> of Index<Vec<T>, usize, T> {
+    #[inline(always)]
+    fn index(ref self: Vec<T>, index: usize) -> T {
+        self.at(index)
     }
 }


### PR DESCRIPTION
## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

To fetch an element at a particular index in a `Vec`, one has to use `at`

Issue Number: N/A

## What is the new behavior?

PR implements the `Index` trait to allow for using `[]` operator when fetching Vec elements:

```
let element_at_2 = a_vec[2];
```

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
