### PR TITLE
fix fpow overflow

### DIFF
--- a/src/math/src/lib.cairo
+++ b/src/math/src/lib.cairo
@@ -2,6 +2,7 @@ use option::OptionTrait;
 use traits::Into;
 
 /// Raise a number to a power.
+/// O(n) time complexity.
 /// * `base` - The number to raise.
 /// * `exp` - The exponent.
 /// # Returns
@@ -42,6 +43,8 @@ impl U128BitShift of BitShift<u128> {
     fn fpow(x: u128, n: u128) -> u128 {
         if n == 0 {
             1
+        } else if n == 1 {
+            x
         } else if (n & 1) == 1 {
             x * BitShift::fpow(x * x, n / 2)
         } else {
@@ -61,6 +64,8 @@ impl U256BitShift of BitShift<u256> {
     fn fpow(x: u256, n: u256) -> u256 {
         if n == 0 {
             1
+        } else if n == 1 {
+            x
         } else if (n & 1) == 1 {
             x * BitShift::fpow(x * x, n / 2)
         } else {


### PR DESCRIPTION
**Problem Description**

In the implementation of bitshifts in [lib.cairo](https://github.com/keep-starknet-strange/alexandria/blob/main/src/math/src/lib.cairo#L42-L50), the existing fpow function exhibits an overflow error when computing 2^n for n ≥ 64 using the generic function for u128.

**Details**

When we want to compute 2^n for n ≥ 64 using the generic function for u128, we encounter an overflow error. The error occurs in the last steps where we need to compute x * x, and x is greater than or equal to 2^64. Thus, x * x is greater than or equal to 2^128, leading to an overflow error.

**Proposed Solution**

The proposed solution is to modify the fpow function with a specific condition for n == 1. Below are the old and new code snippets:

**Old function code:**
```cairo
fn fpow(x: u128, n: u128) -> u128 {
    if n == 0 {
        1
    } else if (n & 1) == 1 {
        x * fpow(x * x, n / 2)
    } else {
        fpow(x * x, n / 2)
    }
}
```

**New function code:**
```cairo
fn fpow(x: u128, n: u128) -> u128 {
    if n == 0 {
        1
    } else if n == 1 {
        x
    } else if (n & 1) == 1 {
        x * fpow(x * x, n / 2)
    } else {
        fpow(x * x, n / 2)
    }
}
```
This change fixes the issue by handling the specific case where n is 1, preventing the overflow error.