### PR TITLE
dev: test everything in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,12 @@ run:
 # Test the project
 test:
 	@echo "Testing everything..."
-	cairo-test $(ROOT_PROJECT)
+	$(MAKE) test-cairo
+	$(MAKE) test-starknet
+
+test-cairo: test-data_structures test-encoding test-math test-sorting test-searching
+
+test-starknet: test-storage
 
 test-data_structures:
 	@echo "Testing data structures..."
@@ -50,11 +55,15 @@ test-numeric:
 	@echo "Testing numeric"
 	cairo-test $(PROJECT_NAME)/numeric
 
+test-storage:
+	@echo "Testing storage"
+	cairo-test --starknet $(PROJECT_NAME)/storage
+
 test-sorting:
 	@echo "Testing sorting..."
 	cairo-test $(ROOT_PROJECT) --filter alexandria_sorting
 
-test-searching: 
+test-searching:
 	@echo "Testing searching..."
 	cairo-test $(ROOT_PROJECT) --filter alexandria_searching
 


### PR DESCRIPTION
Follow up on #127, adds testing of `storage` to the Makefile's `test` target.

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When running `make test`, the `test-storage` was not run. It is the first target/module that requires a `--starknet` arg to `cairo-test`, so it couldn't have been done like the rest of the stuff.

Issue Number: N/A

## What is the new behavior?

Running `make test` runs the tests for `storage` as well.

There's also a 2 new targets: `test-cairo` and `test-starknet`.
They group other targets as dependencies, former one is intended for non-starknet modules while the latter one for those that are starknet specific.

<!-- Please describe the behavior or changes that are being added by this PR. -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

I'm no a Makefile expert by any stretch of the imagination so I'm open to any suggestions how this can be made better.
