### PR TITLE
Update all Option::None(()) to remove (())

### DIFF
--- a/src/data_structures/array_ext.cairo
+++ b/src/data_structures/array_ext.cairo
@@ -52,7 +52,7 @@ impl ArrayImpl<T, impl TCopy: Copy<T>, impl TDrop: Drop<T>> of ArrayTraitExt<T> 
                 self.append(v);
                 self.append_all(ref arr);
             },
-            Option::None(()) => (),
+            Option::None => (),
         }
     }
 
@@ -60,14 +60,14 @@ impl ArrayImpl<T, impl TCopy: Copy<T>, impl TDrop: Drop<T>> of ArrayTraitExt<T> 
         // Can't do self.span().pop_front_n();
         loop {
             if n == 0 {
-                break ();
+                break;
             }
             match self.pop_front() {
                 Option::Some(v) => {
                     n -= 1;
                 },
-                Option::None(_) => {
-                    break ();
+                Option::None => {
+                    break;
                 },
             };
         };
@@ -141,14 +141,14 @@ impl SpanImpl<T, impl TCopy: Copy<T>, impl TDrop: Drop<T>> of SpanTraitExt<T> {
     fn pop_front_n(ref self: Span<T>, mut n: usize) {
         loop {
             if n == 0 {
-                break ();
+                break;
             }
             match self.pop_front() {
                 Option::Some(v) => {
                     n -= 1;
                 },
-                Option::None(_) => {
-                    break ();
+                Option::None => {
+                    break;
                 },
             };
         };
@@ -157,14 +157,14 @@ impl SpanImpl<T, impl TCopy: Copy<T>, impl TDrop: Drop<T>> of SpanTraitExt<T> {
     fn pop_back_n(ref self: Span<T>, mut n: usize) {
         loop {
             if n == 0 {
-                break ();
+                break;
             }
             match self.pop_back() {
                 Option::Some(v) => {
                     n -= 1;
                 },
-                Option::None(_) => {
-                    break ();
+                Option::None => {
+                    break;
                 },
             };
         };
@@ -177,8 +177,8 @@ impl SpanImpl<T, impl TCopy: Copy<T>, impl TDrop: Drop<T>> of SpanTraitExt<T> {
                 Option::Some(v) => {
                     response.append(*v);
                 },
-                Option::None(_) => {
-                    break (); // Can't `break response;` "Variable was previously moved"
+                Option::None => {
+                    break; // Can't `break response;` "Variable was previously moved"
                 },
             };
         };
@@ -193,7 +193,7 @@ impl SpanImpl<T, impl TCopy: Copy<T>, impl TDrop: Drop<T>> of SpanTraitExt<T> {
                         break true;
                     }
                 },
-                Option::None(_) => {
+                Option::None => {
                     break false;
                 },
             };
@@ -232,8 +232,8 @@ impl SpanImpl<T, impl TCopy: Copy<T>, impl TDrop: Drop<T>> of SpanTraitExt<T> {
                     }
                     index += 1;
                 },
-                Option::None(_) => {
-                    break Option::None(());
+                Option::None => {
+                    break Option::None;
                 },
             };
         }
@@ -248,7 +248,7 @@ impl SpanImpl<T, impl TCopy: Copy<T>, impl TDrop: Drop<T>> of SpanTraitExt<T> {
                         count += 1;
                     }
                 },
-                Option::None(_) => {
+                Option::None => {
                     break count;
                 },
             };
@@ -260,8 +260,8 @@ impl SpanImpl<T, impl TCopy: Copy<T>, impl TDrop: Drop<T>> of SpanTraitExt<T> {
     ) -> Option<T> {
         let mut min = match self.pop_front() {
             Option::Some(item) => *item,
-            Option::None(_) => {
-                return Option::None(());
+            Option::None => {
+                return Option::None;
             },
         };
         loop {
@@ -271,7 +271,7 @@ impl SpanImpl<T, impl TCopy: Copy<T>, impl TDrop: Drop<T>> of SpanTraitExt<T> {
                         min = *item
                     }
                 },
-                Option::None(_) => {
+                Option::None => {
                     break Option::Some(min);
                 },
             };
@@ -285,8 +285,8 @@ impl SpanImpl<T, impl TCopy: Copy<T>, impl TDrop: Drop<T>> of SpanTraitExt<T> {
         let mut index_of_min = 0;
         let mut min: T = match self.pop_front() {
             Option::Some(item) => *item,
-            Option::None(_) => {
-                return Option::None(());
+            Option::None => {
+                return Option::None;
             },
         };
         loop {
@@ -297,7 +297,7 @@ impl SpanImpl<T, impl TCopy: Copy<T>, impl TDrop: Drop<T>> of SpanTraitExt<T> {
                         min = *item;
                     }
                 },
-                Option::None(_) => {
+                Option::None => {
                     break Option::Some(index_of_min);
                 },
             };
@@ -310,8 +310,8 @@ impl SpanImpl<T, impl TCopy: Copy<T>, impl TDrop: Drop<T>> of SpanTraitExt<T> {
     ) -> Option<T> {
         let mut max = match self.pop_front() {
             Option::Some(item) => *item,
-            Option::None(_) => {
-                return Option::None(());
+            Option::None => {
+                return Option::None;
             },
         };
         loop {
@@ -321,7 +321,7 @@ impl SpanImpl<T, impl TCopy: Copy<T>, impl TDrop: Drop<T>> of SpanTraitExt<T> {
                         max = *item
                     }
                 },
-                Option::None(_) => {
+                Option::None => {
                     break Option::Some(max);
                 },
             };
@@ -335,8 +335,8 @@ impl SpanImpl<T, impl TCopy: Copy<T>, impl TDrop: Drop<T>> of SpanTraitExt<T> {
         let mut index_of_max = 0;
         let mut max = match self.pop_front() {
             Option::Some(item) => *item,
-            Option::None(_) => {
-                return Option::None(());
+            Option::None => {
+                return Option::None;
             },
         };
         loop {
@@ -347,7 +347,7 @@ impl SpanImpl<T, impl TCopy: Copy<T>, impl TDrop: Drop<T>> of SpanTraitExt<T> {
                         max = *item
                     }
                 },
-                Option::None(_) => {
+                Option::None => {
                     break Option::Some(index_of_max);
                 },
             };

--- a/src/data_structures/merkle_tree.cairo
+++ b/src/data_structures/merkle_tree.cairo
@@ -60,7 +60,7 @@ impl MerkleTreeImpl of MerkleTreeTrait {
                         current_node = LegacyHash::hash(*proof_element, current_node);
                     }
                 },
-                Option::None(()) => {
+                Option::None => {
                     break current_node;
                 },
             };

--- a/src/data_structures/stack.cairo
+++ b/src/data_structures/stack.cairo
@@ -74,7 +74,7 @@ impl Felt252StackImpl<
     /// * Option<u256> The item removed or None if the stack is empty.
     fn pop(ref self: Felt252Stack<T>) -> Option<T> {
         if self.is_empty() {
-            return Option::None(());
+            return Option::None;
         }
 
         self.len -= 1;
@@ -88,7 +88,7 @@ impl Felt252StackImpl<
     /// * Option<u256> The last item of the stack
     fn peek(ref self: Felt252Stack<T>) -> Option<T> {
         if self.is_empty() {
-            return Option::None(());
+            return Option::None;
         }
         Option::Some(self.elements.get((self.len - 1).into()))
     }
@@ -138,7 +138,7 @@ impl NullableStackImpl<
 
     fn pop(ref self: NullableStack<T>) -> Option<T> {
         if self.is_empty() {
-            return Option::None(());
+            return Option::None;
         }
 
         self.len -= 1;
@@ -148,7 +148,7 @@ impl NullableStackImpl<
 
     fn peek(ref self: NullableStack<T>) -> Option<T> {
         if self.is_empty() {
-            return Option::None(());
+            return Option::None;
         }
         Option::Some(self.elements.get((self.len - 1).into()).deref())
     }

--- a/src/data_structures/tests/queue_test.cairo
+++ b/src/data_structures/tests/queue_test.cairo
@@ -45,7 +45,7 @@ fn queue_peek_front_test() {
         Option::Some(result) => {
             assert(*(result.unbox()) == 1, 'wrong result');
         },
-        Option::None(_) => {
+        Option::None => {
             assert(0 == 1, 'should return value');
         },
     };
@@ -66,7 +66,7 @@ fn queue_dequeue_test() {
         Option::Some(result) => {
             assert(result == 1, 'wrong result');
         },
-        Option::None(_) => {
+        Option::None => {
             assert(0 == 1, 'should return a value');
         },
     };

--- a/src/data_structures/tests/queue_test.cairo
+++ b/src/data_structures/tests/queue_test.cairo
@@ -46,7 +46,7 @@ fn queue_peek_front_test() {
             assert(*(result.unbox()) == 1, 'wrong result');
         },
         Option::None => {
-            assert(0 == 1, 'should return value');
+            assert(false, 'should return value');
         },
     };
 
@@ -67,7 +67,7 @@ fn queue_dequeue_test() {
             assert(result == 1, 'wrong result');
         },
         Option::None => {
-            assert(0 == 1, 'should return a value');
+            assert(false, 'should return a value');
         },
     };
 

--- a/src/data_structures/tests/stack_test.cairo
+++ b/src/data_structures/tests/stack_test.cairo
@@ -45,7 +45,7 @@ fn stack_peek_test<
             assert(result == val_2, 'wrong result');
         },
         Option::None => {
-            assert(0 == 1, 'should return value');
+            assert(false, 'should return value');
         },
     };
 
@@ -72,7 +72,7 @@ fn stack_pop_test<
             assert(result == val_2, 'wrong result');
         },
         Option::None => {
-            assert(0 == 1, 'should return a value');
+            assert(false, 'should return a value');
         },
     };
 

--- a/src/data_structures/tests/stack_test.cairo
+++ b/src/data_structures/tests/stack_test.cairo
@@ -44,7 +44,7 @@ fn stack_peek_test<
         Option::Some(result) => {
             assert(result == val_2, 'wrong result');
         },
-        Option::None(_) => {
+        Option::None => {
             assert(0 == 1, 'should return value');
         },
     };
@@ -71,7 +71,7 @@ fn stack_pop_test<
         Option::Some(result) => {
             assert(result == val_2, 'wrong result');
         },
-        Option::None(_) => {
+        Option::None => {
             assert(0 == 1, 'should return a value');
         },
     };

--- a/src/data_structures/vec.cairo
+++ b/src/data_structures/vec.cairo
@@ -95,7 +95,7 @@ impl Felt252VecImpl<
             let item = self.items.get(index.into());
             Option::Some(item)
         } else {
-            Option::None(())
+            Option::None
         }
     }
 
@@ -140,7 +140,7 @@ impl NullableVecImpl<T, impl TDrop: Drop<T>, impl TCopy: Copy<T>> of VecTrait<Nu
         if index < self.len() {
             Option::Some(self.items.get(index.into()).deref())
         } else {
-            Option::None(())
+            Option::None
         }
     }
 

--- a/src/linalg/dot.cairo
+++ b/src/linalg/dot.cairo
@@ -30,7 +30,7 @@ fn dot<
                 let y_value = ys.pop_front().unwrap();
                 value += *x_value * *y_value;
             },
-            Option::None(_) => {
+            Option::None => {
                 break value;
             },
         };

--- a/src/math/collatz_sequence.cairo
+++ b/src/math/collatz_sequence.cairo
@@ -15,7 +15,7 @@ fn sequence(mut number: u128) -> Array<u128> {
     loop {
         arr.append(number);
         if number == 1 {
-            break ();
+            break;
         }
 
         if number % 2 == 0 {

--- a/src/math/ed25519.cairo
+++ b/src/math/ed25519.cairo
@@ -201,7 +201,7 @@ impl SpanU8TryIntoPoint of TryInto<Span<u8>, Point> {
         }
 
         if (x == 0) {
-            if (x_0 == 1) {
+            if (x_false) {
                 return Option::None;
             }
         }

--- a/src/math/ed25519.cairo
+++ b/src/math/ed25519.cairo
@@ -201,7 +201,7 @@ impl SpanU8TryIntoPoint of TryInto<Span<u8>, Point> {
         }
 
         if (x == 0) {
-            if (x_false) {
+            if (x_0 == 1) {
                 return Option::None;
             }
         }

--- a/src/math/ed25519.cairo
+++ b/src/math/ed25519.cairo
@@ -169,7 +169,7 @@ impl SpanU8TryIntoPoint of TryInto<Span<u8>, Point> {
 
         let mut y: u256 = self.into();
         if (y >= p) {
-            return Option::None(());
+            return Option::None;
         }
         // bitshit of 255
         let bitshift_255: u256 =
@@ -197,12 +197,12 @@ impl SpanU8TryIntoPoint of TryInto<Span<u8>, Point> {
             let p_minus_one_over_4: u256 = div_mod(sub_mod(p, 1, p), 4, p);
             x = mult_mod(x_candidate_root, pow_mod(2, p_minus_one_over_4, p), p);
         } else {
-            return Option::None(());
+            return Option::None;
         }
 
         if (x == 0) {
             if (x_0 == 1) {
-                return Option::None(());
+                return Option::None;
             }
         }
         if (x_0 != x % 2) {
@@ -234,7 +234,7 @@ fn point_mult(mut scalar: u256, mut P: ExtendedHomogeneousPoint) -> ExtendedHomo
     // Double and add method
     loop {
         if (scalar == zero_u512) {
-            break ();
+            break;
         }
         if ((scalar.low & 1) == 1) {
             Q = Q + P;

--- a/src/math/gcd_of_n_numbers.cairo
+++ b/src/math/gcd_of_n_numbers.cairo
@@ -18,7 +18,7 @@ fn gcd(mut n: Span<u128>) -> u128 {
             Option::Some(b) => {
                 a = gcd_two_numbers(a, *b);
             },
-            Option::None(()) => {
+            Option::None => {
                 break a;
             },
         };

--- a/src/math/perfect_number.cairo
+++ b/src/math/perfect_number.cairo
@@ -39,7 +39,7 @@ fn perfect_numbers(max: u128) -> Array<u128> {
 
     loop {
         if index == max {
-            break ();
+            break;
         }
         if is_perfect_number(index) {
             res.append(index);

--- a/src/math/sha512.cairo
+++ b/src/math/sha512.cairo
@@ -155,7 +155,7 @@ fn add_trailing_zeroes(ref data: Array<u8>, msg_len: usize) {
     let mut i = 0;
     loop {
         if (i >= padding_len) {
-            break ();
+            break;
         }
         data.append(0);
         i += 1;
@@ -168,7 +168,7 @@ fn from_u8Array_to_WordArray(data: Array<u8>) -> Array<Word64> {
 
     loop {
         if (i >= data.len()) {
-            break ();
+            break;
         }
         let new_word: u128 = (BitShift::shl((*data[i + 0]).into(), 56)
             + BitShift::shl((*data[i + 1]).into(), 48)
@@ -190,7 +190,7 @@ fn from_WordArray_to_u8array(data: Span<Word64>) -> Array<u8> {
     let mut i: usize = 0;
     loop {
         if (i == data.len()) {
-            break ();
+            break;
         }
         let mut res: u128 = BitShift::shr((*data.at(i).data).into(), 56)
             & BoundedInt::<u8>::max().into();
@@ -233,7 +233,7 @@ fn digest_hash(data: Span<Word64>, msg_len: usize) -> Array<Word64> {
 
     loop {
         if (i == block_nb) {
-            break ();
+            break;
         }
         // Prepare message schedule
         let mut t: usize = 0;
@@ -241,7 +241,7 @@ fn digest_hash(data: Span<Word64>, msg_len: usize) -> Array<Word64> {
         let mut W: Array<Word64> = array![];
         loop {
             if t == 80 {
-                break ();
+                break;
             } else if t < 16 {
                 W.append(*data.at(i * 16 + t));
             } else {

--- a/src/math/zellers_congruence.cairo
+++ b/src/math/zellers_congruence.cairo
@@ -9,7 +9,7 @@
 /// * `month` - The month of the year
 /// * `year` - The year
 /// # Returns
-/// * `Option::None(())` - If the input parameters are invalid
+/// * `Option::None` - If the input parameters are invalid
 /// * `Option::Some(day_of_week)` - The day of the week
 /// # Examples
 /// ```
@@ -21,7 +21,7 @@
 fn day_of_week(mut date: u128, mut month: u128, mut year: u128) -> Option<u128> {
     // Check input parameters
     if !check_input_parameters(date, month, year) {
-        return Option::None(());
+        return Option::None;
     }
     if month < 3 {
         month = month + 12;

--- a/src/numeric/cumsum.cairo
+++ b/src/numeric/cumsum.cairo
@@ -24,8 +24,8 @@ fn cumsum<T, impl TAdd: Add<T>, impl TCopy: Copy<T>, impl TDrop: Drop<T>, >(
                 array.append(sum);
                 prev_value = sum;
             },
-            Option::None(_) => {
-                break ();
+            Option::None => {
+                break;
             },
         };
     };

--- a/src/numeric/diff.cairo
+++ b/src/numeric/diff.cairo
@@ -32,8 +32,8 @@ fn diff<
                 array.append(*current_value - prev_value);
                 prev_value = *current_value;
             },
-            Option::None(_) => {
-                break ();
+            Option::None => {
+                break;
             },
         };
     };

--- a/src/numeric/trapezoidal_rule.cairo
+++ b/src/numeric/trapezoidal_rule.cairo
@@ -34,7 +34,7 @@ fn trapezoidal_rule<
     let mut value = Zeroable::zero();
     loop {
         if index + 1 == xs.len() {
-            break ();
+            break;
         }
         assert(*xs[index + 1] > *xs[index], 'Abscissa must be sorted');
         value += (*xs[index + 1] - *xs[index]) * (*ys[index] + *ys[index + 1]);

--- a/src/searching/binary_search.cairo
+++ b/src/searching/binary_search.cairo
@@ -7,14 +7,14 @@ fn binary_search<
 ) -> Option<u32> {
     // Initial check
     if (span.len() == 0) {
-        return Option::None(());
+        return Option::None;
     }
     let middle = span.len() / 2;
     if (*span[middle] == val) {
         return Option::Some(middle);
     }
     if (span.len() == 1) {
-        return Option::None(());
+        return Option::None;
     }
     if (*span[middle] > val) {
         return (binary_search(span.slice(0, middle), val));
@@ -27,6 +27,6 @@ fn binary_search<
     let val = binary_search(span.slice(middle, len), val);
     match val {
         Option::Some(v) => Option::Some(v + middle),
-        Option::None(()) => Option::None(())
+        Option::None => Option::None
     }
 }

--- a/src/sorting/bubble_sort.cairo
+++ b/src/sorting/bubble_sort.cairo
@@ -23,7 +23,7 @@ fn bubble_sort_elements<
         if idx2 == array.len() {
             sorted_array.append(*array[idx1]);
             if sorted_iteration == 0 {
-                break ();
+                break;
             }
             array = sorted_array;
             sorted_array = array![];

--- a/src/sorting/sorting.cairo
+++ b/src/sorting/sorting.cairo
@@ -18,7 +18,7 @@ fn is_equal(mut a: Span<u32>, mut b: Span<u32>) -> bool {
                     break false;
                 }
             },
-            Option::None(_) => {
+            Option::None => {
                 break true;
             },
         };

--- a/src/storage/list.cairo
+++ b/src/storage/list.cairo
@@ -83,7 +83,7 @@ impl ListImpl<
 
     fn get(self: @List<T>, index: u32) -> Option<T> {
         if (index >= *self.len) {
-            return Option::None(());
+            return Option::None;
         }
 
         let (base, offset) = calculate_base_and_offset_for_index(
@@ -103,7 +103,7 @@ impl ListImpl<
 
     fn pop_front(ref self: List<T>) -> Option<T> {
         if self.len == 0 {
-            return Option::None(());
+            return Option::None;
         }
 
         let popped = self.get(self.len - 1);
@@ -121,7 +121,7 @@ impl ListImpl<
         let mut index = 0;
         loop {
             if index == *self.len {
-                break ();
+                break;
             }
             array.append(self.get(index).expect('List index out of bounds'));
             index += 1;


### PR DESCRIPTION
Updated:
 - break (); => break;
 - Option::None(()) => Option::None
 - Option::None(_) => Option::None