### PR TITLE
🐛 Make numeric and linalg features generic

### DIFF
--- a/alexandria/linalg/src/dot.cairo
+++ b/alexandria/linalg/src/dot.cairo
@@ -9,14 +9,13 @@ use array::ArrayTrait;
 /// * `T` - The dot product.
 fn dot<
     T,
-    impl TMul:Mul<T>,
-    impl TAddEq:AddEq<T>,
-    impl TZeroable:Zeroable<T>,
-    impl TCopy:Copy<T>,
-    impl TDrop:Drop<T>,
+    impl TMul: Mul<T>,
+    impl TAddEq: AddEq<T>,
+    impl TZeroable: Zeroable<T>,
+    impl TCopy: Copy<T>,
+    impl TDrop: Drop<T>,
 >(
-    mut xs: Array<T>,
-    mut ys: Array<T>
+    mut xs: Array<T>, mut ys: Array<T>
 ) -> T {
     // [Check] Inputs
     assert(xs.len() == ys.len(), 'Arrays must have the same len');

--- a/alexandria/linalg/src/dot.cairo
+++ b/alexandria/linalg/src/dot.cairo
@@ -6,20 +6,30 @@ use array::ArrayTrait;
 /// * `xs` - The first sequence of len L.
 /// * `ys` - The second sequence of len L.
 /// # Returns
-/// * `usize` - The dot product.
-fn dot(mut xs: Array<usize>, mut ys: Array<usize>) -> usize {
+/// * `T` - The dot product.
+fn dot<
+    T,
+    impl TMul:Mul<T>,
+    impl TAddEq:AddEq<T>,
+    impl TZeroable:Zeroable<T>,
+    impl TCopy:Copy<T>,
+    impl TDrop:Drop<T>,
+>(
+    mut xs: Array<T>,
+    mut ys: Array<T>
+) -> T {
     // [Check] Inputs
     assert(xs.len() == ys.len(), 'Arrays must have the same len');
 
     // [Compute] Dot product in a loop
-    let mut index = 0_usize;
-    let mut value = 0_usize;
+    let mut index = 0;
+    let mut value = Zeroable::zero();
     loop {
         if index == xs.len() {
             break ();
         }
-        value += *xs.at(index) * *ys.at(index);
-        index += 1_usize;
+        value += *xs[index] * *ys[index];
+        index += 1;
     };
     value
 }

--- a/alexandria/linalg/src/tests/dot_test.cairo
+++ b/alexandria/linalg/src/tests/dot_test.cairo
@@ -4,11 +4,11 @@ use alexandria_linalg::dot::dot;
 #[test]
 #[available_gas(2000000)]
 fn dot_product_test() {
-    let mut xs = ArrayTrait::new();
+    let mut xs = ArrayTrait::<u64>::new();
     xs.append(3);
     xs.append(5);
     xs.append(7);
-    let mut ys = ArrayTrait::new();
+    let mut ys = ArrayTrait::<u64>::new();
     ys.append(11);
     ys.append(13);
     ys.append(17);
@@ -19,8 +19,8 @@ fn dot_product_test() {
 #[should_panic]
 #[available_gas(2000000)]
 fn dot_product_test_check_len() {
-    let mut xs = ArrayTrait::new();
+    let mut xs = ArrayTrait::<u64>::new();
     xs.append(1);
-    let mut ys = ArrayTrait::new();
+    let mut ys = ArrayTrait::<u64>::new();
     dot(xs, ys);
 }

--- a/alexandria/numeric/src/cumsum.cairo
+++ b/alexandria/numeric/src/cumsum.cairo
@@ -6,12 +6,7 @@ use array::ArrayTrait;
 /// * `sequence` - The sequence to operate.
 /// # Returns
 /// * `Array<T>` - The cumulative sum of sequence.
-fn cumsum<
-    T,
-    impl TAdd:Add<T>,
-    impl TCopy:Copy<T>,
-    impl TDrop:Drop<T>,
->(
+fn cumsum<T, impl TAdd: Add<T>, impl TCopy: Copy<T>, impl TDrop: Drop<T>, >(
     mut sequence: @Array<T>
 ) -> Array<T> {
     // [Check] Inputs

--- a/alexandria/numeric/src/cumsum.cairo
+++ b/alexandria/numeric/src/cumsum.cairo
@@ -5,24 +5,31 @@ use array::ArrayTrait;
 /// # Arguments
 /// * `sequence` - The sequence to operate.
 /// # Returns
-/// * `Array<usize>` - The cumulative sum of sequence.
-fn cumsum(mut sequence: @Array<usize>) -> Array<usize> {
+/// * `Array<T>` - The cumulative sum of sequence.
+fn cumsum<
+    T,
+    impl TAdd:Add<T>,
+    impl TCopy:Copy<T>,
+    impl TDrop:Drop<T>,
+>(
+    mut sequence: @Array<T>
+) -> Array<T> {
     // [Check] Inputs
-    assert(sequence.len() >= 1_u32, 'Array must have at least 1 elt');
+    assert(sequence.len() >= 1, 'Array must have at least 1 elt');
 
     // [Compute] Interpolation
-    let mut index = 0_u32;
+    let mut index = 0;
     let mut array = ArrayTrait::new();
     loop {
         if index == sequence.len() {
             break ();
         }
-        if index == 0_u32 {
+        if index == 0 {
             array.append(*sequence[index]);
         } else {
-            array.append(*sequence[index] + *array[index - 1_u32]);
+            array.append(*sequence[index] + *array[index - 1]);
         }
-        index += 1_u32;
+        index += 1;
     };
     array
 }

--- a/alexandria/numeric/src/diff.cairo
+++ b/alexandria/numeric/src/diff.cairo
@@ -1,29 +1,39 @@
 //! The discrete difference of the elements.
 use array::ArrayTrait;
+use zeroable::Zeroable;
 
 /// Compute the discrete difference of a sorted sequence.
 /// # Arguments
 /// * `sequence` - The sorted sequence to operate.
 /// # Returns
-/// * `Array<usize>` - The discrete difference of sorted sequence.
-fn diff(mut sequence: @Array<usize>) -> Array<usize> {
+/// * `Array<T>` - The discrete difference of sorted sequence.
+fn diff<
+    T,
+    impl TPartialOrd:PartialOrd<T>,
+    impl TSub:Sub<T>,
+    impl TCopy:Copy<T>,
+    impl TDrop:Drop<T>,
+    impl TZeroable:Zeroable<T>,
+>(
+    mut sequence: @Array<T>
+) -> Array<T> {
     // [Check] Inputs
-    assert(sequence.len() >= 1_usize, 'Array must have at least 1 elt');
+    assert(sequence.len() >= 1, 'Array must have at least 1 elt');
 
     // [Compute] Interpolation
-    let mut index = 0_usize;
-    let mut array = ArrayTrait::new();
+    let mut index = 0;
+    let mut array = ArrayTrait::<T>::new();
     loop {
         if index == sequence.len() {
             break ();
         }
-        if index == 0_usize {
-            array.append(0_usize);
+        if index == 0 {
+            array.append(Zeroable::zero());
         } else {
-            assert(*sequence[index] >= *sequence[index - 1_usize], 'Sequence must be sorted');
-            array.append(*sequence[index] - *sequence[index - 1_usize]);
+            assert(*sequence[index] >= *sequence[index - 1], 'Sequence must be sorted');
+            array.append(*sequence[index] - *sequence[index - 1]);
         }
-        index += 1_usize;
+        index += 1;
     };
     array
 }

--- a/alexandria/numeric/src/diff.cairo
+++ b/alexandria/numeric/src/diff.cairo
@@ -9,11 +9,11 @@ use zeroable::Zeroable;
 /// * `Array<T>` - The discrete difference of sorted sequence.
 fn diff<
     T,
-    impl TPartialOrd:PartialOrd<T>,
-    impl TSub:Sub<T>,
-    impl TCopy:Copy<T>,
-    impl TDrop:Drop<T>,
-    impl TZeroable:Zeroable<T>,
+    impl TPartialOrd: PartialOrd<T>,
+    impl TSub: Sub<T>,
+    impl TCopy: Copy<T>,
+    impl TDrop: Drop<T>,
+    impl TZeroable: Zeroable<T>,
 >(
     mut sequence: @Array<T>
 ) -> Array<T> {

--- a/alexandria/numeric/src/interpolate.cairo
+++ b/alexandria/numeric/src/interpolate.cairo
@@ -28,21 +28,17 @@ enum Extrapolation {
 /// * `T` - The interpolated y at x.
 fn interpolate<
     T,
-    impl TPartialOrd:PartialOrd<T>,
-    impl TNumericLiteral:NumericLiteral<T>,
-    impl TAdd:Add<T>,
-    impl TSub:Sub<T>,
-    impl TMul:Mul<T>,
-    impl TDiv:Div<T>,
-    impl TZeroable:Zeroable<T>,
-    impl TCopy:Copy<T>,
-    impl TDrop:Drop<T>,
+    impl TPartialOrd: PartialOrd<T>,
+    impl TNumericLiteral: NumericLiteral<T>,
+    impl TAdd: Add<T>,
+    impl TSub: Sub<T>,
+    impl TMul: Mul<T>,
+    impl TDiv: Div<T>,
+    impl TZeroable: Zeroable<T>,
+    impl TCopy: Copy<T>,
+    impl TDrop: Drop<T>,
 >(
-    x: T,
-    xs: @Array<T>,
-    ys: @Array<T>,
-    interpolation: Interpolation,
-    extrapolation: Extrapolation
+    x: T, xs: @Array<T>, ys: @Array<T>, interpolation: Interpolation, extrapolation: Extrapolation
 ) -> T {
     // [Check] Inputs
     assert(xs.len() == ys.len(), 'Arrays must have the same len');

--- a/alexandria/numeric/src/tests/cumsum_test.cairo
+++ b/alexandria/numeric/src/tests/cumsum_test.cairo
@@ -4,7 +4,7 @@ use alexandria_numeric::cumsum::cumsum;
 #[test]
 #[available_gas(2000000)]
 fn cumsum_test() {
-    let mut xs = ArrayTrait::new();
+    let mut xs = ArrayTrait::<u64>::new();
     xs.append(3);
     xs.append(5);
     xs.append(7);
@@ -18,6 +18,6 @@ fn cumsum_test() {
 #[should_panic]
 #[available_gas(2000000)]
 fn cumsum_test_revert_empty() {
-    let mut xs = ArrayTrait::new();
+    let mut xs = ArrayTrait::<u64>::new();
     let ys = cumsum(@xs);
 }

--- a/alexandria/numeric/src/tests/diff_test.cairo
+++ b/alexandria/numeric/src/tests/diff_test.cairo
@@ -4,12 +4,12 @@ use alexandria_numeric::diff::diff;
 #[test]
 #[available_gas(2000000)]
 fn diff_test() {
-    let mut xs = ArrayTrait::new();
+    let mut xs = ArrayTrait::<u256>::new();
     xs.append(3);
     xs.append(5);
     xs.append(7);
     let ys = diff(@xs);
-    assert(*ys[0] == 0_usize, 'wrong value at index 0');
+    assert(*ys[0] == 0_u256, 'wrong value at index 0');
     assert(*ys[1] == *xs[1] - *xs[0], 'wrong value at index 1');
     assert(*ys[2] == *xs[2] - *xs[1], 'wrong value at index 2');
 }
@@ -18,7 +18,7 @@ fn diff_test() {
 #[should_panic]
 #[available_gas(2000000)]
 fn diff_test_revert_not_sorted() {
-    let mut xs = ArrayTrait::new();
+    let mut xs = ArrayTrait::<u128>::new();
     xs.append(3);
     xs.append(2);
     let ys = diff(@xs);
@@ -28,6 +28,6 @@ fn diff_test_revert_not_sorted() {
 #[should_panic]
 #[available_gas(2000000)]
 fn diff_test_revert_empty() {
-    let mut xs = ArrayTrait::new();
+    let mut xs = ArrayTrait::<u8>::new();
     let ys = diff(@xs);
 }

--- a/alexandria/numeric/src/tests/interpolate_test.cairo
+++ b/alexandria/numeric/src/tests/interpolate_test.cairo
@@ -4,7 +4,7 @@ use alexandria_numeric::interpolate::{interpolate, Interpolation, Extrapolation}
 #[test]
 #[available_gas(2000000)]
 fn interp_extrapolation_test() {
-    let mut xs = ArrayTrait::new();
+    let mut xs = ArrayTrait::<u64>::new();
     xs.append(3);
     xs.append(5);
     xs.append(7);
@@ -33,11 +33,11 @@ fn interp_extrapolation_test() {
 #[test]
 #[available_gas(2000000)]
 fn interp_linear_test() {
-    let mut xs = ArrayTrait::new();
+    let mut xs = ArrayTrait::<u64>::new();
     xs.append(3);
     xs.append(5);
     xs.append(7);
-    let mut ys = ArrayTrait::new();
+    let mut ys = ArrayTrait::<u64>::new();
     ys.append(11);
     ys.append(13);
     ys.append(17);
@@ -54,11 +54,11 @@ fn interp_linear_test() {
 #[test]
 #[available_gas(2000000)]
 fn interp_nearest_test() {
-    let mut xs = ArrayTrait::new();
+    let mut xs = ArrayTrait::<u64>::new();
     xs.append(3);
     xs.append(5);
     xs.append(8);
-    let mut ys = ArrayTrait::new();
+    let mut ys = ArrayTrait::<u64>::new();
     ys.append(11);
     ys.append(13);
     ys.append(17);
@@ -79,11 +79,11 @@ fn interp_nearest_test() {
 #[test]
 #[available_gas(2000000)]
 fn interp_constant_left_test() {
-    let mut xs = ArrayTrait::new();
+    let mut xs = ArrayTrait::<u64>::new();
     xs.append(3);
     xs.append(5);
     xs.append(8);
-    let mut ys = ArrayTrait::new();
+    let mut ys = ArrayTrait::<u64>::new();
     ys.append(11);
     ys.append(13);
     ys.append(17);
@@ -110,11 +110,11 @@ fn interp_constant_left_test() {
 #[test]
 #[available_gas(2000000)]
 fn interp_constant_right_test() {
-    let mut xs = ArrayTrait::new();
+    let mut xs = ArrayTrait::<u64>::new();
     xs.append(3);
     xs.append(5);
     xs.append(8);
-    let mut ys = ArrayTrait::new();
+    let mut ys = ArrayTrait::<u64>::new();
     ys.append(11);
     ys.append(13);
     ys.append(17);
@@ -142,10 +142,10 @@ fn interp_constant_right_test() {
 #[should_panic]
 #[available_gas(2000000)]
 fn interp_revert_len_mismatch() {
-    let mut xs = ArrayTrait::new();
+    let mut xs = ArrayTrait::<u64>::new();
     xs.append(3);
     xs.append(5);
-    let mut ys = ArrayTrait::new();
+    let mut ys = ArrayTrait::<u64>::new();
     ys.append(11);
     interpolate(4, @xs, @ys, Interpolation::Linear(()), Extrapolation::Constant(()));
 }
@@ -154,9 +154,9 @@ fn interp_revert_len_mismatch() {
 #[should_panic]
 #[available_gas(2000000)]
 fn interp_revert_len_too_short() {
-    let mut xs = ArrayTrait::new();
+    let mut xs = ArrayTrait::<u64>::new();
     xs.append(3);
-    let mut ys = ArrayTrait::new();
+    let mut ys = ArrayTrait::<u64>::new();
     ys.append(11);
     interpolate(4, @xs, @ys, Interpolation::Linear(()), Extrapolation::Constant(()));
 }

--- a/alexandria/numeric/src/tests/trapezoidal_rule_test.cairo
+++ b/alexandria/numeric/src/tests/trapezoidal_rule_test.cairo
@@ -4,11 +4,11 @@ use alexandria_numeric::trapezoidal_rule::trapezoidal_rule;
 #[test]
 #[available_gas(2000000)]
 fn trapezoidal_rule_test() {
-    let mut xs = ArrayTrait::new();
+    let mut xs = ArrayTrait::<u64>::new();
     xs.append(3);
     xs.append(5);
     xs.append(7);
-    let mut ys = ArrayTrait::new();
+    let mut ys = ArrayTrait::<u64>::new();
     ys.append(11);
     ys.append(13);
     ys.append(17);
@@ -19,9 +19,9 @@ fn trapezoidal_rule_test() {
 #[should_panic]
 #[available_gas(2000000)]
 fn trapezoidal_rule_test_revert_len_mismatch() {
-    let mut xs = ArrayTrait::new();
+    let mut xs = ArrayTrait::<u64>::new();
     xs.append(3);
-    let mut ys = ArrayTrait::new();
+    let mut ys = ArrayTrait::<u64>::new();
     trapezoidal_rule(xs, ys);
 }
 
@@ -29,9 +29,9 @@ fn trapezoidal_rule_test_revert_len_mismatch() {
 #[should_panic]
 #[available_gas(2000000)]
 fn trapezoidal_rule_test_revert_len_too_short() {
-    let mut xs = ArrayTrait::new();
+    let mut xs = ArrayTrait::<u64>::new();
     xs.append(3);
-    let mut ys = ArrayTrait::new();
+    let mut ys = ArrayTrait::<u64>::new();
     ys.append(11);
     trapezoidal_rule(xs, ys);
 }
@@ -40,10 +40,10 @@ fn trapezoidal_rule_test_revert_len_too_short() {
 #[should_panic]
 #[available_gas(2000000)]
 fn trapezoidal_rule_test_revert_not_sorted() {
-    let mut xs = ArrayTrait::new();
+    let mut xs = ArrayTrait::<u64>::new();
     xs.append(5);
     xs.append(3);
-    let mut ys = ArrayTrait::new();
+    let mut ys = ArrayTrait::<u64>::new();
     ys.append(11);
     ys.append(13);
     trapezoidal_rule(xs, ys);

--- a/alexandria/numeric/src/trapezoidal_rule.cairo
+++ b/alexandria/numeric/src/trapezoidal_rule.cairo
@@ -11,20 +11,19 @@ use traits::Into;
 /// * `T` - The approximate integral.
 fn trapezoidal_rule<
     T,
-    impl TPartialOrd:PartialOrd<T>,
-    impl TNumericLiteral:NumericLiteral<T>,
-    impl TAdd:Add<T>,
-    impl TAddEq:AddEq<T>,
-    impl TSub:Sub<T>,
-    impl TMul:Mul<T>,
-    impl TDiv:Div<T>,
-    impl TCopy:Copy<T>,
-    impl TDrop:Drop<T>,
-    impl TZeroable:Zeroable<T>,
+    impl TPartialOrd: PartialOrd<T>,
+    impl TNumericLiteral: NumericLiteral<T>,
+    impl TAdd: Add<T>,
+    impl TAddEq: AddEq<T>,
+    impl TSub: Sub<T>,
+    impl TMul: Mul<T>,
+    impl TDiv: Div<T>,
+    impl TCopy: Copy<T>,
+    impl TDrop: Drop<T>,
+    impl TZeroable: Zeroable<T>,
     impl TInto: Into<u8, T>,
 >(
-    mut xs: Array<T>,
-    mut ys: Array<T>
+    mut xs: Array<T>, mut ys: Array<T>
 ) -> T {
     // [Check] Inputs
     assert(xs.len() == ys.len(), 'Arrays must have the same len');

--- a/alexandria/numeric/src/trapezoidal_rule.cairo
+++ b/alexandria/numeric/src/trapezoidal_rule.cairo
@@ -1,27 +1,45 @@
 //! Integrate using the composite trapezoidal rule
 use array::ArrayTrait;
+use zeroable::Zeroable;
+use traits::Into;
 
 /// Integrate y(x).
 /// # Arguments
 /// * `xs` - The sorted abscissa sequence of len L.
 /// * `ys` - The ordinate sequence of len L.
 /// # Returns
-/// * `usize` - The approximate integral.
-fn trapezoidal_rule(mut xs: Array<usize>, mut ys: Array<usize>) -> usize {
+/// * `T` - The approximate integral.
+fn trapezoidal_rule<
+    T,
+    impl TPartialOrd:PartialOrd<T>,
+    impl TNumericLiteral:NumericLiteral<T>,
+    impl TAdd:Add<T>,
+    impl TAddEq:AddEq<T>,
+    impl TSub:Sub<T>,
+    impl TMul:Mul<T>,
+    impl TDiv:Div<T>,
+    impl TCopy:Copy<T>,
+    impl TDrop:Drop<T>,
+    impl TZeroable:Zeroable<T>,
+    impl TInto: Into<u8, T>,
+>(
+    mut xs: Array<T>,
+    mut ys: Array<T>
+) -> T {
     // [Check] Inputs
     assert(xs.len() == ys.len(), 'Arrays must have the same len');
-    assert(xs.len() >= 2_usize, 'Array must have at least 2 elts');
+    assert(xs.len() >= 2, 'Array must have at least 2 elts');
 
     // [Compute] Trapezoidal rule
-    let mut index = 0_usize;
-    let mut value = 0_usize;
+    let mut index = 0;
+    let mut value = Zeroable::zero();
     loop {
-        if index + 1_usize == xs.len() {
+        if index + 1 == xs.len() {
             break ();
         }
-        assert(*xs[index + 1_usize] > *xs[index], 'Abscissa must be sorted');
-        value += (*xs[index + 1_usize] - *xs[index]) * (*ys[index] + *ys[index + 1_usize]);
-        index += 1_usize;
+        assert(*xs[index + 1] > *xs[index], 'Abscissa must be sorted');
+        value += (*xs.at(index + 1) - *xs[index]) * (*ys[index] + *ys[index + 1]);
+        index += 1;
     };
-    value / 2_usize
+    TDiv::div(value, TInto::into(2))
 }


### PR DESCRIPTION
## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The numeric and linalg functions allow only u32 types

Issue Number: #133 

## What is the new behavior?

The functions now allow all types of uint implementing the expected traits

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Workload: ~ 1h
