### PR TITLE
fix: integer overflow in fast_power

### DIFF
--- a/alexandria/data_structures/src/vec.cairo
+++ b/alexandria/data_structures/src/vec.cairo
@@ -22,9 +22,9 @@ struct Vec<T> {
     len: usize,
 }
 
-impl DestructVec<T,
-impl TDrop: Drop<T>,
-impl TFelt252DictValue: Felt252DictValue<T>> of Destruct<Vec<T>> {
+impl DestructVec<
+    T, impl TDrop: Drop<T>, impl TFelt252DictValue: Felt252DictValue<T>
+> of Destruct<Vec<T>> {
     fn destruct(self: Vec<T>) nopanic {
         self.items.squash();
     }
@@ -40,10 +40,9 @@ trait VecTrait<T> {
     fn len(self: @Vec<T>) -> usize;
 }
 
-impl VecImpl<T,
-impl TDrop: Drop<T>,
-impl TCopy: Copy<T>,
-impl TFelt252DictValue: Felt252DictValue<T>> of VecTrait<T> {
+impl VecImpl<
+    T, impl TDrop: Drop<T>, impl TCopy: Copy<T>, impl TFelt252DictValue: Felt252DictValue<T>
+> of VecTrait<T> {
     /// Creates a new Vec instance.
     /// Returns
     /// * Vec The new vec instance.

--- a/alexandria/encoding/src/base64.cairo
+++ b/alexandria/encoding/src/base64.cairo
@@ -82,37 +82,34 @@ fn decode_loop(p: u8, ref data: Array<u8>, d: usize, ref result: Array<u8>) {
     if (d >= data.len()) {
         return ();
     }
-    let x: u128 = shl(
-        upcast(get_base64_value(*data[d])), 18
-    ) | shl(
-        upcast(get_base64_value(*data[d + 1])), 12
-    ) | shl(upcast(get_base64_value(*data[d + 2])), 6) | upcast(get_base64_value(*data[d + 3]));
+    let x: u128 = shl(upcast(get_base64_value(*data[d])), 18)
+        | shl(upcast(get_base64_value(*data[d + 1])), 12)
+        | shl(upcast(get_base64_value(*data[d + 2])), 6)
+        | upcast(get_base64_value(*data[d + 3]));
 
     let i: u8 = downcast(shr(x, 16) & U8_MAX).unwrap();
     result.append(i);
     let i: u8 = downcast(shr(x, 8) & U8_MAX).unwrap();
-    if d
-        + 4 >= data.len() {
-            if p == 2 {
-                return ();
-            } else {
-                result.append(i);
-            }
+    if d + 4 >= data.len() {
+        if p == 2 {
+            return ();
         } else {
             result.append(i);
         }
+    } else {
+        result.append(i);
+    }
 
     let i: u8 = downcast(x & U8_MAX).unwrap();
-    if d
-        + 4 >= data.len() {
-            if p == 1 {
-                return ();
-            } else {
-                result.append(i);
-            }
+    if d + 4 >= data.len() {
+        if p == 1 {
+            return ();
         } else {
             result.append(i);
         }
+    } else {
+        result.append(i);
+    }
     decode_loop(p, ref data, d + 4, ref result);
 }
 
@@ -154,27 +151,25 @@ fn encode_loop(
     let i: u8 = downcast(shr(x, 12) & U6_MAX).unwrap();
     result.append(*char_set[upcast(i)]);
     let i: u8 = downcast(shr(x, 6) & U6_MAX).unwrap();
-    if upcast(d)
-        + 3 >= data.len() {
-            if p == 2 {
-                result.append('=');
-            } else {
-                result.append(*char_set[upcast(i)]);
-            }
+    if upcast(d) + 3 >= data.len() {
+        if p == 2 {
+            result.append('=');
         } else {
             result.append(*char_set[upcast(i)]);
         }
+    } else {
+        result.append(*char_set[upcast(i)]);
+    }
     let i: u8 = downcast(x & U6_MAX).unwrap();
-    if upcast(d)
-        + 3 >= data.len() {
-            if p >= 1 {
-                result.append('=');
-            } else {
-                result.append(*char_set[upcast(i)]);
-            }
+    if upcast(d) + 3 >= data.len() {
+        if p >= 1 {
+            result.append('=');
         } else {
             result.append(*char_set[upcast(i)]);
         }
+    } else {
+        result.append(*char_set[upcast(i)]);
+    }
     encode_loop(p, ref data, d + 3, ref char_set, ref result);
 }
 

--- a/alexandria/math/src/fast_power.cairo
+++ b/alexandria/math/src/fast_power.cairo
@@ -22,7 +22,7 @@ fn fast_power(mut base: u128, mut power: u128, modulus: u128) -> u128 {
     // TODO: Simplify thise conversions after https://github.com/starkware-libs/cairo/pull/3293 is merged and released.
     let mut base: u256 = u256 { low: base, high: 0 };
     let modulus: u256 = u256 { low: modulus, high: 0 };
-    let mut result: u256 = 1;
+    let mut result: u256 = u256 { low: 1, high: 0 };
 
     let res = loop {
         if power == 0 {
@@ -42,6 +42,6 @@ fn fast_power(mut base: u128, mut power: u128, modulus: u128) -> u128 {
     if high != 0 {
         panic_with_felt252('value cant be larger than u128')
     }
-    
+
     return low;
 }

--- a/alexandria/math/src/fast_power.cairo
+++ b/alexandria/math/src/fast_power.cairo
@@ -1,21 +1,30 @@
 //! # Fast power algorithm
 use array::ArrayTrait;
+use integer::{u128_wide_mul};
+use core::option::OptionTrait;
+use core::traits::TryInto;
 
-// Calculate the (base^power)mod modulus using the fast powering algorithm
-// # Arguments
-// * `base` - The base of the exponentiation
-// * `power` - The power of the exponentiation
-// * `modulus` - The modulus used in the calculation
-// # Returns
-// * `felt252` - The result of (base^power)mod modulus
+// Calculate the ( base ^ power ) mod modulus
+// using the fast powering algorithm # Arguments
+// * ` base ` - The base of the exponentiation * ` power ` - The power of the exponentiation * ` modulus ` - The modulus used in the calculation # Returns
+// * ` u128 ` - The result of ( base ^ power ) mod modulus
+
 fn fast_power(mut base: u128, mut power: u128, modulus: u128) -> u128 {
     // Return invalid input error
     if base == 0 {
         panic_with_felt252('II')
     }
 
-    let mut result = 1;
-    loop {
+    if modulus == 1 {
+        return 0;
+    }
+
+    // TODO: Simplify thise conversions after https://github.com/starkware-libs/cairo/pull/3293 is merged and released.
+    let mut base: u256 = u256 { low: base, high: 0 };
+    let modulus: u256 = u256 { low: modulus, high: 0 };
+    let mut result: u256 = 1;
+
+    let res = loop {
         if power == 0 {
             break result;
         }
@@ -23,7 +32,16 @@ fn fast_power(mut base: u128, mut power: u128, modulus: u128) -> u128 {
         if power % 2 != 0 {
             result = (result * base) % modulus;
         }
+
         base = (base * base) % modulus;
         power = power / 2;
+    };
+
+    let u256{low: low, high: high } = res;
+
+    if high != 0 {
+        panic_with_felt252('value cant be larger than u128')
     }
+    
+    return low;
 }

--- a/alexandria/math/src/fast_power.cairo
+++ b/alexandria/math/src/fast_power.cairo
@@ -1,12 +1,13 @@
 //! # Fast power algorithm
 use array::ArrayTrait;
-use integer::{u128_wide_mul};
 use core::option::OptionTrait;
 use core::traits::TryInto;
 
 // Calculate the ( base ^ power ) mod modulus
 // using the fast powering algorithm # Arguments
-// * ` base ` - The base of the exponentiation * ` power ` - The power of the exponentiation * ` modulus ` - The modulus used in the calculation # Returns
+// * ` base ` - The base of the exponentiation 
+// * ` power ` - The power of the exponentiation 
+// * ` modulus ` - The modulus used in the calculation # Returns
 // * ` u128 ` - The result of ( base ^ power ) mod modulus
 
 fn fast_power(mut base: u128, mut power: u128, modulus: u128) -> u128 {

--- a/alexandria/math/src/sha256.cairo
+++ b/alexandria/math/src/sha256.cairo
@@ -181,11 +181,10 @@ fn from_u8Array_to_u32Array(data: Array<u8>, i: usize) -> Array<u32> {
 }
 
 fn add_padding(ref data: Array<u8>) {
-    if (64 * ((data.len() - 1) / 64 + 1))
-        - 8 != data.len() {
-            data.append(0);
-            add_padding(ref data);
-        }
+    if (64 * ((data.len() - 1) / 64 + 1)) - 8 != data.len() {
+        data.append(0);
+        add_padding(ref data);
+    }
 }
 
 fn get_h() -> Array<u32> {

--- a/alexandria/math/src/tests/fast_power_test.cairo
+++ b/alexandria/math/src/tests/fast_power_test.cairo
@@ -8,4 +8,30 @@ fn fast_power_test() {
     assert(fast_power(2, 3, 17) == 8, 'invalid result');
     assert(fast_power(3, 4, 17) == 13, 'invalid result');
     assert(fast_power(2, 100, 1000000007) == 976371285, 'invalid result');
+    assert(
+        fast_power(
+            2, 127, 340282366920938463463374607431768211454
+        ) == 170141183460469231731687303715884105728,
+        'invalid result'
+    );
+    assert(
+        fast_power(
+            2, 127, 34028236692093846346337460743176821144
+        ) == 8,
+        'invalid result'
+    );
+
+    assert(
+        fast_power(
+            2, 128, 9299
+        ) == 1412,
+        'invalid result'
+    );
+
+    assert(
+        fast_power(
+            2 , 88329 , 34028236692093846346337460743176821144
+        ) == 2199023255552,
+        'invalid result'
+    );
 }

--- a/alexandria/math/src/tests/fast_power_test.cairo
+++ b/alexandria/math/src/tests/fast_power_test.cairo
@@ -14,24 +14,12 @@ fn fast_power_test() {
         ) == 170141183460469231731687303715884105728,
         'invalid result'
     );
-    assert(
-        fast_power(
-            2, 127, 34028236692093846346337460743176821144
-        ) == 8,
-        'invalid result'
-    );
+    assert(fast_power(2, 127, 34028236692093846346337460743176821144) == 8, 'invalid result');
+
+    assert(fast_power(2, 128, 9299) == 1412, 'invalid result');
 
     assert(
-        fast_power(
-            2, 128, 9299
-        ) == 1412,
-        'invalid result'
-    );
-
-    assert(
-        fast_power(
-            2 , 88329 , 34028236692093846346337460743176821144
-        ) == 2199023255552,
+        fast_power(2, 88329, 34028236692093846346337460743176821144) == 2199023255552,
         'invalid result'
     );
 }

--- a/alexandria/searching/src/binary_search.cairo
+++ b/alexandria/searching/src/binary_search.cairo
@@ -1,10 +1,8 @@
 use array::SpanTrait;
 
-fn binary_search<T,
-impl TCopy: Copy<T>,
-impl TDrop: Drop<T>,
-impl TEq: PartialEq<T>,
-impl TOr: PartialOrd<T>>(
+fn binary_search<
+    T, impl TCopy: Copy<T>, impl TDrop: Drop<T>, impl TEq: PartialEq<T>, impl TOr: PartialOrd<T>
+>(
     span: Span<T>, val: T
 ) -> Option<u32> {
     // Initial check

--- a/alexandria/sorting/src/bubble_sort.cairo
+++ b/alexandria/sorting/src/bubble_sort.cairo
@@ -6,10 +6,9 @@ use array::ArrayTrait;
 /// * `array` - Array to sort
 /// # Returns
 /// * `Array<usize>` - Sorted array
-fn bubble_sort_elements<T,
-impl TCopy: Copy<T>,
-impl TDrop: Drop<T>,
-impl TPartialOrd: PartialOrd<T>>(
+fn bubble_sort_elements<
+    T, impl TCopy: Copy<T>, impl TDrop: Drop<T>, impl TPartialOrd: PartialOrd<T>
+>(
     mut array: Array<T>
 ) -> Array<T> {
     if array.len() <= 1 {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #95 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- panic with overflow error for certain inputs

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

I have choose to change all the parameter types to `u256` instead of using [`u128_wide_mul`](https://github.com/starkware-libs/cairo/blob/77ae28f996c0960ce5cfc926703f60bae8d5db5a/corelib/src/integer.cairo#L66C1-L69).

Because in the loop:
- we would need to do it in 2 places, so 2 type conversions to u256
-  `%` is only implemented for same types we cannot calculate `u256 % u128`, so would need to convert `modulus` to u256 
- after calculating modulus would needs to cast it back to u128

Also for some reason comment mentioned result of function is `felt252` instead of `u128`, so have fixed that as well.