### PR TITLE
feat: unique for arrays

### DIFF
--- a/src/data_structures/src/array_ext.cairo
+++ b/src/data_structures/src/array_ext.cairo
@@ -395,14 +395,9 @@ impl SpanImpl<T, impl TCopy: Copy<T>, impl TDrop: Drop<T>> of SpanTraitExt<T> {
     fn unique<impl TPartialEq: PartialEq<T>>(mut self: Span<T>) -> Array<T> {
         let mut ret = array![];
         loop {
-            let shortest: Span<T> = if (self.len() <= 1) || (ret.len() <= self.len()) {
-                ret.span()
-            } else {
-                self
-            };
             match self.pop_front() {
                 Option::Some(v) => {
-                    if !shortest.contains(*v) {
+                    if !ret.contains(*v) {
                         ret.append(*v);
                     }
                 },

--- a/src/data_structures/src/array_ext.cairo
+++ b/src/data_structures/src/array_ext.cairo
@@ -22,7 +22,7 @@ trait ArrayTraitExt<T> {
         self: @Array<T>
     ) -> Option<usize>;
     fn dedup<impl TPartialEq: PartialEq<T>>(self: @Array<T>) -> Array<T>;
-    fn drop_duplicates<impl TPartialEq: PartialEq<T>>(self: @Array<T>) -> Array<T>;
+    fn unique<impl TPartialEq: PartialEq<T>>(self: @Array<T>) -> Array<T>;
 }
 
 trait SpanTraitExt<T> {
@@ -46,7 +46,7 @@ trait SpanTraitExt<T> {
         self: Span<T>
     ) -> Option<usize>;
     fn dedup<impl TPartialEq: PartialEq<T>>(self: Span<T>) -> Array<T>;
-    fn drop_duplicates<impl TPartialEq: PartialEq<T>>(self: Span<T>) -> Array<T>;
+    fn unique<impl TPartialEq: PartialEq<T>>(self: Span<T>) -> Array<T>;
 }
 
 impl ArrayImpl<T, impl TCopy: Copy<T>, impl TDrop: Drop<T>> of ArrayTraitExt<T> {
@@ -144,8 +144,8 @@ impl ArrayImpl<T, impl TCopy: Copy<T>, impl TDrop: Drop<T>> of ArrayTraitExt<T> 
         self.span().dedup()
     }
 
-    fn drop_duplicates<impl TPartialEq: PartialEq<T>>(mut self: @Array<T>) -> Array<T> {
-        self.span().drop_duplicates()
+    fn unique<impl TPartialEq: PartialEq<T>>(mut self: @Array<T>) -> Array<T> {
+        self.span().unique()
     }
 }
 
@@ -392,7 +392,7 @@ impl SpanImpl<T, impl TCopy: Copy<T>, impl TDrop: Drop<T>> of SpanTraitExt<T> {
         ret
     }
 
-    fn drop_duplicates<impl TPartialEq: PartialEq<T>>(mut self: Span<T>) -> Array<T> {
+    fn unique<impl TPartialEq: PartialEq<T>>(mut self: Span<T>) -> Array<T> {
         let mut ret = array![];
         loop {
             let shortest: Span<T> = if (self.len() <= 1) || (ret.len() <= self.len()) {

--- a/src/data_structures/src/array_ext.cairo
+++ b/src/data_structures/src/array_ext.cairo
@@ -395,13 +395,13 @@ impl SpanImpl<T, impl TCopy: Copy<T>, impl TDrop: Drop<T>> of SpanTraitExt<T> {
     fn drop_duplicates<impl TPartialEq: PartialEq<T>>(mut self: Span<T>) -> Array<T> {
         let mut ret = array![];
         loop {
+            let shortest: Span<T> = if (self.len() <= 1) || (ret.len() <= self.len()) {
+                ret.span()
+            } else {
+                self
+            };
             match self.pop_front() {
                 Option::Some(v) => {
-                    let shortest: Span<T> = if (self.len() <= 1) || (ret.len() <= self.len()) {
-                        ret.span()
-                    } else {
-                        self
-                    };
                     if !shortest.contains(*v) {
                         ret.append(*v);
                     }

--- a/src/data_structures/src/array_ext.cairo
+++ b/src/data_structures/src/array_ext.cairo
@@ -22,6 +22,7 @@ trait ArrayTraitExt<T> {
         self: @Array<T>
     ) -> Option<usize>;
     fn dedup<impl TPartialEq: PartialEq<T>>(self: @Array<T>) -> Array<T>;
+    fn drop_duplicates<impl TPartialEq: PartialEq<T>>(self: @Array<T>) -> Array<T>;
 }
 
 trait SpanTraitExt<T> {
@@ -45,6 +46,7 @@ trait SpanTraitExt<T> {
         self: Span<T>
     ) -> Option<usize>;
     fn dedup<impl TPartialEq: PartialEq<T>>(self: Span<T>) -> Array<T>;
+    fn drop_duplicates<impl TPartialEq: PartialEq<T>>(self: Span<T>) -> Array<T>;
 }
 
 impl ArrayImpl<T, impl TCopy: Copy<T>, impl TDrop: Drop<T>> of ArrayTraitExt<T> {
@@ -140,6 +142,10 @@ impl ArrayImpl<T, impl TCopy: Copy<T>, impl TDrop: Drop<T>> of ArrayTraitExt<T> 
 
     fn dedup<impl TPartialEq: PartialEq<T>>(mut self: @Array<T>) -> Array<T> {
         self.span().dedup()
+    }
+
+    fn drop_duplicates<impl TPartialEq: PartialEq<T>>(mut self: @Array<T>) -> Array<T> {
+        self.span().drop_duplicates()
     }
 }
 
@@ -383,6 +389,28 @@ impl SpanImpl<T, impl TCopy: Copy<T>, impl TDrop: Drop<T>> of SpanTraitExt<T> {
             };
         };
 
+        ret
+    }
+
+    fn drop_duplicates<impl TPartialEq: PartialEq<T>>(mut self: Span<T>) -> Array<T> {
+        let mut ret = array![];
+        loop {
+            match self.pop_front() {
+                Option::Some(v) => {
+                    let shortest: Span<T> = if (self.len() <= 1) || (ret.len() <= self.len()) {
+                        ret.span()
+                    } else {
+                        self
+                    };
+                    if !shortest.contains(*v) {
+                        ret.append(*v);
+                    }
+                },
+                Option::None => {
+                    break;
+                }
+            };
+        };
         ret
     }
 }

--- a/src/data_structures/src/tests/array_ext_test.cairo
+++ b/src/data_structures/src/tests/array_ext_test.cairo
@@ -1067,13 +1067,13 @@ fn index_of_max_last_span() {
     assert(arr.len() == 3, 'arr should not be consummed');
 }
 
-// drop_duplicates
+// unique
 
 #[test]
 #[available_gas(2000000)]
-fn drop_duplicates() {
+fn unique() {
     let mut arr = array![32_u128, 256_u128, 128_u128, 256_u128, 1024_u128];
-    let mut out_arr = arr.drop_duplicates();
+    let mut out_arr = arr.unique();
     assert(out_arr.len() == 4, 'Duplicates should be dropped');
     assert(*out_arr[0] == 32_u128, 'Should be 32');
     assert(*out_arr[1] == 256_u128, 'Should be 256');
@@ -1083,26 +1083,26 @@ fn drop_duplicates() {
 
 #[test]
 #[available_gas(2000000)]
-fn drop_duplicates_all() {
+fn unique_all() {
     let mut arr = array![84_u128, 84_u128, 84_u128];
-    let mut out_arr = arr.drop_duplicates();
+    let mut out_arr = arr.unique();
     assert(out_arr.len() == 1, 'Duplicates should be dropped');
     assert(*out_arr[0] == 84_u128, 'Should be 128');
 }
 
 #[test]
 #[available_gas(2000000)]
-fn drop_duplicates_none() {
+fn unique_none() {
     let mut arr: Array<u128> = array![];
-    let mut out_arr = arr.drop_duplicates();
+    let mut out_arr = arr.unique();
     assert(out_arr.len() == 0, 'out_arr should be empty');
 }
 
 #[test]
 #[available_gas(2000000)]
-fn drop_duplicates_at_start() {
+fn unique_at_start() {
     let mut arr = array![16_u128, 16_u128, 16_u128, 128_u128, 64_u128, 32_u128];
-    let mut out_arr = arr.drop_duplicates();
+    let mut out_arr = arr.unique();
     assert(out_arr.len() == 4, 'Duplicates should be dropped');
     assert(*out_arr[0] == 16_u128, 'Should be 16');
     assert(*out_arr[1] == 128_u128, 'Should be 128');
@@ -1112,9 +1112,9 @@ fn drop_duplicates_at_start() {
 
 #[test]
 #[available_gas(2000000)]
-fn drop_duplicates_at_middle() {
+fn unique_at_middle() {
     let mut arr = array![128_u128, 256_u128, 84_u128, 84_u128, 84_u128, 1_u128];
-    let mut out_arr = arr.drop_duplicates();
+    let mut out_arr = arr.unique();
     assert(out_arr.len() == 4, 'Duplicates should be dropped');
     assert(*out_arr[0] == 128_u128, 'Should be 128');
     assert(*out_arr[1] == 256_u128, 'Should be 256');
@@ -1124,9 +1124,9 @@ fn drop_duplicates_at_middle() {
 
 #[test]
 #[available_gas(2000000)]
-fn drop_duplicates_at_end() {
+fn unique_at_end() {
     let mut arr = array![32_u128, 16_u128, 64_u128, 128_u128, 128_u128, 128_u128];
-    let mut out_arr = arr.drop_duplicates();
+    let mut out_arr = arr.unique();
     assert(out_arr.len() == 4, 'Duplicates should be dropped');
     assert(*out_arr[0] == 32_u128, 'Should be 32');
     assert(*out_arr[1] == 16_u128, 'Should be 16');
@@ -1136,15 +1136,14 @@ fn drop_duplicates_at_end() {
 
 #[test]
 #[available_gas(2000000)]
-fn drop_duplicates_without_duplicates() {
+fn unique_without_duplicates() {
     let mut arr = array![42_u128, 84_u128, 21_u128];
-    let mut out_arr = arr.drop_duplicates();
+    let mut out_arr = arr.unique();
     assert(out_arr.len() == 3, 'No values should drop');
     assert(*out_arr[0] == 42_u128, 'Should be 42');
     assert(*out_arr[1] == 84_u128, 'Should be 84');
     assert(*out_arr[2] == 21_u128, 'Should be 21');
 }
-
 
 // Utility fn
 

--- a/src/data_structures/src/tests/array_ext_test.cairo
+++ b/src/data_structures/src/tests/array_ext_test.cairo
@@ -1092,19 +1092,15 @@ fn drop_duplicates_all() {
 
 #[test]
 #[available_gas(2000000)]
-fn drop_duplicates_middle() {
-    let mut arr = array![128_u128, 256_u128, 84_u128, 84_u128, 84_u128, 1_u128];
+fn drop_duplicates_none() {
+    let mut arr: Array<u128> = array![];
     let mut out_arr = arr.drop_duplicates();
-    assert(out_arr.len() == 4, 'Duplicates should be dropped');
-    assert(*out_arr[0] == 128_u128, 'Should be 128');
-    assert(*out_arr[1] == 256_u128, 'Should be 256');
-    assert(*out_arr[2] == 84_u128, 'Should be 84');
-    assert(*out_arr[3] == 1_u128, 'Should be 1');
+    assert(out_arr.len() == 0, 'out_arr should be empty');
 }
 
 #[test]
 #[available_gas(2000000)]
-fn drop_duplicates_start() {
+fn drop_duplicates_at_start() {
     let mut arr = array![16_u128, 16_u128, 16_u128, 128_u128, 64_u128, 32_u128];
     let mut out_arr = arr.drop_duplicates();
     assert(out_arr.len() == 4, 'Duplicates should be dropped');
@@ -1116,7 +1112,19 @@ fn drop_duplicates_start() {
 
 #[test]
 #[available_gas(2000000)]
-fn drop_duplicates_end() {
+fn drop_duplicates_at_middle() {
+    let mut arr = array![128_u128, 256_u128, 84_u128, 84_u128, 84_u128, 1_u128];
+    let mut out_arr = arr.drop_duplicates();
+    assert(out_arr.len() == 4, 'Duplicates should be dropped');
+    assert(*out_arr[0] == 128_u128, 'Should be 128');
+    assert(*out_arr[1] == 256_u128, 'Should be 256');
+    assert(*out_arr[2] == 84_u128, 'Should be 84');
+    assert(*out_arr[3] == 1_u128, 'Should be 1');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn drop_duplicates_at_end() {
     let mut arr = array![32_u128, 16_u128, 64_u128, 128_u128, 128_u128, 128_u128];
     let mut out_arr = arr.drop_duplicates();
     assert(out_arr.len() == 4, 'Duplicates should be dropped');
@@ -1135,14 +1143,6 @@ fn drop_duplicates_without_duplicates() {
     assert(*out_arr[0] == 42_u128, 'Should be 42');
     assert(*out_arr[1] == 84_u128, 'Should be 84');
     assert(*out_arr[2] == 21_u128, 'Should be 21');
-}
-
-#[test]
-#[available_gas(2000000)]
-fn drop_duplicates_empty() {
-    let mut arr: Array<u128> = array![];
-    let mut out_arr = arr.drop_duplicates();
-    assert(out_arr.len() == 0, 'out_arr should be empty');
 }
 
 

--- a/src/data_structures/src/tests/array_ext_test.cairo
+++ b/src/data_structures/src/tests/array_ext_test.cairo
@@ -1,6 +1,5 @@
 use core::option::OptionTrait;
 use array::{ArrayTrait, SpanTrait};
-
 use alexandria_data_structures::array_ext::{ArrayTraitExt, SpanTraitExt};
 
 // dedup
@@ -1066,6 +1065,84 @@ fn index_of_max_last_span() {
     let mut arr = array![84_u128, 42_u128, 21_u128];
     assert(arr.span().index_of_max().unwrap() == 0, 'index_of_max should be 0');
     assert(arr.len() == 3, 'arr should not be consummed');
+}
+
+// drop_duplicates
+
+#[test]
+#[available_gas(2000000)]
+fn drop_duplicates() {
+    let mut arr = array![32_u128, 256_u128, 128_u128, 256_u128, 1024_u128];
+    let mut out_arr = arr.drop_duplicates();
+    assert(out_arr.len() == 4, 'Duplicates should be dropped');
+    assert(*out_arr[0] == 32_u128, 'Should be 32');
+    assert(*out_arr[1] == 256_u128, 'Should be 256');
+    assert(*out_arr[2] == 128_u128, 'Should be 128');
+    assert(*out_arr[3] == 1024_u128, 'Should be 1024');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn drop_duplicates_all() {
+    let mut arr = array![84_u128, 84_u128, 84_u128];
+    let mut out_arr = arr.drop_duplicates();
+    assert(out_arr.len() == 1, 'Duplicates should be dropped');
+    assert(*out_arr[0] == 84_u128, 'Should be 128');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn drop_duplicates_middle() {
+    let mut arr = array![128_u128, 256_u128, 84_u128, 84_u128, 84_u128, 1_u128];
+    let mut out_arr = arr.drop_duplicates();
+    assert(out_arr.len() == 4, 'Duplicates should be dropped');
+    assert(*out_arr[0] == 128_u128, 'Should be 128');
+    assert(*out_arr[1] == 256_u128, 'Should be 256');
+    assert(*out_arr[2] == 84_u128, 'Should be 84');
+    assert(*out_arr[3] == 1_u128, 'Should be 1');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn drop_duplicates_start() {
+    let mut arr = array![16_u128, 16_u128, 16_u128, 128_u128, 64_u128, 32_u128];
+    let mut out_arr = arr.drop_duplicates();
+    assert(out_arr.len() == 4, 'Duplicates should be dropped');
+    assert(*out_arr[0] == 16_u128, 'Should be 16');
+    assert(*out_arr[1] == 128_u128, 'Should be 128');
+    assert(*out_arr[2] == 64_u128, 'Should be 64');
+    assert(*out_arr[3] == 32_u128, 'Should be 32');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn drop_duplicates_end() {
+    let mut arr = array![32_u128, 16_u128, 64_u128, 128_u128, 128_u128, 128_u128];
+    let mut out_arr = arr.drop_duplicates();
+    assert(out_arr.len() == 4, 'Duplicates should be dropped');
+    assert(*out_arr[0] == 32_u128, 'Should be 32');
+    assert(*out_arr[1] == 16_u128, 'Should be 16');
+    assert(*out_arr[2] == 64_u128, 'Should be 64');
+    assert(*out_arr[3] == 128_u128, 'Should be 128');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn drop_duplicates_without_duplicates() {
+    let mut arr = array![42_u128, 84_u128, 21_u128];
+    let mut out_arr = arr.drop_duplicates();
+    assert(out_arr.len() == 3, 'No values should drop');
+    assert(*out_arr[0] == 42_u128, 'Should be 42');
+    assert(*out_arr[1] == 84_u128, 'Should be 84');
+    assert(*out_arr[2] == 21_u128, 'Should be 21');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn drop_duplicates_empty() {
+    let mut arr: Array<u128> = array![];
+    let mut out_arr = arr.drop_duplicates();
+    assert(out_arr.len() == 0, 'out_arr should be empty');
 }
 
 


### PR DESCRIPTION
## Pull Request type

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Issue number [#172 ](https://github.com/keep-starknet-strange/alexandria/issues/172)

## What is the new behavior?

- Added the `unique` methods for `SpanTraitExt` & `ArrayTraitExt`,
- Added the corresponding unit tests.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

For this little snippet:
```rust
let shortest: Span<T> = if (self.len() <= 1) || (ret.len() <= self.len()) {
    ret.span()
} else {
    self
};
```

Without the `self.len() <= 1` member some of my tests were failing.
Tried multiple things but couldn't find any better even though I feel like there's a more optimized solution... Curious to have your inputs! 🙏