### PR TITLE
✨ Merkle tree generation

### DIFF
--- a/src/data_structures/README.md
+++ b/src/data_structures/README.md
@@ -8,7 +8,7 @@ The Merkle tree algorithm is a cryptographic hashing algorithm used to create a 
 The purpose of the Merkle tree algorithm is to provide a way to verify the integrity and authenticity of large amounts of data without needing to store the entire data set. The algorithm has applications in various areas of computer science, including cryptocurrency, file sharing, and database management.  
 The Merkle tree algorithm is also used in creating digital signatures and verifying the authenticity of transactions.  
 By providing a secure and efficient way to verify data integrity, the Merkle tree algorithm is an important tool in cryptography and information security.
-Two implementations are available to manage both pedersen (legacy) and poseidon hash methods.
+A generic implementation is available to manage both pedersen (legacy) and poseidon hash methods.
 
 ## [Queue](./src/queue.cairo)
 

--- a/src/data_structures/README.md
+++ b/src/data_structures/README.md
@@ -8,6 +8,7 @@ The Merkle tree algorithm is a cryptographic hashing algorithm used to create a 
 The purpose of the Merkle tree algorithm is to provide a way to verify the integrity and authenticity of large amounts of data without needing to store the entire data set. The algorithm has applications in various areas of computer science, including cryptocurrency, file sharing, and database management.  
 The Merkle tree algorithm is also used in creating digital signatures and verifying the authenticity of transactions.  
 By providing a secure and efficient way to verify data integrity, the Merkle tree algorithm is an important tool in cryptography and information security.
+Two implementations are available to manage both pedersen (legacy) and poseidon hash methods.
 
 ## [Queue](./src/queue.cairo)
 

--- a/src/data_structures/src/merkle_tree.cairo
+++ b/src/data_structures/src/merkle_tree.cairo
@@ -5,7 +5,7 @@
 //! use alexandria::data_structures::merkle_tree::{MerkleTree, HashMethod, MerkleTreeTrait};
 //!
 //! // Create a new merkle tree legacy instance, this version uses the pedersen hash method.
-//! let hash_method = HashMethod::Pedersen(());
+//! let hash_method = HashMethod::Pedersen;
 //! let mut merkle_tree: MerkleTree = MerkleTreeTrait::new(hash_method);
 //! let mut proof = array![];
 //! proof.append(element_1);
@@ -14,7 +14,7 @@
 //! let root = merkle_tree.compute_root(leaf, proof);
 //!
 //! // Create a new merkle tree instance, this version uses the poseidon hash method.
-//! let hash_method = HashMethod::Poseidon(());
+//! let hash_method = HashMethod::Poseidon;
 //! let mut merkle_tree: MerkleTree = MerkleTreeTrait::new(hash_method);
 //! let mut proof = array![];
 //! proof.append(element_1);
