### PR TITLE
Serde i33

### DIFF
--- a/alexandria/math/src/signed_integers.cairo
+++ b/alexandria/math/src/signed_integers.cairo
@@ -1,5 +1,7 @@
 // Signed integers : i9, i17, i33, i65, i129
 
+use serde::{Serde, BoolSerde};
+
 // ====================== INT 9 ======================
 
 // i9 represents a 9-bit integer.
@@ -800,6 +802,8 @@ fn i17_min(lhs: i17, rhs: i17) -> i17 {
 
 // ====================== INT 33 ======================
 
+use serde::U32Serde;
+
 // i33 represents a 33-bit integer.
 // The inner field holds the absolute value of the integer.
 // The sign field is true for negative integers, and false for non-negative integers.
@@ -1194,6 +1198,21 @@ fn i33_min(lhs: i33, rhs: i33) -> i33 {
         return lhs;
     } else {
         return rhs;
+    }
+}
+
+impl I33Serde of Serde<i33> {
+    fn serialize(self: @i33, ref output: Array<felt252>) {
+        self.inner.serialize(ref output);
+        self.sign.serialize(ref output)
+    }
+    fn deserialize(ref serialized: Span<felt252>) -> Option<i33> {
+        Option::Some(
+            i33 {
+                inner: U32Serde::deserialize(ref serialized)?,
+                sign: BoolSerde::deserialize(ref serialized)?,
+            },
+        )
     }
 }
 

--- a/alexandria/math/src/tests/signed_integers_test.cairo
+++ b/alexandria/math/src/tests/signed_integers_test.cairo
@@ -1,3 +1,6 @@
+use serde::Serde;
+use option::OptionTrait;
+use array::ArrayTrait;
 use alexandria_math::signed_integers;
 use alexandria_math::signed_integers::{i9, i9_div_rem};
 
@@ -629,7 +632,7 @@ fn i17_test_check_sign_zero() {
 
 // ====================== INT 33 ======================
 
-use alexandria_math::signed_integers::i33;
+use alexandria_math::signed_integers::{i33, I33Serde};
 use alexandria_math::signed_integers::i33_div_rem;
 
 #[test]
@@ -940,6 +943,21 @@ fn i33_test_equality() {
 fn i33_test_check_sign_zero() {
     let x = i33 { inner: 0_u32, sign: true };
     signed_integers::i33_check_sign_zero(x);
+}
+
+#[test]
+#[available_gas(2000000)]
+fn i33_test_serde() {
+    let a = i33 { inner: 42_u32, sign: false };
+    let mut serilized: Array<felt252> = ArrayTrait::new();
+    a.serialize(ref serilized);
+    assert(42 == *serilized.at(0), 'i33 serialization failed');
+    assert(0 == *serilized.at(1), 'i33 serialization failed');
+
+    let mut serialized_span = serilized.span();
+    let a_deserialized = I33Serde::deserialize(ref serialized_span).unwrap();
+    assert(42 == a_deserialized.inner, 'i33 deserialization failed');
+    assert(false == a_deserialized.sign, 'i33 deserialization failed');
 }
 
 // ====================== INT 65 ======================


### PR DESCRIPTION
Adds serde ops for i33

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

No serde ops for i33, and it can't be used in contracts.

Issue Number: N/A

## What is the new behavior?

i33 type can be used in contract endpoint params/return values.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

Will add `serde` for other `i` types soon.