### PR TITLE
fix(encoding/base64): use character set passed as argument

### DIFF
--- a/alexandria/encoding/src/base64.cairo
+++ b/alexandria/encoding/src/base64.cairo
@@ -55,9 +55,6 @@ fn inner_encode(ref data: Array<u8>, ref char_set: Array<u8>) -> Array<u8> {
         0
     };
 
-    let mut char_set = get_base64_char_set();
-    char_set.append('-');
-    char_set.append('_');
     let mut result = ArrayTrait::new();
     encode_loop(p, ref data, 0, ref char_set, ref result);
     result


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`encode_inner` is already passed a character set, it should use that instead of generating it again. This will cause `Base64Encoder` to also use `-` and `_` in character set when it should have been `+` and `/`.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Now character set are properly used

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

I tried to add a test which would cause the encoded output to include `+` and `/`, so maybe this implementation is broken for non-printable characters.