@@ -37,8 +37,8 @@ struct MerkleTree {
 
 #[derive(Serde, Copy, Drop)]
 enum HashMethod {
-    Pedersen: (),
-    Poseidon: (),
+    Pedersen,
+    Poseidon,
 }
 
 /// MerkleTree trait.
@@ -77,7 +77,7 @@ impl MerkleTreeImpl of MerkleTreeTrait<MerkleTree> {
                     // We need to check if the current node is smaller than the current element of the proof.
                     // If it is, we need to swap the order of the hash.
                     current_node = match self.hash_method {
-                        HashMethod::Pedersen(()) => {
+                        HashMethod::Pedersen => {
                             if Into::<felt252, u256>::into(current_node) < (*proof_element).into() {
                                 let mut state = PedersenTrait::new(current_node);
                                 state = state.update(*proof_element);
@@ -88,7 +88,7 @@ impl MerkleTreeImpl of MerkleTreeTrait<MerkleTree> {
                                 state.finalize()
                             }
                         },
-                        HashMethod::Poseidon(()) => {
+                        HashMethod::Poseidon => {
                             let mut state = PoseidonTrait::new();
                             if Into::<felt252, u256>::into(current_node) < (*proof_element).into() {
                                 state = state.update(current_node);
@@ -193,7 +193,7 @@ fn _get_next_level(mut nodes: Span<felt252>, hash_method: HashMethod) -> Array<f
         let left = *nodes.pop_front().expect('Index out of bounds');
         let right = *nodes.pop_front().expect('Index out of bounds');
         let node = match hash_method {
-            HashMethod::Pedersen(()) => {
+            HashMethod::Pedersen => {
                 if Into::<felt252, u256>::into(left) < right.into() {
                     let mut state = PedersenTrait::new(left);
                     state = state.update(right);
@@ -204,7 +204,7 @@ fn _get_next_level(mut nodes: Span<felt252>, hash_method: HashMethod) -> Array<f
                     state.finalize()
                 }
             },
-            HashMethod::Poseidon(()) => {
+            HashMethod::Poseidon => {
                 let mut state = PoseidonTrait::new();
                 if Into::<felt252, u256>::into(left) < right.into() {
                     state = state.update(left);

--- a/src/data_structures/src/merkle_tree.cairo
+++ b/src/data_structures/src/merkle_tree.cairo
@@ -2,7 +2,7 @@
 //!
 //! # Example
 //! ```
-//! use alexandria::data_structures::merkle_tree::{MerklTree, HashMethod, MerkleTreeTrait};
+//! use alexandria::data_structures::merkle_tree::{MerkleTree, HashMethod, MerkleTreeTrait};
 //!
 //! // Create a new merkle tree legacy instance, this version uses the pedersen hash method.
 //! let hash_method = HashMethod::Pedersen(());

--- a/src/data_structures/src/merkle_tree.cairo
+++ b/src/data_structures/src/merkle_tree.cairo
@@ -2,23 +2,17 @@
 //!
 //! # Example
 //! ```
-//! use alexandria::data_structures::merkle_tree::{MerkleTree, HasherTrait, PedersenHasher, PoseidonHasher, MerkleTreeTrait};
+//! use alexandria::data_structures::merkle_tree::{MerkleTree, PedersenHasher, PoseidonHasher, MerkleTreeTrait};
 //!
 //! // Create a new merkle tree legacy instance, this version uses the pedersen hash method.
-//! let hasher: PedersenHasher = HasherTrait::new();
 //! let mut merkle_tree: MerkleTree<PedersenHasher> = MerkleTreeTrait::new();
-//! let mut proof = array![];
-//! proof.append(element_1);
-//! proof.append(element_2);
+//! let mut proof = array![element_1, element_2];
 //! // Compute the merkle root.
 //! let root = merkle_tree.compute_root(leaf, proof);
 //!
 //! // Create a new merkle tree instance, this version uses the poseidon hash method.
-//! let hasher: PoseidonHasher = HasherTrait::new();
 //! let mut merkle_tree: MerkleTree<PoseidonHasher> = MerkleTreeTrait::new();
-//! let mut proof = array![];
-//! proof.append(element_1);
-//! proof.append(element_2);
+//! let mut proof = array![element_1, element_2];
 //! // Compute the merkle root.
 //! let root = merkle_tree.compute_root(leaf, proof);
 

--- a/src/data_structures/src/merkle_tree.cairo
+++ b/src/data_structures/src/merkle_tree.cairo
@@ -4,7 +4,7 @@
 //!
 //! ```
 //! // This version uses the pedersen hash method because the PedersenHasherImpl is in the scope.
-//! use alexandria_data_structures::merkle_tree::{ Hasher, MerkleTree, pedersen::PedersenHasherImpl, MerkleTreeTrait };
+//! use alexandria_data_structures::merkle_tree::{Hasher, MerkleTree, pedersen::PedersenHasherImpl, MerkleTreeTrait};
 //!
 //! // Create a new merkle tree instance.
 //! let mut merkle_tree: MerkleTree<Hasher> = MerkleTreeTrait::new();

--- a/src/data_structures/src/merkle_tree.cairo
+++ b/src/data_structures/src/merkle_tree.cairo
@@ -1,20 +1,28 @@
 //! MerkleTree implementation.
 //!
-//! # Example
-//! ```
-//! use alexandria::data_structures::merkle_tree::{MerkleTree, PedersenHasher, PoseidonHasher, MerkleTreeTrait};
+//! # Examples
 //!
-//! // Create a new merkle tree legacy instance, this version uses the pedersen hash method.
-//! let mut merkle_tree: MerkleTree<PedersenHasher> = MerkleTreeTrait::new();
+//! ```
+//! // This version uses the pedersen hash method because the PedersenHasherImpl is in the scope.
+//! use alexandria_data_structures::merkle_tree::{ Hasher, MerkleTree, pedersen::PedersenHasherImpl, MerkleTreeTrait };
+//!
+//! // Create a new merkle tree instance.
+//! let mut merkle_tree: MerkleTree<Hasher> = MerkleTreeTrait::new();
 //! let mut proof = array![element_1, element_2];
 //! // Compute the merkle root.
 //! let root = merkle_tree.compute_root(leaf, proof);
+//! ```
 //!
-//! // Create a new merkle tree instance, this version uses the poseidon hash method.
+//! ```
+//! // This version uses the poseidon hash method because the PoseidonHasherImpl is in the scope.
+//! use alexandria_data_structures::merkle_tree::{ Hasher, MerkleTree, poseidon::PoseidonHasherImpl, MerkleTreeTrait };
+//!
+//! // Create a new merkle tree instance.
 //! let mut merkle_tree: MerkleTree<PoseidonHasher> = MerkleTreeTrait::new();
 //! let mut proof = array![element_1, element_2];
 //! // Compute the merkle root.
 //! let root = merkle_tree.compute_root(leaf, proof);
+//! ```
 
 // Core lib imports
 use array::{ArrayTrait, SpanTrait};
@@ -40,7 +48,7 @@ mod pedersen {
     use hash::HashStateTrait;
     use super::{Hasher, HasherTrait};
 
-    impl PedersenHasher of HasherTrait<Hasher> {
+    impl PedersenHasherImpl of HasherTrait<Hasher> {
         fn new() -> Hasher {
             Hasher {}
         }
@@ -57,7 +65,7 @@ mod poseidon {
     use hash::HashStateTrait;
     use super::{Hasher, HasherTrait};
 
-    impl PoseidonHasher of HasherTrait<Hasher> {
+    impl PoseidonHasherImpl of HasherTrait<Hasher> {
         fn new() -> Hasher {
             Hasher {}
         }
@@ -69,6 +77,7 @@ mod poseidon {
         }
     }
 }
+
 /// MerkleTree representation.
 
 #[derive(Drop)]

--- a/src/data_structures/src/merkle_tree.cairo
+++ b/src/data_structures/src/merkle_tree.cairo
@@ -25,7 +25,6 @@ use array::{ArrayTrait, SpanTrait};
 use hash::LegacyHash;
 use poseidon::poseidon_hash_span;
 use traits::Into;
-use debug::PrintTrait;
 
 /// MerkleTree Legacy representation.
 #[derive(Drop)]

--- a/src/data_structures/src/merkle_tree.cairo
+++ b/src/data_structures/src/merkle_tree.cairo
@@ -164,7 +164,7 @@ impl MerkleTreeImpl<
         ref self: MerkleTree<T>, mut leaves: Array<felt252>, index: u32
     ) -> Span<felt252> {
         let mut proof: Array<felt252> = array![];
-        _compute_proof(leaves, self.hasher, index, ref proof);
+        compute_proof(leaves, self.hasher, index, ref proof);
         proof.span()
     }
 }
@@ -175,7 +175,7 @@ impl MerkleTreeImpl<
 /// * `index` - The index of the given.
 /// * `hasher` - The hasher to use.
 /// * `proof` - The proof array to fill.
-fn _compute_proof<T, impl THasher: HasherTrait<T>, impl TDrop: Drop<T>>(
+fn compute_proof<T, impl THasher: HasherTrait<T>, impl TDrop: Drop<T>>(
     mut nodes: Array<felt252>, mut hasher: T, index: u32, ref proof: Array<felt252>
 ) {
     // Break if we have reached the top of the tree
@@ -189,7 +189,7 @@ fn _compute_proof<T, impl THasher: HasherTrait<T>, impl TDrop: Drop<T>>(
     }
 
     // Compute next level
-    let mut next_level: Array<felt252> = _get_next_level(nodes.span(), ref hasher);
+    let mut next_level: Array<felt252> = get_next_level(nodes.span(), ref hasher);
 
     // Find neighbor node
     let mut index_parent = 0;
@@ -207,7 +207,7 @@ fn _compute_proof<T, impl THasher: HasherTrait<T>, impl TDrop: Drop<T>>(
         i += 1;
     };
 
-    _compute_proof(next_level, hasher, index_parent, ref proof)
+    compute_proof(next_level, hasher, index_parent, ref proof)
 }
 
 /// Helper function to compute the next layer of a merkle tree providing a layer of nodes.
@@ -216,7 +216,7 @@ fn _compute_proof<T, impl THasher: HasherTrait<T>, impl TDrop: Drop<T>>(
 /// * `hasher` - The hasher to use.
 /// # Returns
 /// The next layer of nodes.
-fn _get_next_level<T, impl THasher: HasherTrait<T>, impl TDrop: Drop<T>>(
+fn get_next_level<T, impl THasher: HasherTrait<T>, impl TDrop: Drop<T>>(
     mut nodes: Span<felt252>, ref hasher: T
 ) -> Array<felt252> {
     let mut next_level: Array<felt252> = array![];

--- a/src/data_structures/src/merkle_tree.cairo
+++ b/src/data_structures/src/merkle_tree.cairo
@@ -18,9 +18,6 @@
 
 // Core lib imports
 use array::{ArrayTrait, SpanTrait};
-use pedersen::PedersenTrait;
-use poseidon::PoseidonTrait;
-use hash::HashStateTrait;
 use traits::{Into, Copy, Drop};
 
 /// Hasher trait.
@@ -34,36 +31,44 @@ trait HasherTrait<T> {
 // Hasher representations.
 
 #[derive(Drop, Copy)]
-struct PedersenHasher {}
-
-#[derive(Drop, Copy)]
-struct PoseidonHasher {}
+struct Hasher {}
 
 /// Hasher impls.
 
-impl PedersenHasherImpl of HasherTrait<PedersenHasher> {
-    fn new() -> PedersenHasher {
-        PedersenHasher {}
-    }
-    fn hash(ref self: PedersenHasher, data1: felt252, data2: felt252) -> felt252 {
-        let mut state = PedersenTrait::new(data1);
-        state = state.update(data2);
-        state.finalize()
+mod pedersen {
+    use pedersen::PedersenTrait;
+    use hash::HashStateTrait;
+    use super::{Hasher, HasherTrait};
+
+    impl PedersenHasher of HasherTrait<Hasher> {
+        fn new() -> Hasher {
+            Hasher {}
+        }
+        fn hash(ref self: Hasher, data1: felt252, data2: felt252) -> felt252 {
+            let mut state = PedersenTrait::new(data1);
+            state = state.update(data2);
+            state.finalize()
+        }
     }
 }
 
-impl PoseidonHasherImpl of HasherTrait<PoseidonHasher> {
-    fn new() -> PoseidonHasher {
-        PoseidonHasher {}
-    }
-    fn hash(ref self: PoseidonHasher, data1: felt252, data2: felt252) -> felt252 {
-        let mut state = PoseidonTrait::new();
-        state = state.update(data1);
-        state = state.update(data2);
-        state.finalize()
+mod poseidon {
+    use poseidon::PoseidonTrait;
+    use hash::HashStateTrait;
+    use super::{Hasher, HasherTrait};
+
+    impl PoseidonHasher of HasherTrait<Hasher> {
+        fn new() -> Hasher {
+            Hasher {}
+        }
+        fn hash(ref self: Hasher, data1: felt252, data2: felt252) -> felt252 {
+            let mut state = PoseidonTrait::new();
+            state = state.update(data1);
+            state = state.update(data2);
+            state.finalize()
+        }
     }
 }
-
 /// MerkleTree representation.
 
 #[derive(Drop)]

--- a/src/data_structures/src/merkle_tree.cairo
+++ b/src/data_structures/src/merkle_tree.cairo
@@ -2,10 +2,18 @@
 //!
 //! # Example
 //! ```
-//! use alexandria::data_structures::merkle_tree::MerkleTreeTrait;
+//! use alexandria::data_structures::merkle_tree::{MerklTree, MerkleTreeLegacy, MerkleTreeTrait};
 //!
-//! // Create a new merkle tree instance.
-//! let mut merkle_tree = MerkleTreeTrait::new();
+//! // Create a new merkle tree legacy instance, this version uses the pedersen hash method.
+//! let mut merkle_tree: MerkleTreeLegacy = MerkleTreeTrait::new();
+//! let mut proof = array![];
+//! proof.append(element_1);
+//! proof.append(element_2);
+//! // Compute the merkle root.
+//! let root = merkle_tree.compute_root(leaf, proof);
+//!
+//! // Create a new merkle tree instance, this version uses the poseidon hash method.
+//! let mut merkle_tree: MerkleTree = MerkleTreeTrait::new();
 //! let mut proof = array![];
 //! proof.append(element_1);
 //! proof.append(element_2);
@@ -13,33 +21,113 @@
 //! let root = merkle_tree.compute_root(leaf, proof);
 
 // Core lib imports
-use array::SpanTrait;
+use array::{ArrayTrait, SpanTrait};
 use hash::LegacyHash;
+use poseidon::poseidon_hash_span;
 use traits::Into;
+use debug::PrintTrait;
+
+/// MerkleTree Legacy representation.
+#[derive(Drop)]
+struct MerkleTreeLegacy {}
 
 /// MerkleTree representation.
 #[derive(Drop)]
 struct MerkleTree {}
 
-/// MerkleTree trait.
-trait MerkleTreeTrait {
-    /// Create a new merkle tree instance.
-    fn new() -> MerkleTree;
-    /// Compute the merkle root of a given proof.
-    fn compute_root(ref self: MerkleTree, current_node: felt252, proof: Span<felt252>) -> felt252;
-    /// Verify a merkle proof.
-    fn verify(ref self: MerkleTree, root: felt252, leaf: felt252, proof: Span<felt252>) -> bool;
+#[derive(Serde, Copy, Drop)]
+enum HashMethod {
+    Pedersen: (),
+    Poseidon: (),
 }
 
-/// MerkleTree implementation.
-impl MerkleTreeImpl of MerkleTreeTrait {
+/// MerkleTree trait.
+trait MerkleTreeTrait<T> {
+    /// Create a new merkle tree instance.
+    fn new() -> T;
+    /// Compute the merkle root of a given proof.
+    fn compute_root(ref self: T, current_node: felt252, proof: Span<felt252>) -> felt252;
+    /// Verify a merkle proof.
+    fn verify(ref self: T, root: felt252, leaf: felt252, proof: Span<felt252>) -> bool;
+    /// Compute a merkle proof of given leaves and at a given index.
+    fn compute_proof(ref self: T, leaves: Array<felt252>, index: u32) -> Span<felt252>;
+}
+
+/// MerkleTree Legacy implementation.
+impl MerkleTreeLegacyImpl of MerkleTreeTrait<MerkleTreeLegacy> {
+    /// Create a new merkle tree instance.
+    #[inline(always)]
+    fn new() -> MerkleTreeLegacy {
+        MerkleTreeLegacy {}
+    }
+
+    /// Compute the merkle root of a given proof using the pedersen hash method.
+    /// # Arguments
+    /// * `current_node` - The current node of the proof.
+    /// * `proof` - The proof.
+    /// # Returns
+    /// The merkle root.
+    fn compute_root(
+        ref self: MerkleTreeLegacy, mut current_node: felt252, mut proof: Span<felt252>
+    ) -> felt252 {
+        loop {
+            match proof.pop_front() {
+                Option::Some(proof_element) => {
+                    // Compute the pedersen hash of the current node and the current element of the proof.
+                    // We need to check if the current node is smaller than the current element of the proof.
+                    // If it is, we need to swap the order of the hash.
+                    current_node =
+                        if Into::<felt252, u256>::into(current_node) < (*proof_element).into() {
+                            LegacyHash::hash(current_node, *proof_element)
+                        } else {
+                            LegacyHash::hash(*proof_element, current_node)
+                        };
+                },
+                Option::None => {
+                    break current_node;
+                },
+            };
+        }
+    }
+
+    /// Verify a merkle proof.
+    /// # Arguments
+    /// * `root` - The merkle root.
+    /// * `leaf` - The leaf to verify.
+    /// * `proof` - The proof.
+    /// # Returns
+    /// True if the proof is valid, false otherwise.
+    fn verify(
+        ref self: MerkleTreeLegacy, root: felt252, leaf: felt252, mut proof: Span<felt252>
+    ) -> bool {
+        let computed_root = self.compute_root(leaf, proof);
+        computed_root == root
+    }
+
+    /// Compute a merkle proof of given leaves and at a given index using the pedersen hash method.
+    /// # Arguments
+    /// * `leaves` - The sorted leaves.
+    /// * `index` - The index of the given.
+    /// # Returns
+    /// The merkle proof.
+    fn compute_proof(
+        ref self: MerkleTreeLegacy, mut leaves: Array<felt252>, index: u32
+    ) -> Span<felt252> {
+        let mut proof: Array<felt252> = array![];
+        _compute_proof(leaves, index, HashMethod::Pedersen(()), ref proof);
+        proof.span()
+    }
+}
+
+/// MerkleTree legacy implementation.
+impl MerkleTreeImpl of MerkleTreeTrait<MerkleTree> {
     /// Create a new merkle tree instance.
     #[inline(always)]
     fn new() -> MerkleTree {
         MerkleTree {}
     }
 
-    /// Compute the merkle root of a given proof.
+    /// Compute the merkle root of a given proof using the poseidon hash method.
     /// # Arguments
     /// * `current_node` - The current node of the proof.
     /// * `proof` - The proof.
@@ -54,11 +142,12 @@ impl MerkleTreeImpl of MerkleTreeTrait {
                     // Compute the hash of the current node and the current element of the proof.
                     // We need to check if the current node is smaller than the current element of the proof.
                     // If it is, we need to swap the order of the hash.
-                    if Into::<felt252, u256>::into(current_node) < (*proof_element).into() {
-                        current_node = LegacyHash::hash(current_node, *proof_element);
-                    } else {
-                        current_node = LegacyHash::hash(*proof_element, current_node);
-                    }
+                    current_node =
+                        if Into::<felt252, u256>::into(current_node) < (*proof_element).into() {
+                            poseidon_hash_span(array![current_node, *proof_element].span())
+                        } else {
+                            poseidon_hash_span(array![*proof_element, current_node].span())
+                        };
                 },
                 Option::None => {
                     break current_node;
@@ -80,4 +169,89 @@ impl MerkleTreeImpl of MerkleTreeTrait {
         let computed_root = self.compute_root(leaf, proof);
         computed_root == root
     }
+
+    /// Compute a merkle proof of given leaves and at a given index using the poseidon hash method.
+    /// # Arguments
+    /// * `leaves` - The sorted leaves.
+    /// * `index` - The index of the given.
+    /// # Returns
+    /// The merkle proof.
+    fn compute_proof(
+        ref self: MerkleTree, mut leaves: Array<felt252>, index: u32
+    ) -> Span<felt252> {
+        let mut proof: Array<felt252> = array![];
+        _compute_proof(leaves, index, HashMethod::Poseidon(()), ref proof);
+        proof.span()
+    }
+}
+
+/// Helper function to compute a merkle proof of given leaves and at a given index.
+/// # Arguments
+/// * `nodes` - The sorted nodes.
+/// * `index` - The index of the given.
+/// * `method` - The hash method to use.
+/// * `proof` - The proof array to fill.
+fn _compute_proof(
+    mut nodes: Array<felt252>, index: u32, method: HashMethod, ref proof: Array<felt252>
+) {
+    // Break if we have reached the top of the tree
+    if nodes.len() == 1 {
+        return;
+    }
+
+    // If odd number of nodes, add a null virtual leaf
+    if nodes.len() % 2 != 0 {
+        nodes.append(0);
+    }
+
+    // Compute next level
+    let mut next_level: Array<felt252> = _get_next_level(nodes.span(), method);
+
+    // Find neighbor node
+    let mut index_parent = 0;
+    let mut i = 0;
+    loop {
+        if i == index {
+            index_parent = i / 2;
+            if i % 2 == 0 {
+                proof.append(*nodes.at(i + 1));
+            } else {
+                proof.append(*nodes.at(i - 1));
+            }
+            break;
+        }
+        i += 1;
+    };
+
+    _compute_proof(next_level, index_parent, method, ref proof)
+}
+
+/// Helper function to compute the next layer of a merkle tree providing a layer of nodes.
+/// # Arguments
+/// * `nodes` - The sorted nodes.
+/// * `method` - The hash method to use.
+/// # Returns
+/// The next layer of nodes.
+fn _get_next_level(mut nodes: Span<felt252>, method: HashMethod) -> Array<felt252> {
+    let mut next_level: Array<felt252> = array![];
+    loop {
+        if nodes.is_empty() {
+            break;
+        }
+        let left = *nodes.pop_front().expect('Index out of bounds');
+        let right = *nodes.pop_front().expect('Index out of bounds');
+        let node = if Into::<felt252, u256>::into(left) < right.into() {
+            match method {
+                HashMethod::Pedersen => LegacyHash::hash(left, right),
+                HashMethod::Poseidon => poseidon_hash_span(array![left, right].span()),
+            }
+        } else {
+            match method {
+                HashMethod::Pedersen => LegacyHash::hash(right, left),
+                HashMethod::Poseidon => poseidon_hash_span(array![right, left].span()),
+            }
+        };
+        next_level.append(node);
+    };
+    next_level
 }

--- a/src/data_structures/src/merkle_tree.cairo
+++ b/src/data_structures/src/merkle_tree.cairo
@@ -100,7 +100,7 @@ impl MerkleTreeImpl<
         MerkleTree { hasher: HasherTrait::new() }
     }
 
-    /// Compute the merkle root of a given proof using the pedersen hash method.
+    /// Compute the merkle root of a given proof using the generic T hasher.
     /// # Arguments
     /// * `current_node` - The current node of the proof.
     /// * `proof` - The proof.
@@ -129,7 +129,7 @@ impl MerkleTreeImpl<
         }
     }
 
-    /// Verify a merkle proof.
+    /// Verify a merkle proof using the generic T hasher.
     /// # Arguments
     /// * `root` - The merkle root.
     /// * `leaf` - The leaf to verify.
@@ -160,7 +160,7 @@ impl MerkleTreeImpl<
         computed_root == root
     }
 
-    /// Compute a merkle proof of given leaves and at a given index using the pedersen hash method.
+    /// Compute a merkle proof of given leaves and at a given index using the generic T hasher.
     /// # Arguments
     /// * `leaves` - The sorted leaves.
     /// * `index` - The index of the given.
@@ -179,7 +179,7 @@ impl MerkleTreeImpl<
 /// # Arguments
 /// * `nodes` - The sorted nodes.
 /// * `index` - The index of the given.
-/// * `method` - The hash method to use.
+/// * `hasher` - The hasher to use.
 /// * `proof` - The proof array to fill.
 fn _compute_proof<T, impl THasher: HasherTrait<T>, impl TDrop: Drop<T>>(
     mut nodes: Array<felt252>, mut hasher: T, index: u32, ref proof: Array<felt252>
@@ -219,7 +219,7 @@ fn _compute_proof<T, impl THasher: HasherTrait<T>, impl TDrop: Drop<T>>(
 /// Helper function to compute the next layer of a merkle tree providing a layer of nodes.
 /// # Arguments
 /// * `nodes` - The sorted nodes.
-/// * `method` - The hash method to use.
+/// * `hasher` - The hasher to use.
 /// # Returns
 /// The next layer of nodes.
 fn _get_next_level<T, impl THasher: HasherTrait<T>, impl TDrop: Drop<T>>(

--- a/src/data_structures/src/tests/merkle_tree_test.cairo
+++ b/src/data_structures/src/tests/merkle_tree_test.cairo
@@ -3,14 +3,66 @@ use array::ArrayTrait;
 use hash::LegacyHash;
 // Internal imports
 use alexandria_data_structures::merkle_tree::{
-    MerkleTree, PedersenHasher, PoseidonHasher, MerkleTreeTrait
+    Hasher, MerkleTree, pedersen::PedersenHasher, poseidon::PoseidonHasher, MerkleTreeTrait,
+    MerkleTreeImpl
 };
+
+
+mod regular_call_merkle_tree_pedersen {
+    // Core lib imports
+    use array::ArrayTrait;
+    use hash::LegacyHash;
+    // Internal imports
+    use alexandria_data_structures::merkle_tree::{
+        Hasher, MerkleTree, pedersen::PedersenHasher, MerkleTreeTrait,
+    };
+    #[test]
+    #[available_gas(2000000)]
+    fn regular_call_merkle_tree_pedersen_test() {
+        // [Setup] Merkle tree.
+        let mut merkle_tree: MerkleTree<Hasher> = MerkleTreeTrait::new();
+        let root = 0x15ac9e457789ef0c56e5d559809e7336a909c14ee2511503fa7af69be1ba639;
+        let leaf = 0x1;
+        let valid_proof = array![
+            0x2, 0x68ba2a188dd231112c1cb5aaa5d18be6d84f6c8683e5c3a6638dee83e727acc
+        ]
+            .span();
+        let leaves = array![0x1, 0x2, 0x3];
+
+        // [Assert] Compute merkle root.
+        let computed_root = merkle_tree.compute_root(leaf, valid_proof);
+        assert(computed_root == root, 'compute valid root failed');
+
+        // [Assert] Compute merkle proof.
+        let mut input_leaves = leaves;
+        let index = 0;
+        let computed_proof = merkle_tree.compute_proof(input_leaves, index);
+        assert(computed_proof == valid_proof, 'compute valid proof failed');
+
+        // [Assert] Verify a valid proof.
+        let result = merkle_tree.verify(root, leaf, valid_proof);
+        assert(result, 'verify valid proof failed');
+
+        // [Assert] Verify an invalid proof.
+        let invalid_proof = array![
+            0x2 + 1, 0x68ba2a188dd231112c1cb5aaa5d18be6d84f6c8683e5c3a6638dee83e727acc
+        ]
+            .span();
+        let result = merkle_tree.verify(root, leaf, invalid_proof);
+        assert(!result, 'verify invalid proof failed');
+
+        // [Assert] Verify a valid proof with an invalid leaf.
+        let invalid_leaf = 0x1 + 1;
+        let result = merkle_tree.verify(root, invalid_leaf, valid_proof);
+        assert(!result, 'wrong result');
+    }
+}
 
 #[test]
 #[available_gas(2000000)]
 fn merkle_tree_pedersen_test() {
     // [Setup] Merkle tree.
-    let mut merkle_tree: MerkleTree<PedersenHasher> = MerkleTreeTrait::new();
+    let mut merkle_tree: MerkleTree<Hasher> = MerkleTreeImpl::<_, PedersenHasher>::new();
     let root = 0x15ac9e457789ef0c56e5d559809e7336a909c14ee2511503fa7af69be1ba639;
     let leaf = 0x1;
     let valid_proof = array![0x2, 0x68ba2a188dd231112c1cb5aaa5d18be6d84f6c8683e5c3a6638dee83e727acc]
@@ -18,17 +70,20 @@ fn merkle_tree_pedersen_test() {
     let leaves = array![0x1, 0x2, 0x3];
 
     // [Assert] Compute merkle root.
-    let computed_root = merkle_tree.compute_root(leaf, valid_proof);
+    let computed_root = MerkleTreeImpl::<_,
+    PedersenHasher>::compute_root(ref merkle_tree, leaf, valid_proof);
     assert(computed_root == root, 'compute valid root failed');
 
     // [Assert] Compute merkle proof.
     let mut input_leaves = leaves;
     let index = 0;
-    let computed_proof = merkle_tree.compute_proof(input_leaves, index);
+    let computed_proof = MerkleTreeImpl::<_,
+    PedersenHasher>::compute_proof(ref merkle_tree, input_leaves, index);
     assert(computed_proof == valid_proof, 'compute valid proof failed');
 
     // [Assert] Verify a valid proof.
-    let result = merkle_tree.verify(root, leaf, valid_proof);
+    let result = MerkleTreeImpl::<_,
+    PedersenHasher>::verify(ref merkle_tree, root, leaf, valid_proof);
     assert(result, 'verify valid proof failed');
 
     // [Assert] Verify an invalid proof.
@@ -36,12 +91,14 @@ fn merkle_tree_pedersen_test() {
         0x2 + 1, 0x68ba2a188dd231112c1cb5aaa5d18be6d84f6c8683e5c3a6638dee83e727acc
     ]
         .span();
-    let result = merkle_tree.verify(root, leaf, invalid_proof);
+    let result = MerkleTreeImpl::<_,
+    PedersenHasher>::verify(ref merkle_tree, root, leaf, invalid_proof);
     assert(!result, 'verify invalid proof failed');
 
     // [Assert] Verify a valid proof with an invalid leaf.
     let invalid_leaf = 0x1 + 1;
-    let result = merkle_tree.verify(root, invalid_leaf, valid_proof);
+    let result = MerkleTreeImpl::<_,
+    PedersenHasher>::verify(ref merkle_tree, root, invalid_leaf, valid_proof);
     assert(!result, 'wrong result');
 }
 
@@ -49,7 +106,7 @@ fn merkle_tree_pedersen_test() {
 #[available_gas(2000000)]
 fn merkle_tree_poseidon_test() {
     // [Setup] Merkle tree.
-    let mut merkle_tree: MerkleTree<PoseidonHasher> = MerkleTreeTrait::new();
+    let mut merkle_tree: MerkleTree<Hasher> = MerkleTreeImpl::<_, PoseidonHasher>::new();
     let root = 0x7abc09d19c8a03abd4333a23f7823975c7bdd325170f0d32612b8baa1457d47;
     let leaf = 0x1;
     let valid_proof = array![0x2, 0x47ef3ad11ad3f8fc055281f1721acd537563ec134036bc4bd4de2af151f0832]
@@ -57,17 +114,20 @@ fn merkle_tree_poseidon_test() {
     let leaves = array![0x1, 0x2, 0x3];
 
     // [Assert] Compute merkle root.
-    let computed_root = merkle_tree.compute_root(leaf, valid_proof);
+    let computed_root = MerkleTreeImpl::<_,
+    PoseidonHasher>::compute_root(ref merkle_tree, leaf, valid_proof);
     assert(computed_root == root, 'compute valid root failed');
 
     // [Assert] Compute merkle proof.
     let mut input_leaves = leaves;
     let index = 0;
-    let computed_proof = merkle_tree.compute_proof(input_leaves, index);
+    let computed_proof = MerkleTreeImpl::<_,
+    PoseidonHasher>::compute_proof(ref merkle_tree, input_leaves, index);
     assert(computed_proof == valid_proof, 'compute valid proof failed');
 
     // [Assert] Verify a valid proof.
-    let result = merkle_tree.verify(root, leaf, valid_proof);
+    let result = MerkleTreeImpl::<_,
+    PoseidonHasher>::verify(ref merkle_tree, root, leaf, valid_proof);
     assert(result, 'verify valid proof failed');
 
     // [Assert] Verify an invalid proof.
@@ -75,11 +135,13 @@ fn merkle_tree_poseidon_test() {
         0x2 + 1, 0x68ba2a188dd231112c1cb5aaa5d18be6d84f6c8683e5c3a6638dee83e727acc
     ]
         .span();
-    let result = merkle_tree.verify(root, leaf, invalid_proof);
+    let result = MerkleTreeImpl::<_,
+    PoseidonHasher>::verify(ref merkle_tree, root, leaf, invalid_proof);
     assert(!result, 'verify invalid proof failed');
 
     // [Assert] Verify a valid proof with an invalid leaf.
     let invalid_leaf = 0x1 + 1;
-    let result = merkle_tree.verify(root, invalid_leaf, valid_proof);
+    let result = MerkleTreeImpl::<_,
+    PoseidonHasher>::verify(ref merkle_tree, root, invalid_leaf, valid_proof);
     assert(!result, 'wrong result');
 }

--- a/src/data_structures/src/tests/merkle_tree_test.cairo
+++ b/src/data_structures/src/tests/merkle_tree_test.cairo
@@ -1,7 +1,6 @@
 // Core lib imports
 use array::ArrayTrait;
 use hash::LegacyHash;
-use debug::PrintTrait;
 // Internal imports
 use alexandria_data_structures::merkle_tree::{MerkleTree, MerkleTreeLegacy, MerkleTreeTrait};
 

--- a/src/data_structures/src/tests/merkle_tree_test.cairo
+++ b/src/data_structures/src/tests/merkle_tree_test.cairo
@@ -1,20 +1,14 @@
-// Core lib imports
-use array::ArrayTrait;
-use hash::LegacyHash;
 // Internal imports
 use alexandria_data_structures::merkle_tree::{
-    Hasher, MerkleTree, pedersen::PedersenHasher, poseidon::PoseidonHasher, MerkleTreeTrait,
+    Hasher, MerkleTree, pedersen::PedersenHasherImpl, poseidon::PoseidonHasherImpl, MerkleTreeTrait,
     MerkleTreeImpl
 };
 
 
 mod regular_call_merkle_tree_pedersen {
-    // Core lib imports
-    use array::ArrayTrait;
-    use hash::LegacyHash;
     // Internal imports
     use alexandria_data_structures::merkle_tree::{
-        Hasher, MerkleTree, pedersen::PedersenHasher, MerkleTreeTrait,
+        Hasher, MerkleTree, pedersen::PedersenHasherImpl, MerkleTreeTrait,
     };
     #[test]
     #[available_gas(2000000)]
@@ -62,7 +56,7 @@ mod regular_call_merkle_tree_pedersen {
 #[available_gas(2000000)]
 fn merkle_tree_pedersen_test() {
     // [Setup] Merkle tree.
-    let mut merkle_tree: MerkleTree<Hasher> = MerkleTreeImpl::<_, PedersenHasher>::new();
+    let mut merkle_tree: MerkleTree<Hasher> = MerkleTreeImpl::<_, PedersenHasherImpl>::new();
     let root = 0x15ac9e457789ef0c56e5d559809e7336a909c14ee2511503fa7af69be1ba639;
     let leaf = 0x1;
     let valid_proof = array![0x2, 0x68ba2a188dd231112c1cb5aaa5d18be6d84f6c8683e5c3a6638dee83e727acc]
@@ -71,19 +65,19 @@ fn merkle_tree_pedersen_test() {
 
     // [Assert] Compute merkle root.
     let computed_root = MerkleTreeImpl::<_,
-    PedersenHasher>::compute_root(ref merkle_tree, leaf, valid_proof);
+    PedersenHasherImpl>::compute_root(ref merkle_tree, leaf, valid_proof);
     assert(computed_root == root, 'compute valid root failed');
 
     // [Assert] Compute merkle proof.
     let mut input_leaves = leaves;
     let index = 0;
     let computed_proof = MerkleTreeImpl::<_,
-    PedersenHasher>::compute_proof(ref merkle_tree, input_leaves, index);
+    PedersenHasherImpl>::compute_proof(ref merkle_tree, input_leaves, index);
     assert(computed_proof == valid_proof, 'compute valid proof failed');
 
     // [Assert] Verify a valid proof.
     let result = MerkleTreeImpl::<_,
-    PedersenHasher>::verify(ref merkle_tree, root, leaf, valid_proof);
+    PedersenHasherImpl>::verify(ref merkle_tree, root, leaf, valid_proof);
     assert(result, 'verify valid proof failed');
 
     // [Assert] Verify an invalid proof.
@@ -92,13 +86,13 @@ fn merkle_tree_pedersen_test() {
     ]
         .span();
     let result = MerkleTreeImpl::<_,
-    PedersenHasher>::verify(ref merkle_tree, root, leaf, invalid_proof);
+    PedersenHasherImpl>::verify(ref merkle_tree, root, leaf, invalid_proof);
     assert(!result, 'verify invalid proof failed');
 
     // [Assert] Verify a valid proof with an invalid leaf.
     let invalid_leaf = 0x1 + 1;
     let result = MerkleTreeImpl::<_,
-    PedersenHasher>::verify(ref merkle_tree, root, invalid_leaf, valid_proof);
+    PedersenHasherImpl>::verify(ref merkle_tree, root, invalid_leaf, valid_proof);
     assert(!result, 'wrong result');
 }
 
@@ -106,7 +100,7 @@ fn merkle_tree_pedersen_test() {
 #[available_gas(2000000)]
 fn merkle_tree_poseidon_test() {
     // [Setup] Merkle tree.
-    let mut merkle_tree: MerkleTree<Hasher> = MerkleTreeImpl::<_, PoseidonHasher>::new();
+    let mut merkle_tree: MerkleTree<Hasher> = MerkleTreeImpl::<_, PoseidonHasherImpl>::new();
     let root = 0x7abc09d19c8a03abd4333a23f7823975c7bdd325170f0d32612b8baa1457d47;
     let leaf = 0x1;
     let valid_proof = array![0x2, 0x47ef3ad11ad3f8fc055281f1721acd537563ec134036bc4bd4de2af151f0832]
@@ -115,19 +109,19 @@ fn merkle_tree_poseidon_test() {
 
     // [Assert] Compute merkle root.
     let computed_root = MerkleTreeImpl::<_,
-    PoseidonHasher>::compute_root(ref merkle_tree, leaf, valid_proof);
+    PoseidonHasherImpl>::compute_root(ref merkle_tree, leaf, valid_proof);
     assert(computed_root == root, 'compute valid root failed');
 
     // [Assert] Compute merkle proof.
     let mut input_leaves = leaves;
     let index = 0;
     let computed_proof = MerkleTreeImpl::<_,
-    PoseidonHasher>::compute_proof(ref merkle_tree, input_leaves, index);
+    PoseidonHasherImpl>::compute_proof(ref merkle_tree, input_leaves, index);
     assert(computed_proof == valid_proof, 'compute valid proof failed');
 
     // [Assert] Verify a valid proof.
     let result = MerkleTreeImpl::<_,
-    PoseidonHasher>::verify(ref merkle_tree, root, leaf, valid_proof);
+    PoseidonHasherImpl>::verify(ref merkle_tree, root, leaf, valid_proof);
     assert(result, 'verify valid proof failed');
 
     // [Assert] Verify an invalid proof.
@@ -136,12 +130,12 @@ fn merkle_tree_poseidon_test() {
     ]
         .span();
     let result = MerkleTreeImpl::<_,
-    PoseidonHasher>::verify(ref merkle_tree, root, leaf, invalid_proof);
+    PoseidonHasherImpl>::verify(ref merkle_tree, root, leaf, invalid_proof);
     assert(!result, 'verify invalid proof failed');
 
     // [Assert] Verify a valid proof with an invalid leaf.
     let invalid_leaf = 0x1 + 1;
     let result = MerkleTreeImpl::<_,
-    PoseidonHasher>::verify(ref merkle_tree, root, invalid_leaf, valid_proof);
+    PoseidonHasherImpl>::verify(ref merkle_tree, root, invalid_leaf, valid_proof);
     assert(!result, 'wrong result');
 }

--- a/src/data_structures/src/tests/merkle_tree_test.cairo
+++ b/src/data_structures/src/tests/merkle_tree_test.cairo
@@ -3,14 +3,13 @@ use array::ArrayTrait;
 use hash::LegacyHash;
 // Internal imports
 use alexandria_data_structures::merkle_tree::{
-    MerkleTree, PedersenHasher, PoseidonHasher, HasherTrait, MerkleTreeTrait
+    MerkleTree, PedersenHasher, PoseidonHasher, MerkleTreeTrait
 };
 
 #[test]
 #[available_gas(2000000)]
 fn merkle_tree_pedersen_test() {
     // [Setup] Merkle tree.
-    let hasher: PedersenHasher = HasherTrait::new();
     let mut merkle_tree: MerkleTree<PedersenHasher> = MerkleTreeTrait::new();
     let root = 0x15ac9e457789ef0c56e5d559809e7336a909c14ee2511503fa7af69be1ba639;
     let leaf = 0x1;
@@ -50,7 +49,6 @@ fn merkle_tree_pedersen_test() {
 #[available_gas(2000000)]
 fn merkle_tree_poseidon_test() {
     // [Setup] Merkle tree.
-    let hasher: PoseidonHasher = HasherTrait::new();
     let mut merkle_tree: MerkleTree<PoseidonHasher> = MerkleTreeTrait::new();
     let root = 0x7abc09d19c8a03abd4333a23f7823975c7bdd325170f0d32612b8baa1457d47;
     let leaf = 0x1;

--- a/src/data_structures/src/tests/merkle_tree_test.cairo
+++ b/src/data_structures/src/tests/merkle_tree_test.cairo
@@ -2,13 +2,14 @@
 use array::ArrayTrait;
 use hash::LegacyHash;
 // Internal imports
-use alexandria_data_structures::merkle_tree::{MerkleTree, MerkleTreeLegacy, MerkleTreeTrait};
+use alexandria_data_structures::merkle_tree::{MerkleTree, HashMethod, MerkleTreeTrait};
 
 #[test]
 #[available_gas(2000000)]
-fn merkle_tree_legacy_test() {
+fn merkle_tree_pedersen_test() {
     // [Setup] Merkle tree.
-    let mut merkle_tree: MerkleTreeLegacy = MerkleTreeTrait::new();
+    let hash_method = HashMethod::Pedersen(());
+    let mut merkle_tree: MerkleTree = MerkleTreeTrait::new(hash_method);
     let root = 0x15ac9e457789ef0c56e5d559809e7336a909c14ee2511503fa7af69be1ba639;
     let leaf = 0x1;
     let valid_proof = array![0x2, 0x68ba2a188dd231112c1cb5aaa5d18be6d84f6c8683e5c3a6638dee83e727acc]
@@ -45,9 +46,10 @@ fn merkle_tree_legacy_test() {
 
 #[test]
 #[available_gas(2000000)]
-fn merkle_tree_test() {
+fn merkle_tree_poseidon_test() {
     // [Setup] Merkle tree.
-    let mut merkle_tree: MerkleTree = MerkleTreeTrait::new();
+    let hash_method = HashMethod::Poseidon(());
+    let mut merkle_tree: MerkleTree = MerkleTreeTrait::new(hash_method);
     let root = 0x7abc09d19c8a03abd4333a23f7823975c7bdd325170f0d32612b8baa1457d47;
     let leaf = 0x1;
     let valid_proof = array![0x2, 0x47ef3ad11ad3f8fc055281f1721acd537563ec134036bc4bd4de2af151f0832]

--- a/src/data_structures/src/tests/merkle_tree_test.cairo
+++ b/src/data_structures/src/tests/merkle_tree_test.cairo
@@ -1,74 +1,84 @@
 // Core lib imports
 use array::ArrayTrait;
 use hash::LegacyHash;
+use debug::PrintTrait;
 // Internal imports
-use alexandria_data_structures::merkle_tree::{MerkleTree, MerkleTreeTrait};
+use alexandria_data_structures::merkle_tree::{MerkleTree, MerkleTreeLegacy, MerkleTreeTrait};
+
+#[test]
+#[available_gas(2000000)]
+fn merkle_tree_legacy_test() {
+    // [Setup] Merkle tree.
+    let mut merkle_tree: MerkleTreeLegacy = MerkleTreeTrait::new();
+    let root = 0x15ac9e457789ef0c56e5d559809e7336a909c14ee2511503fa7af69be1ba639;
+    let leaf = 0x1;
+    let valid_proof = array![0x2, 0x68ba2a188dd231112c1cb5aaa5d18be6d84f6c8683e5c3a6638dee83e727acc]
+        .span();
+    let leaves = array![0x1, 0x2, 0x3];
+
+    // [Assert] Compute merkle root.
+    let computed_root = merkle_tree.compute_root(leaf, valid_proof);
+    assert(computed_root == root, 'compute valid root failed');
+
+    // [Assert] Compute merkle proof.
+    let mut input_leaves = leaves;
+    let index = 0;
+    let computed_proof = merkle_tree.compute_proof(input_leaves, index);
+    assert(computed_proof == valid_proof, 'compute valid proof failed');
+
+    // [Assert] Verify a valid proof.
+    let result = merkle_tree.verify(root, leaf, valid_proof);
+    assert(result, 'verify valid proof failed');
+
+    // [Assert] Verify an invalid proof.
+    let invalid_proof = array![
+        0x2 + 1, 0x68ba2a188dd231112c1cb5aaa5d18be6d84f6c8683e5c3a6638dee83e727acc
+    ]
+        .span();
+    let result = merkle_tree.verify(root, leaf, invalid_proof);
+    assert(!result, 'verify invalid proof failed');
+
+    // [Assert] Verify a valid proof with an invalid leaf.
+    let invalid_leaf = 0x1 + 1;
+    let result = merkle_tree.verify(root, invalid_leaf, valid_proof);
+    assert(!result, 'wrong result');
+}
 
 #[test]
 #[available_gas(2000000)]
 fn merkle_tree_test() {
-    let mut merkle_tree = MerkleTreeTrait::new();
-    // Create a proof.
-    let proof = generate_proof_2_elements(
-        275015828570532818958877094293872118179858708489648969448465143543997518327,
-        3081470326846576744486900207655708080595997326743041181982939514729891127832
-    );
+    // [Setup] Merkle tree.
+    let mut merkle_tree: MerkleTree = MerkleTreeTrait::new();
+    let root = 0x7abc09d19c8a03abd4333a23f7823975c7bdd325170f0d32612b8baa1457d47;
+    let leaf = 0x1;
+    let valid_proof = array![0x2, 0x47ef3ad11ad3f8fc055281f1721acd537563ec134036bc4bd4de2af151f0832]
+        .span();
+    let leaves = array![0x1, 0x2, 0x3];
 
-    let leaf = 1743721452664603547538108163491160873761573033120794192633007665066782417603;
-    let expected_merkle_root =
-        455571898402516024591265345720711356365422160584912150000578530706912124657;
-    test_case_compute_root(ref merkle_tree, proof, leaf, expected_merkle_root);
+    // [Assert] Compute merkle root.
+    let computed_root = merkle_tree.compute_root(leaf, valid_proof);
+    assert(computed_root == root, 'compute valid root failed');
 
-    // Create a valid proof.
-    let mut valid_proof = generate_proof_2_elements(
-        275015828570532818958877094293872118179858708489648969448465143543997518327,
-        3081470326846576744486900207655708080595997326743041181982939514729891127832
-    );
-    // Verify the proof is valid.
-    test_case_verify(ref merkle_tree, expected_merkle_root, leaf, valid_proof, true);
+    // [Assert] Compute merkle proof.
+    let mut input_leaves = leaves;
+    let index = 0;
+    let computed_proof = merkle_tree.compute_proof(input_leaves, index);
+    assert(computed_proof == valid_proof, 'compute valid proof failed');
 
-    // Create an invalid proof.
-    let invalid_proof = generate_proof_2_elements(
-        275015828570532818958877094293872118179858708489648969448465143543997518327 + 1,
-        3081470326846576744486900207655708080595997326743041181982939514729891127832
-    );
-    // Verify the proof is invalid.
-    test_case_verify(ref merkle_tree, expected_merkle_root, leaf, invalid_proof, false);
+    // [Assert] Verify a valid proof.
+    let result = merkle_tree.verify(root, leaf, valid_proof);
+    assert(result, 'verify valid proof failed');
 
-    // Create a valid proof but we will pass a wrong leaf.
-    let valid_proof = generate_proof_2_elements(
-        275015828570532818958877094293872118179858708489648969448465143543997518327,
-        3081470326846576744486900207655708080595997326743041181982939514729891127832
-    );
-    // Verify the proof is invalid when passed the wrong leaf to verify.
-    test_case_verify(
-        ref merkle_tree,
-        expected_merkle_root,
-        1743721452664603547538108163491160873761573033120794192633007665066782417603 + 1,
-        valid_proof,
-        false
-    );
-}
+    // [Assert] Verify an invalid proof.
+    let invalid_proof = array![
+        0x2 + 1, 0x68ba2a188dd231112c1cb5aaa5d18be6d84f6c8683e5c3a6638dee83e727acc
+    ]
+        .span();
+    let result = merkle_tree.verify(root, leaf, invalid_proof);
+    assert(!result, 'verify invalid proof failed');
 
-fn test_case_compute_root(
-    ref merkle_tree: MerkleTree, proof: Array<felt252>, leaf: felt252, expected_root: felt252
-) {
-    let mut merkle_tree = MerkleTreeTrait::new();
-    let root = merkle_tree.compute_root(leaf, proof.span());
-    assert(root == expected_root, 'wrong result');
-}
-
-fn test_case_verify(
-    ref merkle_tree: MerkleTree,
-    root: felt252,
-    leaf: felt252,
-    proof: Array<felt252>,
-    expected_result: bool
-) {
-    let result = merkle_tree.verify(root, leaf, proof.span());
-    assert(result == expected_result, 'wrong result');
-}
-
-fn generate_proof_2_elements(element_1: felt252, element_2: felt252) -> Array<felt252> {
-    array![element_1, element_2]
+    // [Assert] Verify a valid proof with an invalid leaf.
+    let invalid_leaf = 0x1 + 1;
+    let result = merkle_tree.verify(root, invalid_leaf, valid_proof);
+    assert(!result, 'wrong result');
 }

--- a/src/data_structures/src/tests/merkle_tree_test.cairo
+++ b/src/data_structures/src/tests/merkle_tree_test.cairo
@@ -2,14 +2,16 @@
 use array::ArrayTrait;
 use hash::LegacyHash;
 // Internal imports
-use alexandria_data_structures::merkle_tree::{MerkleTree, HashMethod, MerkleTreeTrait};
+use alexandria_data_structures::merkle_tree::{
+    MerkleTree, PedersenHasher, PoseidonHasher, MerkleTreeTrait
+};
 
 #[test]
 #[available_gas(2000000)]
 fn merkle_tree_pedersen_test() {
     // [Setup] Merkle tree.
-    let hash_method = HashMethod::Pedersen;
-    let mut merkle_tree: MerkleTree = MerkleTreeTrait::new(hash_method);
+    let hasher: PedersenHasher = PedersenHasher {};
+    let mut merkle_tree: MerkleTree<PedersenHasher> = MerkleTreeTrait::new();
     let root = 0x15ac9e457789ef0c56e5d559809e7336a909c14ee2511503fa7af69be1ba639;
     let leaf = 0x1;
     let valid_proof = array![0x2, 0x68ba2a188dd231112c1cb5aaa5d18be6d84f6c8683e5c3a6638dee83e727acc]
@@ -48,8 +50,8 @@ fn merkle_tree_pedersen_test() {
 #[available_gas(2000000)]
 fn merkle_tree_poseidon_test() {
     // [Setup] Merkle tree.
-    let hash_method = HashMethod::Poseidon;
-    let mut merkle_tree: MerkleTree = MerkleTreeTrait::new(hash_method);
+    let hasher: PoseidonHasher = PoseidonHasher {};
+    let mut merkle_tree: MerkleTree<PoseidonHasher> = MerkleTreeTrait::new();
     let root = 0x7abc09d19c8a03abd4333a23f7823975c7bdd325170f0d32612b8baa1457d47;
     let leaf = 0x1;
     let valid_proof = array![0x2, 0x47ef3ad11ad3f8fc055281f1721acd537563ec134036bc4bd4de2af151f0832]

--- a/src/data_structures/src/tests/merkle_tree_test.cairo
+++ b/src/data_structures/src/tests/merkle_tree_test.cairo
@@ -3,14 +3,14 @@ use array::ArrayTrait;
 use hash::LegacyHash;
 // Internal imports
 use alexandria_data_structures::merkle_tree::{
-    MerkleTree, PedersenHasher, PoseidonHasher, MerkleTreeTrait
+    MerkleTree, PedersenHasher, PoseidonHasher, HasherTrait, MerkleTreeTrait
 };
 
 #[test]
 #[available_gas(2000000)]
 fn merkle_tree_pedersen_test() {
     // [Setup] Merkle tree.
-    let hasher: PedersenHasher = PedersenHasher {};
+    let hasher: PedersenHasher = HasherTrait::new();
     let mut merkle_tree: MerkleTree<PedersenHasher> = MerkleTreeTrait::new();
     let root = 0x15ac9e457789ef0c56e5d559809e7336a909c14ee2511503fa7af69be1ba639;
     let leaf = 0x1;
@@ -50,7 +50,7 @@ fn merkle_tree_pedersen_test() {
 #[available_gas(2000000)]
 fn merkle_tree_poseidon_test() {
     // [Setup] Merkle tree.
-    let hasher: PoseidonHasher = PoseidonHasher {};
+    let hasher: PoseidonHasher = HasherTrait::new();
     let mut merkle_tree: MerkleTree<PoseidonHasher> = MerkleTreeTrait::new();
     let root = 0x7abc09d19c8a03abd4333a23f7823975c7bdd325170f0d32612b8baa1457d47;
     let leaf = 0x1;

--- a/src/data_structures/src/tests/merkle_tree_test.cairo
+++ b/src/data_structures/src/tests/merkle_tree_test.cairo
@@ -8,7 +8,7 @@ use alexandria_data_structures::merkle_tree::{MerkleTree, HashMethod, MerkleTree
 #[available_gas(2000000)]
 fn merkle_tree_pedersen_test() {
     // [Setup] Merkle tree.
-    let hash_method = HashMethod::Pedersen(());
+    let hash_method = HashMethod::Pedersen;
     let mut merkle_tree: MerkleTree = MerkleTreeTrait::new(hash_method);
     let root = 0x15ac9e457789ef0c56e5d559809e7336a909c14ee2511503fa7af69be1ba639;
     let leaf = 0x1;
@@ -48,7 +48,7 @@ fn merkle_tree_pedersen_test() {
 #[available_gas(2000000)]
 fn merkle_tree_poseidon_test() {
     // [Setup] Merkle tree.
-    let hash_method = HashMethod::Poseidon(());
+    let hash_method = HashMethod::Poseidon;
     let mut merkle_tree: MerkleTree = MerkleTreeTrait::new(hash_method);
     let root = 0x7abc09d19c8a03abd4333a23f7823975c7bdd325170f0d32612b8baa1457d47;
     let leaf = 0x1;


### PR DESCRIPTION
- [x] Add poseidon version of the merkle tree
- [x] Add proof computation
- [x] Clean and add corresponding tests

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #169  
Issue Number: #170 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- A new implementation of the MerkleTree using poseidon hash method
- Add a `compute_proof` method to the MerkleTreeTrait to generate a proof based on leaves and an index
- Rename the previous merkle tree type from MerkleTree to MerkleTreeLegacy
- Merkle tree tests refactoring to clarify tests and add tests according to the new feature

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

Before the change you could just have:

```cairo
use alexandria_data_structures::merkle_tree::MerkleTreeTrait;
let mut merkle_tree = MerkleTreeTrait::new();
```

Now you must specify which kind of merkle tree you want (the legacy version or the new one):

```cairo
// The new version, using the poseidon hash method
use alexandria_data_structures::merkle_tree::{MerkleTree, HashMethod, MerkleTreeTrait};
let hash_method = HashMethod::Poseidon(());
let mut merkle_tree = MerkleTreeTrait::new(hash_method);
```

```cairo
// The legacy version, using the pedersen hash method
use alexandria_data_structures::merkle_tree::{MerkleTree, HashMethod, MerkleTreeTrait};
let hash_method = HashMethod::Poseidon(());
let mut merkle_tree = MerkleTreeTrait::new(hash_method);
```

## Other information

Work load: ~ 8 hours
