### PR TITLE
Downgrade to Cairo 2.0.0

### DIFF
--- a/Scarb.toml
+++ b/Scarb.toml
@@ -5,7 +5,7 @@ description = "Starknet utilities"
 homepage = "https://github.com/keep-starknet-strange/alexandria/"
 
 [dependencies]
-starknet = ">=2.0.1"
+starknet = ">=2.0.0"
 
 [scripts]
 all = "scarb build && scarb test"

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -5,7 +5,7 @@ description = "Starknet utilities"
 homepage = "https://github.com/keep-starknet-strange/alexandria/"
 
 [dependencies]
-starknet = ">=2.0.0"
+starknet = "=2.0.0"
 
 [scripts]
 all = "scarb build && scarb test"


### PR DESCRIPTION
`2.0.1` isn't supported on any testnet so addings alexandria as a dependency to any project makes it undeployable to any network currently.

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [X] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):
