### PR TITLE
Add generic type parameter to Stack implementation

### DIFF
--- a/alexandria/data_structures/src/data_structures.cairo
+++ b/alexandria/data_structures/src/data_structures.cairo
@@ -6,7 +6,9 @@ use array::ArrayTrait;
 /// * `end` - The index to end the slice at (not included).
 /// # Returns
 /// * `Array<u256>` - The slice of the array.
-fn array_slice<T, impl TDrop: Drop<T>, impl TCopy: Copy<T>>(src: @Array<T>, mut begin: usize, end: usize) -> Array<T> {
+fn array_slice<T, impl TDrop: Drop<T>, impl TCopy: Copy<T>>(
+    src: @Array<T>, mut begin: usize, end: usize
+) -> Array<T> {
     let mut slice = ArrayTrait::<T>::new();
     let len = begin + end;
     loop {

--- a/alexandria/data_structures/src/data_structures.cairo
+++ b/alexandria/data_structures/src/data_structures.cairo
@@ -6,8 +6,8 @@ use array::ArrayTrait;
 /// * `end` - The index to end the slice at (not included).
 /// # Returns
 /// * `Array<u256>` - The slice of the array.
-fn array_slice(src: @Array<u256>, mut begin: usize, end: usize) -> Array<u256> {
-    let mut slice = ArrayTrait::new();
+fn array_slice<T, impl TDrop: Drop<T>, impl TCopy: Copy<T>>(src: @Array<T>, mut begin: usize, end: usize) -> Array<T> {
+    let mut slice = ArrayTrait::<T>::new();
     let len = begin + end;
     loop {
         if begin >= len {
@@ -22,4 +22,3 @@ fn array_slice(src: @Array<u256>, mut begin: usize, end: usize) -> Array<u256> {
     };
     slice
 }
-

--- a/alexandria/data_structures/src/merkle_tree.cairo
+++ b/alexandria/data_structures/src/merkle_tree.cairo
@@ -54,7 +54,7 @@ impl MerkleTreeImpl of MerkleTreeTrait {
                     // Compute the hash of the current node and the current element of the proof.
                     // We need to check if the current node is smaller than the current element of the proof.
                     // If it is, we need to swap the order of the hash.
-                    if current_node.into() < (*proof_element).into() {
+                    if current_node.into() < Felt252IntoU256::into(*proof_element) {
                         current_node = LegacyHash::hash(current_node, *proof_element);
                     } else {
                         current_node = LegacyHash::hash(*proof_element, current_node);

--- a/alexandria/data_structures/src/merkle_tree.cairo
+++ b/alexandria/data_structures/src/merkle_tree.cairo
@@ -54,7 +54,9 @@ impl MerkleTreeImpl of MerkleTreeTrait {
                     // Compute the hash of the current node and the current element of the proof.
                     // We need to check if the current node is smaller than the current element of the proof.
                     // If it is, we need to swap the order of the hash.
-                    if current_node.into() < Felt252IntoU256::into(*proof_element) {
+                    if current_node.into() < Felt252IntoU256::into(
+                        *proof_element
+                    ) {
                         current_node = LegacyHash::hash(current_node, *proof_element);
                     } else {
                         current_node = LegacyHash::hash(*proof_element, current_node);

--- a/alexandria/data_structures/src/stack.cairo
+++ b/alexandria/data_structures/src/stack.cairo
@@ -22,31 +22,31 @@ use alexandria_data_structures::array_slice;
 const ZERO_USIZE: usize = 0;
 
 #[derive(Drop)]
-struct Stack {
-    elements: Array<u256>, 
+struct Stack<T> {
+    elements: Array<T>,
 }
 
-trait StackTrait {
+trait StackTrait<T> {
     /// Creates a new Stack instance.
-    fn new() -> Stack;
+    fn new() -> Stack<T>;
     /// Pushes a new value onto the stack.
-    fn push(ref self: Stack, value: u256);
+    fn push(ref self: Stack<T>, value: T);
     /// Removes the last item from the stack and returns it, or None if the stack is empty.
-    fn pop(ref self: Stack) -> Option<u256>;
+    fn pop(ref self: Stack<T>) -> Option<T>;
     /// Returns the last item from the stack without removing it, or None if the stack is empty.
-    fn peek(self: @Stack) -> Option<u256>;
+    fn peek(self: @Stack<T>) -> Option<T>;
     /// Returns the number of items in the stack.
-    fn len(self: @Stack) -> usize;
+    fn len(self: @Stack<T>) -> usize;
     /// Returns true if the stack is empty.
-    fn is_empty(self: @Stack) -> bool;
+    fn is_empty(self: @Stack<T>) -> bool;
 }
 
-impl StackImpl of StackTrait {
+impl StackImpl<T, impl TCopy: Copy<T>, impl TDrop: Drop<T>> of StackTrait<T> {
     #[inline(always)]
     /// Creates a new Stack instance.
     /// Returns
     /// * Stack The new stack instance.
-    fn new() -> Stack {
+    fn new() -> Stack<T> {
         let mut elements = ArrayTrait::new();
         Stack { elements }
     }
@@ -54,7 +54,7 @@ impl StackImpl of StackTrait {
     /// Pushes a new value onto the stack.
     /// * `self` - The stack to push the value onto.
     /// * `value` - The value to push onto the stack.
-    fn push(ref self: Stack, value: u256) {
+    fn push(ref self: Stack<T>, value: T) {
         let Stack{mut elements } = self;
         elements.append(value);
         self = Stack { elements }
@@ -66,12 +66,12 @@ impl StackImpl of StackTrait {
     /// Returns
     /// * Stack The stack with the item removed.
     /// * Option<u256> The item removed or None if the stack is empty.
-    fn pop(ref self: Stack) -> Option<u256> {
+    fn pop(ref self: Stack<T>) -> Option<T> {
         if self.is_empty() {
             return Option::None(());
         }
         // Deconstruct the stack struct because we consume it
-        let Stack{elements: mut elements } = self;
+        let Stack{ elements: mut elements } = self;
         let stack_len = elements.len();
         let last_idx = stack_len - 1;
 
@@ -86,7 +86,7 @@ impl StackImpl of StackTrait {
     /// * `self` - The stack to peek the item off of.
     /// Returns
     /// * Option<u256> The last item of the stack
-    fn peek(self: @Stack) -> Option<u256> {
+    fn peek(self: @Stack<T>) -> Option<T> {
         if self.is_empty() {
             return Option::None(());
         }
@@ -97,7 +97,7 @@ impl StackImpl of StackTrait {
     /// * `self` - The stack to get the length of.
     /// Returns
     /// * usize The number of items in the stack.
-    fn len(self: @Stack) -> usize {
+    fn len(self: @Stack<T>) -> usize {
         self.elements.len()
     }
 
@@ -105,7 +105,7 @@ impl StackImpl of StackTrait {
     /// * `self` - The stack to check if it is empty.
     /// Returns
     /// * bool True if the stack is empty, false otherwise.
-    fn is_empty(self: @Stack) -> bool {
+    fn is_empty(self: @Stack<T>) -> bool {
         self.len() == ZERO_USIZE
     }
 }

--- a/alexandria/data_structures/src/tests/stack_test.cairo
+++ b/alexandria/data_structures/src/tests/stack_test.cairo
@@ -111,11 +111,7 @@ fn felt252_stack_is_empty_test() {
 #[available_gas(2000000)]
 fn felt252_stack_push_test() {
     let mut stack = StackTrait::<Felt252Stack, u128>::new();
-    stack_push_test(
-        ref stack,
-        1.try_into().unwrap(),
-        2.try_into().unwrap()
-    );
+    stack_push_test(ref stack, 1.try_into().unwrap(), 2.try_into().unwrap());
 }
 
 
@@ -123,22 +119,14 @@ fn felt252_stack_push_test() {
 #[available_gas(2000000)]
 fn felt252_stack_peek_test() {
     let mut stack = StackTrait::<Felt252Stack, u128>::new();
-    stack_peek_test(
-        ref stack,
-        1.try_into().unwrap(),
-        2.try_into().unwrap()
-    );
+    stack_peek_test(ref stack, 1.try_into().unwrap(), 2.try_into().unwrap());
 }
 
 #[test]
 #[available_gas(2000000)]
 fn felt252_stack_pop_test() {
     let mut stack = StackTrait::<Felt252Stack, u128>::new();
-    stack_pop_test(
-        ref stack,
-        1.try_into().unwrap(),
-        2.try_into().unwrap()
-    );
+    stack_pop_test(ref stack, 1.try_into().unwrap(), 2.try_into().unwrap());
 }
 
 #[test]
@@ -147,10 +135,8 @@ fn felt252_stack_push_pop_push_test() {
     let mut stack = StackTrait::<Felt252Stack, u128>::new();
 
     stack_push_pop_push_test(
-        ref stack,
-        1.try_into().unwrap(),
-        2.try_into().unwrap(),
-        3.try_into().unwrap());
+        ref stack, 1.try_into().unwrap(), 2.try_into().unwrap(), 3.try_into().unwrap()
+    );
 }
 
 

--- a/alexandria/data_structures/src/tests/stack_test.cairo
+++ b/alexandria/data_structures/src/tests/stack_test.cairo
@@ -8,7 +8,7 @@ use alexandria_data_structures::stack::StackTrait;
 #[test]
 #[available_gas(2000000)]
 fn stack_new_test() {
-    let mut stack = StackTrait::new();
+    let mut stack = StackTrait::<u256>::new();
     let result_len = stack.len();
 
     assert(result_len == 0, 'stack length should be 0');
@@ -17,7 +17,7 @@ fn stack_new_test() {
 #[test]
 #[available_gas(2000000)]
 fn stack_is_empty_test() {
-    let mut stack = StackTrait::new();
+    let mut stack = StackTrait::<u256>::new();
     let result = stack.is_empty();
 
     assert(result == true, 'stack should be empty');
@@ -26,7 +26,7 @@ fn stack_is_empty_test() {
 #[test]
 #[available_gas(2000000)]
 fn stack_push_test() {
-    let mut stack = StackTrait::new();
+    let mut stack = StackTrait::<u256>::new();
     let val_1: u256 = 1.into();
     let val_2: u256 = 2.into();
 
@@ -42,7 +42,7 @@ fn stack_push_test() {
 #[test]
 #[available_gas(2000000)]
 fn stack_peek_test() {
-    let mut stack = StackTrait::new();
+    let mut stack = StackTrait::<u256>::new();
     let val_1: u256 = 1.into();
     let val_2: u256 = 2.into();
 
@@ -64,7 +64,7 @@ fn stack_peek_test() {
 #[test]
 #[available_gas(2000000)]
 fn stack_pop_test() {
-    let mut stack = StackTrait::new();
+    let mut stack = StackTrait::<u256>::new();
     let val_1: u256 = 1.into();
     let val_2: u256 = 2.into();
 
@@ -84,4 +84,3 @@ fn stack_pop_test() {
 // let result_len = stack.len();
 // assert(result_len == 1, 'should remove item');
 }
-


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Stack implementation is bound to u256;

Issue Number: N/A

## What is the new behavior?

Stack implementation takes generic type parameter:

```
let mut stack = StackTrait::<u256>::new();
```

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
