### PR TITLE
feat(storage): list

### DIFF
--- a/alexandria/storage/README.md
+++ b/alexandria/storage/README.md
@@ -1,0 +1,3 @@
+# Storage
+
+TODO

--- a/alexandria/storage/Scarb.toml
+++ b/alexandria/storage/Scarb.toml
@@ -1,0 +1,5 @@
+[package]
+name = "alexandria_storage"
+version = "0.1.0"
+description = "Starknet storage utilities"
+homepage = "https://github.com/keep-starknet-strange/alexandria/tree/main/storage"

--- a/alexandria/storage/cairo_project.toml
+++ b/alexandria/storage/cairo_project.toml
@@ -1,0 +1,2 @@
+[crate_roots]
+alexandria_storage = "src"

--- a/alexandria/storage/src/lib.cairo
+++ b/alexandria/storage/src/lib.cairo
@@ -1,0 +1,4 @@
+mod list;
+
+#[cfg(test)]
+mod tests;

--- a/alexandria/storage/src/list.cairo
+++ b/alexandria/storage/src/list.cairo
@@ -37,13 +37,6 @@ trait StorageSize<T> {
     fn storage_size() -> u8;
 }
 
-// any type that can Into to u128 has a size of 1
-impl StorageSizeU128<T, impl TInto: Into<T, u128>> of StorageSize<T> {
-    fn storage_size() -> u8 {
-        1
-    }
-}
-
 // any type that can Into to felt252 has a size of 1
 impl StorageSizeFelt252<T, impl TInto: Into<T, felt252>> of StorageSize<T> {
     fn storage_size() -> u8 {
@@ -51,8 +44,8 @@ impl StorageSizeFelt252<T, impl TInto: Into<T, felt252>> of StorageSize<T> {
     }
 }
 
-// any type that can Into to u256 has a size of 2
-impl StorageSizeU256<T, impl TInto: Into<T, u256>> of StorageSize<T> {
+// u256 needs 2 storage slots
+impl StorageSizeU256 of StorageSize<u256> {
     fn storage_size() -> u8 {
         2
     }

--- a/alexandria/storage/src/list.cairo
+++ b/alexandria/storage/src/list.cairo
@@ -1,0 +1,200 @@
+use hash::LegacyHash;
+use integer::U32DivRem;
+use option::OptionTrait;
+use starknet::{storage_read_syscall, storage_write_syscall, SyscallResult, SyscallResultTrait};
+use starknet::storage_access::{StorageAccess, StorageBaseAddress, storage_address_to_felt252, storage_address_from_base, storage_address_from_base_and_offset, storage_base_address_from_felt252};
+use traits::{Default, DivRem, IndexView, Into, TryInto};
+
+const POW2_8: u32 = 256; // 2^8
+
+#[derive(Drop)]
+struct List<T> {
+    address_domain: u32,
+    base: StorageBaseAddress,
+    len: u32, // number of elements in array
+    storage_size: u8
+}
+
+trait ListTrait<T> {
+    fn len(self: @List<T>) -> u32;
+    fn is_empty(self: @List<T>) -> bool;
+    fn append(ref self: List<T>, value: T) -> u32;
+    fn get(self: @List<T>, index: u32) -> T;
+    fn set(ref self: List<T>, index: u32, value: T);
+}
+
+// when writing elements in storage, we need to know how many storage slots
+// they take up to properly calculate the offset into a storage segment
+// that's what this trait provides
+// it's very similar to the `size_internal` function in StorageAccess trait
+// with one crutial difference - this function does not need a T element
+// to return the size of the T element!
+trait StorageSize<T> {
+    fn storage_size() -> u8;
+}
+
+// any type that can Into to u128 has a size of 1
+impl StorageSizeU128<T, impl TInto: Into<T, u128>> of StorageSize<T> {
+    fn storage_size() -> u8 {
+        1
+    }
+}
+
+// any type that can Into to felt252 has a size of 1
+impl StorageSizeFelt252<T, impl TInto: Into<T, felt252>> of StorageSize<T> {
+    fn storage_size() -> u8 {
+        1
+    }
+}
+
+// any type that can Into to u258 has a size of 2
+impl StorageSizeU256<T, impl TInto: Into<T, u256>> of StorageSize<T> {
+    fn storage_size() -> u8 {
+        2
+    }
+}
+
+impl ListImpl<T,
+    impl TCopy: Copy<T>,
+    impl TDrop: Drop<T>,
+    impl TStorageAccess: StorageAccess<T>,
+    impl TStorageSize: StorageSize<T>>
+    of ListTrait<T>
+{
+    fn len(self: @List<T>) -> u32 {
+        *self.len
+    }
+
+    fn is_empty(self: @List<T>) -> bool {
+        *self.len == 0
+    }
+
+    fn append(ref self: List<T>, value: T) -> u32 {
+        let (base, offset) = calculate_base_and_offset_for_index(self.base, self.len, self.storage_size);
+        StorageAccess::write_at_offset_internal(
+            self.address_domain,
+            base,
+            offset,
+            value
+        ).unwrap_syscall();
+
+        let append_at = self.len;
+        self.len += 1;
+        StorageAccess::write(self.address_domain, self.base, self.len);
+
+        append_at
+    }
+
+    fn get(self: @List<T>, index: u32) -> T {
+        assert(index < *self.len, 'index out of bounds');
+        let (base, offset) = calculate_base_and_offset_for_index(*self.base, index, *self.storage_size);
+        StorageAccess::read_at_offset_internal(
+            *self.address_domain,
+            base,
+            offset
+        ).unwrap_syscall()
+    }
+
+    fn set(ref self: List<T>, index: u32, value: T) {
+        assert(index < self.len, 'index out of bounds');
+        let (base, offset) = calculate_base_and_offset_for_index(self.base, index, self.storage_size);
+        StorageAccess::write_at_offset_internal(
+            self.address_domain,
+            base,
+            offset,
+            value
+        ).unwrap_syscall();
+    }
+}
+
+impl AListIndexViewImpl<T,
+    impl TCopy: Copy<T>,
+    impl TDrop: Drop<T>,
+    impl TStorageAccess: StorageAccess<T>,
+    impl TStorageSize: StorageSize<T>>
+    of IndexView<List<T>, u32, T>
+{
+    fn index(self: @List<T>, index: u32) -> T {
+        self.get(index)
+    }
+}
+
+// this functions finds the StorageBaseAddress of a "storage segment" (a continuous space of 256 storage slots)
+// and an offset into that segment where a value at `index` is stored
+// each segment can hold up to `256 // storage_size` elements
+//
+// the way how the address is calculated is very similar to how a LegacyHash map works:
+//
+// first we take the `list_base` address which is derived from the name of the storage variable
+// then we hash it with a `key` which is the number of the segment where the element at `index` belongs (from 0 upwards)
+// we hash these two values: H(list_base, key) to the the `segment_base` address
+// finally, we calculate the offset into this segment, taking into account the size of the elements held in the array
+//
+// by way of example:
+//
+// say we have an List<Foo> and Foo's storage_size is 8
+// struct storage: {
+//    bar: List<Foo>
+// }
+//
+// the storage layout would look like this:
+//
+// segment0: [0..31] - elements at indexes 0 to 31
+// segment1: [32..63] - elements at indexes 32 to 63
+// segment2: [64..95] - elements at indexes 64 to 95
+// etc.
+//
+// where addresses of each segment are:
+//
+// segment0 = hash(bar.address(), 0)
+// segment1 = hash(bar.address(), 1)
+// segment2 = hash(bar.address(), 2)
+//
+// so for getting a Foo at index 90 this function would return address of segment2 and offset of 26
+
+fn calculate_base_and_offset_for_index(list_base: StorageBaseAddress, index: u32, storage_size: u8) -> (StorageBaseAddress, u8) {
+    let max_elements = POW2_8 / storage_size.into();
+    let (key, offset) = U32DivRem::div_rem(index, max_elements.try_into().unwrap());
+
+    let segment_base = storage_base_address_from_felt252(
+        LegacyHash::hash(
+            storage_address_to_felt252(
+                storage_address_from_base(
+                    list_base
+                )
+            ),
+            key
+    ));
+
+    (segment_base, offset.try_into().unwrap() * storage_size)
+}
+
+impl ListStorageAccess<T, impl TStorageSize: StorageSize<T>> of StorageAccess<List<T>> {
+    fn read(address_domain: u32, base: StorageBaseAddress) -> SyscallResult<List<T>> {
+        let len: u32 = StorageAccess::read(address_domain, base).unwrap_syscall();
+        let storage_size: u8 = StorageSize::<T>::storage_size();
+        Result::Ok(List { address_domain, base, len, storage_size })
+    }
+
+    fn write(address_domain: u32, base: StorageBaseAddress, value: List<T>) -> SyscallResult<()> {
+        StorageAccess::write(address_domain, base, value.len)
+    }
+
+    fn read_at_offset_internal(
+        address_domain: u32, base: StorageBaseAddress, offset: u8
+    ) -> SyscallResult<List<T>> {
+        let len: u32 = StorageAccess::read_at_offset_internal(address_domain, base, offset).unwrap_syscall();
+        let storage_size: u8 = StorageSize::<T>::storage_size();
+        Result::Ok(List { address_domain, base, len, storage_size })
+    }
+
+    fn write_at_offset_internal(
+        address_domain: u32, base: StorageBaseAddress, offset: u8, value: List<T>
+    ) -> SyscallResult<()> {
+        StorageAccess::write_at_offset_internal(address_domain, base, offset, value.len)
+    }
+
+    fn size_internal(value: List<T>) -> u8 {
+        StorageAccess::size_internal(value.len)
+    }
+}

--- a/alexandria/storage/src/list.cairo
+++ b/alexandria/storage/src/list.cairo
@@ -51,7 +51,7 @@ impl StorageSizeFelt252<T, impl TInto: Into<T, felt252>> of StorageSize<T> {
     }
 }
 
-// any type that can Into to u258 has a size of 2
+// any type that can Into to u256 has a size of 2
 impl StorageSizeU256<T, impl TInto: Into<T, u256>> of StorageSize<T> {
     fn storage_size() -> u8 {
         2

--- a/alexandria/storage/src/tests.cairo
+++ b/alexandria/storage/src/tests.cairo
@@ -1,0 +1,1 @@
+mod list_test;

--- a/alexandria/storage/src/tests/list_test.cairo
+++ b/alexandria/storage/src/tests/list_test.cairo
@@ -1,0 +1,236 @@
+use starknet::ContractAddress;
+
+#[starknet::interface]
+trait IAListHolder<TContractState> {
+    fn do_get_len(self: @TContractState) -> (u32, u32);
+    fn do_is_empty(self: @TContractState) -> (bool, bool);
+    fn do_append(ref self: TContractState, addrs_value: ContractAddress, numbers_value: u256) -> (u32, u32);
+    fn do_get(self: @TContractState, index: u32) -> (ContractAddress, u256);
+    fn do_get_index(self: @TContractState, index: u32) -> (ContractAddress, u256);
+    fn do_set(ref self: TContractState, index: u32, addrs_value: ContractAddress, numbers_value: u256);
+}
+
+#[starknet::contract]
+mod AListHolder {
+    use alexandria_storage::list::{List, ListTrait};
+    use starknet::ContractAddress;
+
+    #[storage]
+    struct Storage {
+        // to test a corelib type that has StorageAccess and
+        // Into<ContractAddress, felt252>
+        addrs: List<ContractAddress>,
+
+        // to test a corelib compound struct
+        numbers: List<u256>
+    }
+
+    #[external(v0)]
+    impl Holder of super::IAListHolder<ContractState> {
+        fn do_get_len(self: @ContractState) -> (u32, u32) {
+            (self.addrs.read().len(), self.numbers.read().len())
+        }
+
+        fn do_is_empty(self: @ContractState) -> (bool, bool) {
+            (self.addrs.read().is_empty(), self.numbers.read().is_empty())
+        }
+
+        fn do_append(ref self: ContractState, addrs_value: ContractAddress, numbers_value: u256) -> (u32, u32) {
+            let mut a = self.addrs.read();
+            let mut n = self.numbers.read();
+            (a.append(addrs_value), n.append(numbers_value))
+        }
+
+        fn do_get(self: @ContractState, index: u32) -> (ContractAddress, u256) {
+            (self.addrs.read().get(index), self.numbers.read().get(index))
+        }
+
+        fn do_get_index(self: @ContractState, index: u32) -> (ContractAddress, u256) {
+            (self.addrs.read()[index], self.numbers.read()[index])
+        }
+
+        fn do_set(ref self: ContractState, index: u32, addrs_value: ContractAddress, numbers_value: u256) {
+            let mut a = self.addrs.read();
+            let mut n = self.numbers.read();
+            a.set(index, addrs_value);
+            n.set(index, numbers_value);
+        }
+    }
+}
+
+#[cft(test)]
+mod tests {
+    use array::{ArrayTrait, SpanTrait};
+    use debug::PrintTrait;
+    use option::OptionTrait;
+    use starknet::{ClassHash, ContractAddress, deploy_syscall, SyscallResultTrait};
+    use traits::{Default, Into, TryInto};
+
+    use super::{AListHolder, IAListHolderDispatcher, IAListHolderDispatcherTrait};
+
+    // so that we're able to compare 2-tuples in the test code
+    impl TupleSize2PartialEq<
+        E0, E1, impl E0PartialEq: PartialEq<E0>, impl E1PartialEq: PartialEq<E1>>
+    of PartialEq<(E0, E1)>
+    {
+        #[inline(always)]
+        fn eq(lhs: @(E0, E1), rhs: @(E0, E1)) -> bool {
+            let (lhs0, lhs1) = lhs;
+            let (rhs0, rhs1) = rhs;
+            (lhs0 == rhs0) & (lhs1 == rhs1)
+        }
+        #[inline(always)]
+        fn ne(lhs: @(E0, E1), rhs: @(E0, E1)) -> bool {
+            !(rhs == lhs)
+        }
+    }
+
+
+    fn deploy_mock() -> IAListHolderDispatcher {
+        let class_hash: ClassHash = AListHolder::TEST_CLASS_HASH.try_into().unwrap();
+        let ctor_data: Array<felt252> = Default::default();
+        let (addr, _) = deploy_syscall(class_hash, 0, ctor_data.span(), false)
+            .unwrap_syscall();
+        IAListHolderDispatcher { contract_address: addr }
+    }
+
+    fn mock_addr() -> ContractAddress {
+        starknet::contract_address_const::<'hello'>()
+    }
+
+    #[test]
+    #[available_gas(100000000)]
+    fn test_deploy() {
+        let contract = deploy_mock();
+        assert(contract.do_get_len() == (0, 0), 'do_get_len');
+    }
+
+    #[test]
+    #[available_gas(100000000)]
+    fn test_is_empty() {
+        let contract = deploy_mock();
+
+        assert(contract.do_is_empty() == (true, true), 'is empty');
+        contract.do_append(mock_addr(), 1337);
+        assert(contract.do_is_empty() == (false, false), 'is not empty');
+    }
+
+    #[test]
+    #[available_gas(100000000)]
+    fn test_append_few() {
+        let contract = deploy_mock();
+
+        assert(contract.do_append(mock_addr(), 10) == (0, 0), '1st append idx');
+        assert(contract.do_append(mock_addr(), 20) == (1, 1), '2nd append idx');
+        assert(contract.do_get_len() == (2, 2), 'len');
+    }
+
+    #[test]
+    #[available_gas(100000000000)]
+    fn test_append_get_many() {
+        let contract = deploy_mock();
+        let mock_addr = mock_addr();
+
+        let mut index: u32 = 0;
+        let max: u32 = 1025;
+
+        // test appending many
+        loop {
+            if index == max {
+                break;
+            }
+
+            let append_indexes = contract.do_append(mock_addr, index.into());
+            assert(append_indexes == (index, index), index.into());
+            index += 1;
+        };
+
+        assert(contract.do_get_len() == (max, max), 'len');
+
+        // test getting many
+        index = 0;
+        loop {
+            if index == max {
+                break;
+            }
+            assert(contract.do_get(index) == (mock_addr, index.into()), index.into());
+            index += 1;
+        }
+    }
+
+    #[test]
+    #[available_gas(100000000)]
+    fn test_get_pass() {
+        let contract = deploy_mock();
+        let mock_addr = mock_addr();
+
+        contract.do_append(mock_addr, 100); // idx 0
+        contract.do_append(mock_addr, 200); // idx 1
+        contract.do_append(mock_addr, 300); // idx 2
+
+        assert(contract.do_get(0) == (mock_addr, 100), 'idx 0');
+        assert(contract.do_get(1) == (mock_addr, 200), 'idx 1');
+        assert(contract.do_get(2) == (mock_addr, 300), 'idx 2');
+    }
+
+    #[test]
+    #[available_gas(100000000)]
+    fn test_get_index_pass() {
+        let contract = deploy_mock();
+        let mock_addr = mock_addr();
+
+        contract.do_append(mock_addr, 100); // idx 0
+        contract.do_append(mock_addr, 200); // idx 1
+        contract.do_append(mock_addr, 300); // idx 2
+
+        assert(contract.do_get_index(0) == (mock_addr, 100), 'idx 0');
+        assert(contract.do_get_index(1) == (mock_addr, 200), 'idx 1');
+        assert(contract.do_get_index(2) == (mock_addr, 300), 'idx 2');
+    }
+
+    #[test]
+    #[available_gas(100000000)]
+    #[should_panic(expected: ('index out of bounds', 'ENTRYPOINT_FAILED'))]
+    fn test_get_out_of_bounds() {
+        let contract = deploy_mock();
+        contract.do_append(mock_addr(), 10);
+        contract.do_get(10);
+    }
+
+    #[test]
+    #[available_gas(100000000)]
+    #[should_panic(expected: ('index out of bounds', 'ENTRYPOINT_FAILED'))]
+    fn test_get_index_out_of_bounds() {
+        let contract = deploy_mock();
+        contract.do_append(mock_addr(), 10);
+        contract.do_get_index(10);
+    }
+
+    #[test]
+    #[available_gas(100000000)]
+    fn test_set_pass() {
+        let contract = deploy_mock();
+        let mock_addr = mock_addr();
+        let diff_addr = starknet::contract_address_const::<'bye'>();
+
+        contract.do_append(mock_addr, 10);
+        contract.do_append(mock_addr, 20);
+        contract.do_append(mock_addr, 30);
+
+        contract.do_set(0, diff_addr, 100);
+        contract.do_set(2, diff_addr, 300);
+
+        assert(contract.do_get(0) == (diff_addr, 100), 'new at 0');
+        assert(contract.do_get(1) == (mock_addr, 20), 'old at 1');
+        assert(contract.do_get(2) == (diff_addr, 300), 'new at 2');
+        assert(contract.do_get_len() == (3, 3), 'len');
+    }
+
+    #[test]
+    #[available_gas(100000000)]
+    #[should_panic(expected: ('index out of bounds', 'ENTRYPOINT_FAILED'))]
+    fn test_set_out_of_bounds() {
+        let contract = deploy_mock();
+        contract.do_set(2, mock_addr(), 20);
+    }
+}

--- a/alexandria/storage/src/tests/list_test.cairo
+++ b/alexandria/storage/src/tests/list_test.cairo
@@ -4,10 +4,14 @@ use starknet::ContractAddress;
 trait IAListHolder<TContractState> {
     fn do_get_len(self: @TContractState) -> (u32, u32);
     fn do_is_empty(self: @TContractState) -> (bool, bool);
-    fn do_append(ref self: TContractState, addrs_value: ContractAddress, numbers_value: u256) -> (u32, u32);
+    fn do_append(
+        ref self: TContractState, addrs_value: ContractAddress, numbers_value: u256
+    ) -> (u32, u32);
     fn do_get(self: @TContractState, index: u32) -> (ContractAddress, u256);
     fn do_get_index(self: @TContractState, index: u32) -> (ContractAddress, u256);
-    fn do_set(ref self: TContractState, index: u32, addrs_value: ContractAddress, numbers_value: u256);
+    fn do_set(
+        ref self: TContractState, index: u32, addrs_value: ContractAddress, numbers_value: u256
+    );
 }
 
 #[starknet::contract]
@@ -20,7 +24,6 @@ mod AListHolder {
         // to test a corelib type that has StorageAccess and
         // Into<ContractAddress, felt252>
         addrs: List<ContractAddress>,
-
         // to test a corelib compound struct
         numbers: List<u256>
     }
@@ -35,7 +38,9 @@ mod AListHolder {
             (self.addrs.read().is_empty(), self.numbers.read().is_empty())
         }
 
-        fn do_append(ref self: ContractState, addrs_value: ContractAddress, numbers_value: u256) -> (u32, u32) {
+        fn do_append(
+            ref self: ContractState, addrs_value: ContractAddress, numbers_value: u256
+        ) -> (u32, u32) {
             let mut a = self.addrs.read();
             let mut n = self.numbers.read();
             (a.append(addrs_value), n.append(numbers_value))
@@ -49,7 +54,9 @@ mod AListHolder {
             (self.addrs.read()[index], self.numbers.read()[index])
         }
 
-        fn do_set(ref self: ContractState, index: u32, addrs_value: ContractAddress, numbers_value: u256) {
+        fn do_set(
+            ref self: ContractState, index: u32, addrs_value: ContractAddress, numbers_value: u256
+        ) {
             let mut a = self.addrs.read();
             let mut n = self.numbers.read();
             a.set(index, addrs_value);
@@ -70,9 +77,8 @@ mod tests {
 
     // so that we're able to compare 2-tuples in the test code
     impl TupleSize2PartialEq<
-        E0, E1, impl E0PartialEq: PartialEq<E0>, impl E1PartialEq: PartialEq<E1>>
-    of PartialEq<(E0, E1)>
-    {
+        E0, E1, impl E0PartialEq: PartialEq<E0>, impl E1PartialEq: PartialEq<E1>
+    > of PartialEq<(E0, E1)> {
         #[inline(always)]
         fn eq(lhs: @(E0, E1), rhs: @(E0, E1)) -> bool {
             let (lhs0, lhs1) = lhs;
@@ -89,8 +95,7 @@ mod tests {
     fn deploy_mock() -> IAListHolderDispatcher {
         let class_hash: ClassHash = AListHolder::TEST_CLASS_HASH.try_into().unwrap();
         let ctor_data: Array<felt252> = Default::default();
-        let (addr, _) = deploy_syscall(class_hash, 0, ctor_data.span(), false)
-            .unwrap_syscall();
+        let (addr, _) = deploy_syscall(class_hash, 0, ctor_data.span(), false).unwrap_syscall();
         IAListHolderDispatcher { contract_address: addr }
     }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Adding support for array storage (up to 2^32 elements). This feature enables things like:

```rust
#[storage]
struct Storage {
    values: List<u256>
}
```

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently, when you want to store an array of values in a Starknet contracts, you have to resort to sth like this

```rust
struct Storage {
    values_count: u32,
    values: LegacyMap<u32, u256>
}
```

i.e. have a dictionary where the key is the index of the element. This is cumbersome as you have to take care of properly updating both values and just deal with multiple storage variables all the time.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR adds a new data structure called `List` which rectifies the above approach. There's only one storage variable and in general it acts as an "array" from other programming languages that devs are used to (or rather it tries its best to do so).

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

The TL;DR of the implementation is that the storage segment where the List values are written is based on the name of the storage variable and a index, hashed together. I've written about it in more detail in the inline comments, so I won't reproduce it here, but please feel free to ask any questions.

Storing most (all?) corelib values in a List should work out of the box. For custom types, devs will have to implement a simple trait `StorageSize` - the reason why is also mentioned in the inline comment in the code.

Using `append` costs 2 storage writes, but that's the same as with the counter + map approach described above.

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

I'm happy to hear any kind of feedback about the implementation. It's also completely fine if you deem this not be a good fit in Alexandria, I can just publish it on my own.

Beyond that, I have a list of questions I'd like to hear yours' opinions;

### Open questions:

1.  Is the structure - creating a new module called `storage` ok?
2. ~~Should `get` return an `Option<T>`? In other words, if getting an element at index > len, should the return value be `Option::None`? That would be similar to corelib's array.~~ UPDATE: `get` now returns `Option<T>`.
3. Should there be a `span` fn that returns a `Span<T>` of all the elements in the list? 
4. Should it use Poseidon for hashing rather than `LegacyHash` (Pedersen)?
5. Should it use `usize` instead of `u32` for `len` and `index`? Currently, `usize` is an alias for `u32` in Cairo, but that might change it the future. What's the best option?
6. ~~Should there be a `pop_front` function that removes the "topmost" element?~~ UPDATE: there's now a `pop_front` returning `Option<T>`.

I think this is also the first Starknet specific module in Alexandria. As such, it needs the `--starknet` flag to be passed with `cairo-test`. How should this be done? A solution I though of was to have two targets, `test-cairo` and `test-starknet` and make them dependencies of `test`, so sth like

```makefile
test: test-cairo test-starknet

test-cairo: test-data_structures test-encoding test-math test-sorting test-searching

test-starknet: test-storage

#...

test-storage:
	@echo "Testing storage"
	cairo-test --starknet $(PROJECT_NAME)/storage
```

But I'm far from an expert in Makefiles 😁

Also, as discussed in the TG group, this works only with Cairo v2 due to the new `StorageAccess` trait (it doesn't have the internal functions in v1.1).