### PR TITLE
Feat: Add solidity like bytes which supports keccak and sha256

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ This repository is composed of multiple crates:
 - [Searching](./src/searching/README.md)
 - [Sorting](./src/sorting/README.md)
 - [Storage](./src/storage/README.md)
+- [Bytes](./src/bytes/README.md)
 
 ## Getting Started
 

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -8,7 +8,8 @@ members = [
     "src/searching",
     "src/sorting",
     "src/storage",
-    "src/ascii"
+    "src/ascii",
+    "src/bytes"
 ]
 name = "alexandria"
 version = "0.1.0"

--- a/src/bytes/README.md
+++ b/src/bytes/README.md
@@ -1,0 +1,39 @@
+# bytes
+
+**bytes** is an implementation similar to Solidity bytes written in Cairo 1 by [zkLink](https://zk.link/). It is notable for its built-in implementation of `Keccak` and `Sha256` hash functions, offering convenience for migrating EVM Contracts written in Solidity to the Starknet ecosystem.
+
+## Example
+
+**bytes** implements read and write operations for all Cairo built-in types, as well as `keccak/sha256` operations. For example, in Solidity, if there is a `Token` type, and we want to calculate the keccak256 hash of an instance of this structure.
+
+```solidity
+struct Token {
+    uint16 tokenId;
+    address tokenAddress;
+    uint8 decimals;
+}
+```
+
+In Solidity, we can achieve this by doing the following:
+
+```solidity
+keccak256(abi.encodePacked(tokenId, tokenAddress, decimals));
+```
+
+In Cairo, we can effortlessly achieve the same using `Bytes`:
+
+```rust
+use alexandria_bytes::Bytes;
+use alexandria_bytes::BytesTrait;
+use debug::PrintTrait;
+use starknet::contract_address_const;
+
+fn main() {
+    let mut bytes: Bytes = BytesTrait::new(0, array![]);
+    bytes.append_u16(1);
+    bytes.append_address(contract_address_const::<0x123>());
+    bytes.append_u8(16);
+    let keccak_hash = bytes.keccak();
+    keccak_hash.print();
+}
+```

--- a/src/bytes/Scarb.toml
+++ b/src/bytes/Scarb.toml
@@ -1,0 +1,9 @@
+[package]
+name = "alexandria_bytes"
+version = "0.1.0"
+description = "An implementation similar to Solidity bytes written in Cairo 1"
+homepage = "https://github.com/keep-starknet-strange/alexandria/tree/main/src/bytes"
+
+[dependencies]
+alexandria_math = { path = "../math" }
+alexandria_data_structures = { path = "../data_structures" }

--- a/src/bytes/src/bytes.cairo
+++ b/src/bytes/src/bytes.cairo
@@ -1,0 +1,507 @@
+use clone::Clone;
+use array::ArrayTrait;
+use traits::Into;
+use traits::TryInto;
+use traits::DivRem;
+use option::OptionTrait;
+use starknet::{ContractAddress, Felt252TryIntoContractAddress};
+use alexandria_math::sha256::sha256;
+use alexandria_bytes::utils::{
+    u128_join, u128_sub_value, u128_split, u128_array_slice, keccak_u128s_be, u8_array_to_u256
+};
+
+// Bytes is a dynamic array of u128, where each element contains 16 bytes.
+const BYTES_PER_ELEMENT: usize = 16;
+
+// Note that:   In Bytes, there are many variables about size and length.
+//              We use size to represent the number of bytes in Bytes.
+//              We use length to represent the number of elements in Bytes.
+
+// Bytes is a cairo implementation of solidity Bytes in Big-endian.
+// It is a dynamic array of u128, where each element contains 16 bytes.
+// To save cost, the last element MUST be filled fully.
+// That's means that every element should and MUST contains 16 bytes.
+// For example, if we have a Bytes with 33 bytes, we will have 3 elements.
+// Theroetically, the bytes looks like this:
+//      first element:  [16 bytes]
+//      second element: [16 bytes]
+//      third element:  [1 byte]
+// But in zkLink Bytes, the last element should be padded with zero to make
+// it 16 bytes. So the zkLink bytes looks like this:
+//      first element:  [16 bytes]
+//      second element: [16 bytes]
+//      third element:  [1 byte] + [15 bytes zero padding]
+
+// Bytes is a dynamic array of u128, where each element contains 16 bytes.
+//  - size: the number of bytes in the Bytes
+//  - data: the data of the Bytes
+#[derive(Drop, Clone, PartialEq, Serde)]
+struct Bytes {
+    size: usize,
+    data: Array<u128>
+}
+
+trait BytesTrait {
+    // Create a Bytes from an array of u128
+    fn new(size: usize, data: Array::<u128>) -> Bytes;
+    // Create a Bytes with size bytes 0
+    fn zero(size: usize) -> Bytes;
+    // Locate offset in Bytes
+    fn locate(offset: usize) -> (usize, usize);
+    // Get Bytes size
+    fn size(self: @Bytes) -> usize;
+    // update specific value (1 bytes) at specific offset
+    fn update(ref self: Bytes, offset: usize, value: u8);
+    // Read value with size bytes from Bytes, and packed into u128
+    fn read_u128_packed(self: @Bytes, offset: usize, size: usize) -> (usize, u128);
+    // Read value with element_size bytes from Bytes, and packed into u128 array
+    fn read_u128_array_packed(
+        self: @Bytes, offset: usize, array_length: usize, element_size: usize
+    ) -> (usize, Array<u128>);
+    // Read value with size bytes from Bytes, and packed into felt252
+    fn read_felt252_packed(self: @Bytes, offset: usize, size: usize) -> (usize, felt252);
+    // Read a u8 from Bytes
+    fn read_u8(self: @Bytes, offset: usize) -> (usize, u8);
+    // Read a u16 from Bytes
+    fn read_u16(self: @Bytes, offset: usize) -> (usize, u16);
+    // Read a u32 from Bytes
+    fn read_u32(self: @Bytes, offset: usize) -> (usize, u32);
+    // Read a usize from Bytes
+    fn read_usize(self: @Bytes, offset: usize) -> (usize, usize);
+    // Read a u64 from Bytes
+    fn read_u64(self: @Bytes, offset: usize) -> (usize, u64);
+    // Read a u128 from Bytes
+    fn read_u128(self: @Bytes, offset: usize) -> (usize, u128);
+    // Read a u256 from Bytes
+    fn read_u256(self: @Bytes, offset: usize) -> (usize, u256);
+    // Read a u256 array from Bytes
+    fn read_u256_array(self: @Bytes, offset: usize, array_length: usize) -> (usize, Array<u256>);
+    // Read sub Bytes with size bytes from Bytes
+    fn read_bytes(self: @Bytes, offset: usize, size: usize) -> (usize, Bytes);
+    // Read felt252 from Bytes, which stored as u256
+    fn read_felt252(self: @Bytes, offset: usize) -> (usize, felt252);
+    // Read a ContractAddress from Bytes
+    fn read_address(self: @Bytes, offset: usize) -> (usize, ContractAddress);
+    // Write value with size bytes into Bytes, value is packed into u128
+    fn append_u128_packed(ref self: Bytes, value: u128, size: usize);
+    // Write u8 into Bytes
+    fn append_u8(ref self: Bytes, value: u8);
+    // Write u16 into Bytes
+    fn append_u16(ref self: Bytes, value: u16);
+    // Write u32 into Bytes
+    fn append_u32(ref self: Bytes, value: u32);
+    // Write usize into Bytes
+    fn append_usize(ref self: Bytes, value: usize);
+    // Write u64 into Bytes
+    fn append_u64(ref self: Bytes, value: u64);
+    // Write u128 into Bytes
+    fn append_u128(ref self: Bytes, value: u128);
+    // Write u256 into Bytes
+    fn append_u256(ref self: Bytes, value: u256);
+    // Write felt252 into Bytes, which stored as u256
+    fn append_felt252(ref self: Bytes, value: felt252);
+    // Write address into Bytes
+    fn append_address(ref self: Bytes, value: ContractAddress);
+    // concat with other Bytes
+    fn concat(ref self: Bytes, other: @Bytes);
+    // keccak hash
+    fn keccak(self: @Bytes) -> u256;
+    // sha256 hash
+    fn sha256(self: @Bytes) -> u256;
+}
+
+impl BytesImpl of BytesTrait {
+    fn new(size: usize, data: Array::<u128>) -> Bytes {
+        Bytes { size, data }
+    }
+
+    fn zero(size: usize) -> Bytes {
+        let mut data = ArrayTrait::<u128>::new();
+        let aligned = size % BYTES_PER_ELEMENT == 0;
+        let mut data_len = size / BYTES_PER_ELEMENT;
+        if !aligned {
+            data_len += 1;
+        }
+
+        loop {
+            if data_len == 0 {
+                break ();
+            };
+            data.append(0_u128);
+            data_len -= 1;
+        };
+
+        Bytes { size, data }
+    }
+
+    // Locat offset in Bytes
+    // Arguments:
+    //  - offset: the offset in Bytes
+    // Returns:
+    //  - element_index: the index of the element in Bytes
+    //  - element_offset: the offset in the element
+    fn locate(offset: usize) -> (usize, usize) {
+        DivRem::div_rem(offset, BYTES_PER_ELEMENT.try_into().unwrap())
+    }
+
+    // Get Bytes size
+    fn size(self: @Bytes) -> usize {
+        *self.size
+    }
+
+    // update specific value (1 bytes) at specific offset
+    fn update(ref self: Bytes, offset: usize, value: u8) {
+        assert(offset < self.size(), 'update out of bound');
+        let mut new_bytes = BytesTrait::new(0, array![]);
+
+        // if update first bytes, ignore
+        if offset > 0 {
+            let (_, left) = self.read_bytes(0, offset);
+            new_bytes.concat(@left);
+        }
+        new_bytes.append_u8(value);
+
+        // if update last bytes, ignore
+        if offset < self.size() - 1 {
+            let (_, right) = self.read_bytes(offset + 1, self.size() - offset - 1);
+            new_bytes.concat(@right);
+        }
+        self = new_bytes;
+    }
+
+    // Read value with size bytes from Bytes, and packed into u128
+    // Arguments:
+    //  - offset: the offset in Bytes
+    //  - size: the number of bytes to read
+    // Returns:
+    //  - new_offset: next value offset in Bytes
+    //  - value: the value packed into u128
+    fn read_u128_packed(self: @Bytes, offset: usize, size: usize) -> (usize, u128) {
+        // check
+        assert(offset + size <= self.size(), 'out of bound');
+        assert(size * 8 <= 128, 'too large');
+
+        // check value in one element or two
+        // if value in one element, just read it
+        // if value in two elements, read them and join them
+        let (element_index, element_offset) = BytesTrait::locate(offset);
+        let value_in_one_element = element_offset + size <= BYTES_PER_ELEMENT;
+
+        if value_in_one_element {
+            let value = u128_sub_value(
+                *self.data[element_index], BYTES_PER_ELEMENT, element_offset, size
+            );
+            return (offset + size, value);
+        } else {
+            let (_, end_element_offset) = BytesTrait::locate(offset + size);
+            let left = u128_sub_value(
+                *self.data[element_index],
+                BYTES_PER_ELEMENT,
+                element_offset,
+                BYTES_PER_ELEMENT - element_offset
+            );
+            let right = u128_sub_value(
+                *self.data[element_index + 1], BYTES_PER_ELEMENT, 0, end_element_offset
+            );
+            let value = u128_join(left, right, end_element_offset);
+            return (offset + size, value);
+        }
+    }
+
+    fn read_u128_array_packed(
+        self: @Bytes, offset: usize, array_length: usize, element_size: usize
+    ) -> (usize, Array<u128>) {
+        assert(offset + array_length * element_size <= self.size(), 'out of bound');
+        let mut array = ArrayTrait::<u128>::new();
+
+        if array_length == 0 {
+            return (offset, array);
+        }
+        let mut offset = offset;
+        let mut i = array_length;
+        loop {
+            let (new_offset, value) = self.read_u128_packed(offset, element_size);
+            array.append(value);
+            offset = new_offset;
+            i -= 1;
+            if i == 0 {
+                break ();
+            };
+        };
+        (offset, array)
+    }
+
+    // Read value with size bytes from Bytes, and packed into felt252
+    fn read_felt252_packed(self: @Bytes, offset: usize, size: usize) -> (usize, felt252) {
+        // check
+        assert(offset + size <= self.size(), 'out of bound');
+        // Bytes unit is one byte
+        // felt252 can hold 31 bytes max
+        assert(size * 8 <= 248, 'too large');
+
+        if size <= 16 {
+            let (new_offset, value) = self.read_u128_packed(offset, size);
+            return (new_offset, value.into());
+        } else {
+            let (new_offset, high) = self.read_u128_packed(offset, size - 16);
+            let (new_offset, low) = self.read_u128_packed(new_offset, 16);
+            return (new_offset, u256 { low, high }.try_into().unwrap());
+        }
+    }
+
+    // Read a u8 from Bytes
+    fn read_u8(self: @Bytes, offset: usize) -> (usize, u8) {
+        let (new_offset, value) = self.read_u128_packed(offset, 1);
+        (new_offset, value.try_into().unwrap())
+    }
+    // Read a u16 from Bytes
+    fn read_u16(self: @Bytes, offset: usize) -> (usize, u16) {
+        let (new_offset, value) = self.read_u128_packed(offset, 2);
+        (new_offset, value.try_into().unwrap())
+    }
+    // Read a u32 from Bytes
+    fn read_u32(self: @Bytes, offset: usize) -> (usize, u32) {
+        let (new_offset, value) = self.read_u128_packed(offset, 4);
+        (new_offset, value.try_into().unwrap())
+    }
+    // Read a usize from Bytes
+    fn read_usize(self: @Bytes, offset: usize) -> (usize, usize) {
+        let (new_offset, value) = self.read_u128_packed(offset, 4);
+        (new_offset, value.try_into().unwrap())
+    }
+    // Read a u64 from Bytes
+    fn read_u64(self: @Bytes, offset: usize) -> (usize, u64) {
+        let (new_offset, value) = self.read_u128_packed(offset, 8);
+        (new_offset, value.try_into().unwrap())
+    }
+
+    fn read_u128(self: @Bytes, offset: usize) -> (usize, u128) {
+        self.read_u128_packed(offset, 16)
+    }
+
+    // read a u256 from Bytes
+    fn read_u256(self: @Bytes, offset: usize) -> (usize, u256) {
+        // check
+        assert(offset + 32 <= self.size(), 'out of bound');
+
+        let (new_offset, high) = self.read_u128(offset);
+        let (new_offset, low) = self.read_u128(new_offset);
+
+        (new_offset, u256 { low, high })
+    }
+
+    // read a u256 array from Bytes
+    fn read_u256_array(self: @Bytes, offset: usize, array_length: usize) -> (usize, Array<u256>) {
+        assert(offset + array_length * 32 <= self.size(), 'out of bound');
+        let mut array = ArrayTrait::<u256>::new();
+
+        if array_length == 0 {
+            return (offset, array);
+        }
+
+        let mut offset = offset;
+        let mut i = array_length;
+        loop {
+            let (new_offset, value) = self.read_u256(offset);
+            array.append(value);
+            offset = new_offset;
+            i -= 1;
+            if i == 0 {
+                break ();
+            };
+        };
+        (offset, array)
+    }
+
+    // read sub Bytes from Bytes
+    fn read_bytes(self: @Bytes, offset: usize, size: usize) -> (usize, Bytes) {
+        // check
+        assert(offset + size <= self.size(), 'out of bound');
+        let mut array = ArrayTrait::<u128>::new();
+        if size == 0 {
+            return (offset, BytesTrait::new(0, array));
+        }
+
+        // read full array element for sub_bytes
+        let mut offset = offset;
+        let mut sub_bytes_full_array_len = size / BYTES_PER_ELEMENT;
+        loop {
+            if sub_bytes_full_array_len == 0 {
+                break ();
+            };
+            let (new_offset, value) = self.read_u128(offset);
+            array.append(value);
+            offset = new_offset;
+            sub_bytes_full_array_len -= 1;
+        };
+
+        // process last array element for sub_bytes
+        // 1. read last element real value;
+        // 2. make last element full with padding 0;
+        let sub_bytes_last_element_size = size % BYTES_PER_ELEMENT;
+        if sub_bytes_last_element_size > 0 {
+            let (new_offset, value) = self.read_u128_packed(offset, sub_bytes_last_element_size);
+            let padding = BYTES_PER_ELEMENT - sub_bytes_last_element_size;
+            let value = u128_join(value, 0, padding);
+            array.append(value);
+            offset = new_offset;
+        }
+
+        return (offset, BytesTrait::new(size, array));
+    }
+
+    // read felt252 from Bytes
+    // felt252 stores as u256 in Bytes
+    fn read_felt252(self: @Bytes, offset: usize) -> (usize, felt252) {
+        let (new_offset, value) = self.read_u256(offset);
+        (new_offset, value.try_into().unwrap())
+    }
+
+    // read address from Bytes
+    fn read_address(self: @Bytes, offset: usize) -> (usize, ContractAddress) {
+        let (new_offset, value) = self.read_u256(offset);
+        let address: felt252 = value.try_into().unwrap();
+        (new_offset, address.try_into().unwrap())
+    }
+
+    // Write value with size bytes into Bytes, value is packed into u128
+    fn append_u128_packed(ref self: Bytes, value: u128, size: usize) {
+        assert(size <= 16, 'size must be less than 16');
+
+        let Bytes{size: old_bytes_size, mut data } = self;
+        let (last_data_index, last_element_size) = BytesTrait::locate(old_bytes_size);
+
+        if last_element_size == 0 {
+            let padded_value = u128_join(value, 0, BYTES_PER_ELEMENT - size);
+            data.append(padded_value);
+        } else {
+            let (last_element_value, _) = u128_split(*data[last_data_index], 16, last_element_size);
+            data = u128_array_slice(@data, 0, last_data_index);
+            if size + last_element_size > BYTES_PER_ELEMENT {
+                let (left, right) = u128_split(value, size, BYTES_PER_ELEMENT - last_element_size);
+                let value_full = u128_join(
+                    last_element_value, left, BYTES_PER_ELEMENT - last_element_size
+                );
+                let value_padded = u128_join(
+                    right, 0, 2 * BYTES_PER_ELEMENT - size - last_element_size
+                );
+                data.append(value_full);
+                data.append(value_padded);
+            } else {
+                let value = u128_join(last_element_value, value, size);
+                let value_padded = u128_join(
+                    value, 0, BYTES_PER_ELEMENT - size - last_element_size
+                );
+                data.append(value_padded);
+            }
+        }
+        self = Bytes { size: old_bytes_size + size, data }
+    }
+
+    // Write u8 into Bytes
+    fn append_u8(ref self: Bytes, value: u8) {
+        self.append_u128_packed(value.into(), 1)
+    }
+
+    // Write u16 into Bytes
+    fn append_u16(ref self: Bytes, value: u16) {
+        self.append_u128_packed(value.into(), 2)
+    }
+
+    // Write u32 into Bytes
+    fn append_u32(ref self: Bytes, value: u32) {
+        self.append_u128_packed(value.into(), 4)
+    }
+
+    // Write usize into Bytes
+    fn append_usize(ref self: Bytes, value: usize) {
+        self.append_u128_packed(value.into(), 4)
+    }
+
+    // Write u64 into Bytes
+    fn append_u64(ref self: Bytes, value: u64) {
+        self.append_u128_packed(value.into(), 8)
+    }
+
+    // Write u128 into Bytes
+    fn append_u128(ref self: Bytes, value: u128) {
+        self.append_u128_packed(value, 16)
+    }
+
+    // Write u256 into Bytes
+    fn append_u256(ref self: Bytes, value: u256) {
+        self.append_u128(value.high);
+        self.append_u128(value.low);
+    }
+
+    // Write felt252 into Bytes, which stored as u256
+    fn append_felt252(ref self: Bytes, value: felt252) {
+        let value: u256 = value.into();
+        self.append_u256(value)
+    }
+
+    // Write address into Bytes
+    fn append_address(ref self: Bytes, value: ContractAddress) {
+        let address_felt256: felt252 = value.into();
+        let address_u256: u256 = address_felt256.into();
+        self.append_u256(address_u256)
+    }
+
+    // concat with other Bytes
+    fn concat(ref self: Bytes, other: @Bytes) {
+        // read full array element for other
+        let mut offset = 0;
+        let mut sub_bytes_full_array_len = *other.size / BYTES_PER_ELEMENT;
+        loop {
+            if sub_bytes_full_array_len == 0 {
+                break ();
+            };
+            let (new_offset, value) = other.read_u128(offset);
+            self.append_u128(value);
+            offset = new_offset;
+            sub_bytes_full_array_len -= 1;
+        };
+
+        // process last array element for right
+        let sub_bytes_last_element_size = *other.size % BYTES_PER_ELEMENT;
+        if sub_bytes_last_element_size > 0 {
+            let (new_offset, value) = other.read_u128_packed(offset, sub_bytes_last_element_size);
+            self.append_u128_packed(value, sub_bytes_last_element_size);
+        }
+    }
+
+    // keccak hash
+    fn keccak(self: @Bytes) -> u256 {
+        let (last_data_index, last_element_size) = BytesTrait::locate(self.size());
+        if last_element_size == 0 {
+            return keccak_u128s_be(self.data.span(), self.size());
+        } else {
+            let mut hash_data = u128_array_slice(self.data, 0, last_data_index);
+            // To cumpute hash, we should remove 0 padded
+            let (last_element_value, _) = u128_split(
+                *self.data[last_data_index], BYTES_PER_ELEMENT, last_element_size
+            );
+            hash_data.append(last_element_value);
+            return keccak_u128s_be(hash_data.span(), self.size());
+        }
+    }
+
+    // sha256 hash
+    fn sha256(self: @Bytes) -> u256 {
+        let mut hash_data: Array<u8> = ArrayTrait::new();
+        let mut i: usize = 0;
+        let mut offset: usize = 0;
+        loop {
+            if i == self.size() {
+                break ();
+            }
+            let (new_offset, hash_data_item) = self.read_u8(offset);
+            hash_data.append(hash_data_item);
+            offset = new_offset;
+            i += 1;
+        };
+
+        let output: Array<u8> = sha256(hash_data);
+        u8_array_to_u256(output.span())
+    }
+}

--- a/src/bytes/src/lib.cairo
+++ b/src/bytes/src/lib.cairo
@@ -1,0 +1,7 @@
+mod bytes;
+mod utils;
+
+use bytes::{Bytes, BytesTrait};
+
+#[cfg(test)]
+mod tests;

--- a/src/bytes/src/tests.cairo
+++ b/src/bytes/src/tests.cairo
@@ -1,0 +1,1 @@
+mod test_bytes;

--- a/src/bytes/src/tests/test_bytes.cairo
+++ b/src/bytes/src/tests/test_bytes.cairo
@@ -1,0 +1,668 @@
+use traits::Into;
+use array::ArrayTrait;
+use starknet::{ContractAddress, ContractAddressIntoFelt252, contract_address_const};
+use alexandria_bytes::{Bytes, BytesTrait};
+use debug::PrintTrait;
+
+#[test]
+#[available_gas(20000000)]
+fn test_bytes_zero() {
+    let bytes = BytesTrait::zero(1);
+    assert(bytes.size == 1, 'invalid size');
+    assert(*bytes.data[0] == 0, 'invalid value');
+
+    let bytes = BytesTrait::zero(17);
+    assert(bytes.size == 17, 'invalid size');
+    assert(*bytes.data[0] == 0, 'invalid value');
+    assert(*bytes.data[1] == 0, 'invalid value');
+    let (_, value) = bytes.read_u8(15);
+    assert(value == 0, 'invalid value');
+    let (_, value) = bytes.read_u8(0);
+    assert(value == 0, 'invalid value');
+    let (_, value) = bytes.read_u8(16);
+    assert(value == 0, 'invalid value');
+}
+
+#[test]
+#[available_gas(200000000)]
+#[should_panic(expected: ('update out of bound',))]
+fn test_bytes_update_panic() {
+    let mut bytes = BytesTrait::new(0, array![]);
+    bytes.update(0, 0x01);
+}
+
+#[test]
+#[available_gas(200000000)]
+fn test_bytes_update() {
+    let mut bytes = BytesTrait::new(5, array![0x01020304050000000000000000000000]);
+
+    bytes.update(0, 0x05);
+    assert(bytes.size == 5, 'update_size1');
+    assert(*bytes.data[0] == 0x05020304050000000000000000000000, 'update_value_1');
+
+    bytes.update(1, 0x06);
+    assert(bytes.size == 5, 'update_size2');
+    assert(*bytes.data[0] == 0x05060304050000000000000000000000, 'update_value_2');
+
+    bytes.update(2, 0x07);
+    assert(bytes.size == 5, 'update_size3');
+    assert(*bytes.data[0] == 0x05060704050000000000000000000000, 'update_value_3');
+
+    bytes.update(3, 0x08);
+    assert(bytes.size == 5, 'update_size4');
+    assert(*bytes.data[0] == 0x05060708050000000000000000000000, 'update_value_4');
+
+    bytes.update(4, 0x09);
+    assert(bytes.size == 5, 'update_size5');
+    assert(*bytes.data[0] == 0x05060708090000000000000000000000, 'update_value_5');
+
+    let mut bytes = BytesTrait::new(
+        42,
+        array![
+            0x01020304050607080910111213141516,
+            0x01020304050607080910111213141516,
+            0x01020304050607080910000000000000
+        ]
+    );
+
+    bytes.update(16, 0x16);
+    assert(bytes.size == 42, 'update_size6');
+    assert(*bytes.data[0] == 0x01020304050607080910111213141516, 'update_value_6');
+    assert(*bytes.data[1] == 0x16020304050607080910111213141516, 'update_value_7');
+    assert(*bytes.data[2] == 0x01020304050607080910000000000000, 'update_value_8');
+
+    bytes.update(15, 0x01);
+    assert(bytes.size == 42, 'update_size7');
+    assert(*bytes.data[0] == 0x01020304050607080910111213141501, 'update_value_9');
+    assert(*bytes.data[1] == 0x16020304050607080910111213141516, 'update_value_10');
+    assert(*bytes.data[2] == 0x01020304050607080910000000000000, 'update_value_11');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_bytes_read_u128_packed() {
+    let mut array = ArrayTrait::<u128>::new();
+    array.append(0x01020304050607080910111213141516);
+    array.append(0x01020304050607080910111213141516);
+    array.append(0x01020304050607080910000000000000);
+
+    let bytes = BytesTrait::new(42, array);
+
+    let (new_offset, value) = bytes.read_u128_packed(0, 1);
+    assert(new_offset == 1, 'read_u128_packed_1_offset');
+    assert(value == 0x01, 'read_u128_packed_1_value');
+
+    let (new_offset, value) = bytes.read_u128_packed(new_offset, 14);
+    assert(new_offset == 15, 'read_u128_packed_2_offset');
+    assert(value == 0x0203040506070809101112131415, 'read_u128_packed_2_value');
+
+    let (new_offset, value) = bytes.read_u128_packed(new_offset, 15);
+    assert(new_offset == 30, 'read_u128_packed_3_offset');
+    assert(value == 0x160102030405060708091011121314, 'read_u128_packed_3_value');
+
+    let (new_offset, value) = bytes.read_u128_packed(new_offset, 8);
+    assert(new_offset == 38, 'read_u128_packed_4_offset');
+    assert(value == 0x1516010203040506, 'read_u128_packed_4_value');
+
+    let (new_offset, value) = bytes.read_u128_packed(new_offset, 4);
+    assert(new_offset == 42, 'read_u128_packed_5_offset');
+    assert(value == 0x07080910, 'read_u128_packed_5_value');
+}
+
+#[test]
+#[available_gas(20000000)]
+#[should_panic(expected: ('out of bound',))]
+fn test_bytes_read_u128_packed_out_of_bound() {
+    let mut array = ArrayTrait::<u128>::new();
+    array.append(0x01020304050607080910111213141516);
+    array.append(0x01020304050607080910111213141516);
+    array.append(0x01020304050607080910000000000000);
+
+    let bytes = BytesTrait::new(42, array);
+
+    let (new_offset, value) = bytes.read_u128_packed(0, 43);
+}
+
+#[test]
+#[available_gas(20000000)]
+#[should_panic(expected: ('too large',))]
+fn test_bytes_read_u128_packed_too_large() {
+    let mut array = ArrayTrait::<u128>::new();
+    array.append(0x01020304050607080910111213141516);
+    array.append(0x01020304050607080910111213141516);
+    array.append(0x01020304050607080910000000000000);
+
+    let bytes = BytesTrait::new(42, array);
+
+    let (new_offset, value) = bytes.read_u128_packed(0, 17);
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_bytes_read_u128_array_packed() {
+    let mut array = ArrayTrait::<u128>::new();
+    array.append(0x01020304050607080910111213141516);
+    array.append(0x01020304050607080910111213141516);
+    array.append(0x01020304050607080910000000000000);
+
+    let bytes = BytesTrait::new(42, array);
+
+    let (new_offset, new_array) = bytes.read_u128_array_packed(0, 3, 3);
+    assert(new_offset == 9, 'read_u128_array_1_offset');
+    assert(*new_array[0] == 0x010203, 'read_u128_array_1_value_1');
+    assert(*new_array[1] == 0x040506, 'read_u128_array_1_value_2');
+    assert(*new_array[2] == 0x070809, 'read_u128_array_1_value_3');
+
+    let (new_offset, new_array) = bytes.read_u128_array_packed(9, 4, 7);
+    assert(new_offset == 37, 'read_u128_array_2_offset');
+    assert(*new_array[0] == 0x10111213141516, 'read_u128_array_2_value_1');
+    assert(*new_array[1] == 0x01020304050607, 'read_u128_array_2_value_2');
+    assert(*new_array[2] == 0x08091011121314, 'read_u128_array_2_value_3');
+    assert(*new_array[3] == 0x15160102030405, 'read_u128_array_2_value_4');
+}
+
+#[test]
+#[available_gas(20000000)]
+#[should_panic(expected: ('out of bound',))]
+fn test_bytes_read_u128_array_packed_out_of_bound() {
+    let mut array = ArrayTrait::<u128>::new();
+    array.append(0x01020304050607080910111213141516);
+    array.append(0x01020304050607080910111213141516);
+    array.append(0x01020304050607080910000000000000);
+
+    let bytes = BytesTrait::new(42, array);
+
+    let (new_offset, new_array) = bytes.read_u128_array_packed(0, 11, 4);
+}
+
+#[test]
+#[available_gas(20000000)]
+#[should_panic(expected: ('too large',))]
+fn test_bytes_read_u128_array_packed_too_large() {
+    let mut array = ArrayTrait::<u128>::new();
+    array.append(0x01020304050607080910111213141516);
+    array.append(0x01020304050607080910111213141516);
+    array.append(0x01020304050607080910000000000000);
+
+    let bytes = BytesTrait::new(42, array);
+
+    let (new_offset, new_array) = bytes.read_u128_array_packed(0, 2, 17);
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_bytes_read_felt252_packed() {
+    let mut array = ArrayTrait::<u128>::new();
+    array.append(0x01020304050607080910111213141516);
+    array.append(0x01020304050607080910111213141516);
+    array.append(0x01020304050607080910000000000000);
+
+    let bytes = BytesTrait::new(42, array);
+
+    let (new_offset, value) = bytes.read_felt252_packed(13, 20);
+    assert(new_offset == 33, 'read_felt252_1_offset');
+    assert(value == 0x1415160102030405060708091011121314151601, 'read_felt252_1_value');
+}
+
+#[test]
+#[available_gas(20000000)]
+#[should_panic(expected: ('out of bound',))]
+fn test_bytes_read_felt252_packed_out_of_bound() {
+    let mut array = ArrayTrait::<u128>::new();
+    array.append(0x01020304050607080910111213141516);
+    array.append(0x01020304050607080910111213141516);
+    array.append(0x01020304050607080910000000000000);
+
+    let bytes = BytesTrait::new(42, array);
+
+    let (new_offset, new_array) = bytes.read_felt252_packed(0, 43);
+}
+
+#[test]
+#[available_gas(20000000)]
+#[should_panic(expected: ('too large',))]
+fn test_bytes_read_felt252_packed_too_large() {
+    let mut array = ArrayTrait::<u128>::new();
+    array.append(0x01020304050607080910111213141516);
+    array.append(0x01020304050607080910111213141516);
+    array.append(0x01020304050607080910000000000000);
+
+    let bytes = BytesTrait::new(42, array);
+
+    let (new_offset, new_array) = bytes.read_felt252_packed(0, 32);
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_bytes_read_u8() {
+    let mut array = ArrayTrait::<u128>::new();
+    array.append(0x01020304050607080910111213141516);
+    array.append(0x01020304050607080910111213141516);
+    array.append(0x01020304050607080910000000000000);
+
+    let bytes = BytesTrait::new(42, array);
+
+    let (new_offset, value) = bytes.read_u8(15);
+    assert(new_offset == 16, 'read_u8_offset');
+    assert(value == 0x16, 'read_u8_value');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_bytes_read_u16() {
+    let mut array = ArrayTrait::<u128>::new();
+    array.append(0x01020304050607080910111213141516);
+    array.append(0x01020304050607080910111213141516);
+    array.append(0x01020304050607080910000000000000);
+
+    let bytes = BytesTrait::new(42, array);
+
+    let (new_offset, value) = bytes.read_u16(15);
+    assert(new_offset == 17, 'read_u16_offset');
+    assert(value == 0x1601, 'read_u16_value');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_bytes_read_u32() {
+    let mut array = ArrayTrait::<u128>::new();
+    array.append(0x01020304050607080910111213141516);
+    array.append(0x01020304050607080910111213141516);
+    array.append(0x01020304050607080910000000000000);
+
+    let bytes = BytesTrait::new(42, array);
+
+    let (new_offset, value) = bytes.read_u32(15);
+    assert(new_offset == 19, 'read_u32_offset');
+    assert(value == 0x16010203, 'read_u32_value');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_bytes_read_usize() {
+    let mut array = ArrayTrait::<u128>::new();
+    array.append(0x01020304050607080910111213141516);
+    array.append(0x01020304050607080910111213141516);
+    array.append(0x01020304050607080910000000000000);
+
+    let bytes = BytesTrait::new(42, array);
+
+    let (new_offset, value) = bytes.read_usize(15);
+    assert(new_offset == 19, 'read_usize_offset');
+    assert(value == 0x16010203, 'read_usize_value');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_bytes_read_u64() {
+    let mut array = ArrayTrait::<u128>::new();
+    array.append(0x01020304050607080910111213141516);
+    array.append(0x01020304050607080910111213141516);
+    array.append(0x01020304050607080910000000000000);
+
+    let bytes = BytesTrait::new(42, array);
+
+    let (new_offset, value) = bytes.read_u64(15);
+    assert(new_offset == 23, 'read_u64_offset');
+    assert(value == 0x1601020304050607, 'read_u64_value');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_bytes_read_u128() {
+    let mut array = ArrayTrait::<u128>::new();
+    array.append(0x01020304050607080910111213141516);
+    array.append(0x01020304050607080910111213141516);
+    array.append(0x01020304050607080910000000000000);
+
+    let bytes = BytesTrait::new(42, array);
+
+    let (new_offset, value) = bytes.read_u128(15);
+    assert(new_offset == 31, 'read_u128_offset');
+    assert(value == 0x16010203040506070809101112131415, 'read_u128_value');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_bytes_read_u256() {
+    let mut array = ArrayTrait::<u128>::new();
+    array.append(0x01020304050607080910111213141516);
+    array.append(0x01020304050607080910111213141516);
+    array.append(0x01020304050607080910000000000000);
+
+    let bytes = BytesTrait::new(42, array);
+
+    let (new_offset, value) = bytes.read_u256(4);
+    assert(new_offset == 36, 'read_u256_1_offset');
+    assert(value.high == 0x05060708091011121314151601020304, 'read_u256_1_value_high');
+    assert(value.low == 0x05060708091011121314151601020304, 'read_u256_1_value_low');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_bytes_read_u256_array() {
+    let mut array = ArrayTrait::<u128>::new();
+    array.append(0x01020304050607080910111213141516);
+    array.append(0x16151413121110090807060504030201);
+    array.append(0x16151413121110090807060504030201);
+    array.append(0x01020304050607080910111213141516);
+    array.append(0x01020304050607080910111213141516);
+    array.append(0x16151413121110090000000000000000);
+
+    let bytes = BytesTrait::new(88, array);
+
+    let (new_offset, new_array) = bytes.read_u256_array(7, 2);
+    assert(new_offset == 71, 'read_u256_array_offset');
+    let result: u256 = *new_array[0];
+    assert(result.high == 0x08091011121314151616151413121110, 'read_256_array_value_1_high');
+    assert(result.low == 0x09080706050403020116151413121110, 'read_256_array_value_1_low');
+    let result: u256 = *new_array[1];
+    assert(result.high == 0x09080706050403020101020304050607, 'read_256_array_value_2_high');
+    assert(result.low == 0x08091011121314151601020304050607, 'read_256_array_value_2_low');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_bytes_read_address() {
+    let mut array = ArrayTrait::<u128>::new();
+    array.append(0x01020304050607080910111213140154);
+    array.append(0x01855d7796176b05d160196ff92381eb);
+    array.append(0x7910f5446c2e0e04e13db2194a4f0000);
+
+    let bytes = BytesTrait::new(46, array);
+    let address = 0x015401855d7796176b05d160196ff92381eb7910f5446c2e0e04e13db2194a4f;
+
+    let (new_offset, value) = bytes.read_address(14);
+    assert(new_offset == 46, 'read_address_offset');
+    assert(value.into() == address, 'read_address_value');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_bytes_read_bytes() {
+    let mut array = ArrayTrait::<u128>::new();
+    array.append(0x01020304050607080910111213140154);
+    array.append(0x01855d7796176b05d160196ff92381eb);
+    array.append(0x7910f5446c2e0e04e13db2194a4f0000);
+
+    let bytes = BytesTrait::new(46, array);
+
+    let (new_offset, sub_bytes) = bytes.read_bytes(4, 37);
+    let sub_bytes_data = @sub_bytes.data;
+    assert(new_offset == 41, 'read_bytes_offset');
+    assert(sub_bytes.size() == 37, 'read_bytes_size');
+    assert(*sub_bytes_data[0] == 0x05060708091011121314015401855d77, 'read_bytes_value_1');
+    assert(*sub_bytes_data[1] == 0x96176b05d160196ff92381eb7910f544, 'read_bytes_value_2');
+    assert(*sub_bytes_data[2] == 0x6c2e0e04e10000000000000000000000, 'read_bytes_value_3');
+
+    let (new_offset, sub_bytes) = bytes.read_bytes(0, 14);
+    let sub_bytes_data = @sub_bytes.data;
+    assert(new_offset == 14, 'read_bytes_offset');
+    assert(sub_bytes.size() == 14, 'read_bytes_size');
+    assert(*sub_bytes_data[0] == 0x01020304050607080910111213140000, 'read_bytes_value_4');
+
+    // read first byte
+    let (new_offset, sub_bytes) = bytes.read_bytes(0, 1);
+    let sub_bytes_data = @sub_bytes.data;
+    assert(new_offset == 1, 'read_bytes_offset');
+    assert(sub_bytes.size() == 1, 'read_bytes_size');
+    assert(*sub_bytes_data[0] == 0x01000000000000000000000000000000, 'read_bytes_value_5');
+
+    // read last byte
+    let (new_offset, sub_bytes) = bytes.read_bytes(45, 1);
+    let sub_bytes_data = @sub_bytes.data;
+    assert(new_offset == 46, 'read_bytes_offset');
+    assert(sub_bytes.size() == 1, 'read_bytes_size');
+    assert(*sub_bytes_data[0] == 0x4f000000000000000000000000000000, 'read_bytes_value_6');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_bytes_append() {
+    let mut bytes = BytesTrait::new(0, array![]);
+
+    // append_u128_packed
+    bytes.append_u128_packed(0x101112131415161718, 9);
+    let Bytes{size, mut data } = bytes;
+    assert(size == 9, 'append_u128_packed_1_size');
+    assert(*data[0] == 0x10111213141516171800000000000000, 'append_u128_packed_1_value_1');
+    bytes = Bytes { size: size, data: data };
+
+    bytes.append_u128_packed(0x101112131415161718, 9);
+    let Bytes{size, mut data } = bytes;
+    assert(size == 18, 'append_u128_packed_2_size');
+    assert(*data[0] == 0x10111213141516171810111213141516, 'append_u128_packed_2_value_1');
+    assert(*data[1] == 0x17180000000000000000000000000000, 'append_u128_packed_2_value_2');
+    bytes = Bytes { size: size, data: data };
+
+    // append_u8
+    bytes.append_u8(0x01);
+    let Bytes{size, mut data } = bytes;
+    assert(size == 19, 'append_u8_size');
+    assert(*data[0] == 0x10111213141516171810111213141516, 'append_u8_value_1');
+    assert(*data[1] == 0x17180100000000000000000000000000, 'append_u8_value_2');
+    bytes = Bytes { size: size, data: data };
+
+    // append_u16
+    bytes.append_u16(0x0102);
+    let Bytes{size, mut data } = bytes;
+    assert(size == 21, 'append_u16_size');
+    assert(*data[0] == 0x10111213141516171810111213141516, 'append_u16_value_1');
+    assert(*data[1] == 0x17180101020000000000000000000000, 'append_u16_value_2');
+    bytes = Bytes { size: size, data: data };
+
+    // append_u32
+    bytes.append_u32(0x01020304);
+    let Bytes{size, mut data } = bytes;
+    assert(size == 25, 'append_u32_size');
+    assert(*data[0] == 0x10111213141516171810111213141516, 'append_u32_value_1');
+    assert(*data[1] == 0x17180101020102030400000000000000, 'append_u32_value_2');
+    bytes = Bytes { size: size, data: data };
+
+    // append_usize
+    bytes.append_usize(0x01);
+    let Bytes{size, mut data } = bytes;
+    assert(size == 29, 'append_usize_size');
+    assert(*data[0] == 0x10111213141516171810111213141516, 'append_usize_value_1');
+    assert(*data[1] == 0x17180101020102030400000001000000, 'append_usize_value_2');
+    bytes = Bytes { size: size, data: data };
+
+    // append_u64
+    bytes.append_u64(0x030405060708);
+    let Bytes{size, mut data } = bytes;
+    assert(size == 37, 'append_u64_size');
+    assert(*data[0] == 0x10111213141516171810111213141516, 'append_u64_value_1');
+    assert(*data[1] == 0x17180101020102030400000001000003, 'append_u64_value_2');
+    assert(*data[2] == 0x04050607080000000000000000000000, 'append_u64_value_3');
+    bytes = Bytes { size: size, data: data };
+
+    // append_u128
+    bytes.append_u128(0x101112131415161718);
+    let Bytes{size, mut data } = bytes;
+    assert(size == 53, 'append_u128_size');
+    assert(*data[0] == 0x10111213141516171810111213141516, 'append_u128_value_1');
+    assert(*data[1] == 0x17180101020102030400000001000003, 'append_u128_value_2');
+    assert(*data[2] == 0x04050607080000000000000010111213, 'append_u128_value_3');
+    assert(*data[3] == 0x14151617180000000000000000000000, 'append_u128_value_4');
+    bytes = Bytes { size: size, data: data };
+
+    // append_u256
+    bytes.append_u256(u256 { low: 0x01020304050607, high: 0x010203040506070809 });
+    let Bytes{size, mut data } = bytes;
+    assert(size == 85, 'append_u256_size');
+    assert(*data[0] == 0x10111213141516171810111213141516, 'append_u256_value_1');
+    assert(*data[1] == 0x17180101020102030400000001000003, 'append_u256_value_2');
+    assert(*data[2] == 0x04050607080000000000000010111213, 'append_u256_value_3');
+    assert(*data[3] == 0x14151617180000000000000001020304, 'append_u256_value_4');
+    assert(*data[4] == 0x05060708090000000000000000000102, 'append_u256_value_5');
+    assert(*data[5] == 0x03040506070000000000000000000000, 'append_u256_value_6');
+    bytes = Bytes { size: size, data: data };
+
+    // append_address
+    let address =
+        contract_address_const::<0x015401855d7796176b05d160196ff92381eb7910f5446c2e0e04e13db2194a4f>();
+    bytes.append_address(address);
+    let Bytes{size, mut data } = bytes;
+    assert(size == 117, 'append_address_size');
+    assert(*data[0] == 0x10111213141516171810111213141516, 'append_address_value_1');
+    assert(*data[1] == 0x17180101020102030400000001000003, 'append_address_value_2');
+    assert(*data[2] == 0x04050607080000000000000010111213, 'append_address_value_3');
+    assert(*data[3] == 0x14151617180000000000000001020304, 'append_address_value_4');
+    assert(*data[4] == 0x05060708090000000000000000000102, 'append_address_value_5');
+    assert(*data[5] == 0x0304050607015401855d7796176b05d1, 'append_address_value_6');
+    assert(*data[6] == 0x60196ff92381eb7910f5446c2e0e04e1, 'append_address_value_7');
+    assert(*data[7] == 0x3db2194a4f0000000000000000000000, 'append_address_value_8');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_bytes_concat() {
+    let array: Array<u128> = array![
+        0x10111213141516171810111213141516,
+        0x17180101020102030400000001000003,
+        0x04050607080000000000000010111213,
+        0x14151617180000000000000001020304,
+        0x05060708090000000000000000000102,
+        0x0304050607015401855d7796176b05d1,
+        0x60196ff92381eb7910f5446c2e0e04e1,
+        0x3db2194a4f0000000000000000000000
+    ];
+    let mut bytes = BytesTrait::new(117, array);
+
+    let mut array: Array<u128> = array![
+        0x01020304050607080910111213140154,
+        0x01855d7796176b05d160196ff92381eb,
+        0x7910f5446c2e0e04e13db2194a4f0000
+    ];
+    let other = BytesTrait::new(46, array);
+
+    bytes.concat(@other);
+    let Bytes{size, mut data } = bytes;
+    assert(size == 163, 'concat_size');
+    assert(*data[0] == 0x10111213141516171810111213141516, 'concat_value_1');
+    assert(*data[1] == 0x17180101020102030400000001000003, 'concat_value_2');
+    assert(*data[2] == 0x04050607080000000000000010111213, 'concat_value_3');
+    assert(*data[3] == 0x14151617180000000000000001020304, 'concat_value_4');
+    assert(*data[4] == 0x05060708090000000000000000000102, 'concat_value_5');
+    assert(*data[5] == 0x0304050607015401855d7796176b05d1, 'concat_value_6');
+    assert(*data[6] == 0x60196ff92381eb7910f5446c2e0e04e1, 'concat_value_7');
+    assert(*data[7] == 0x3db2194a4f0102030405060708091011, 'concat_value_8');
+    assert(*data[8] == 0x121314015401855d7796176b05d16019, 'concat_value_9');
+    assert(*data[9] == 0x6ff92381eb7910f5446c2e0e04e13db2, 'concat_value_10');
+    assert(*data[10] == 0x194a4f00000000000000000000000000, 'concat_value_11');
+    bytes = Bytes { size: size, data: data };
+
+    // empty bytes concat
+    let mut empty_bytes = BytesTrait::new(0, array![]);
+    empty_bytes.concat(@bytes);
+    let Bytes{size, data } = empty_bytes;
+
+    assert(size == 163, 'concat_size');
+    assert(*data[0] == 0x10111213141516171810111213141516, 'concat_value_1');
+    assert(*data[1] == 0x17180101020102030400000001000003, 'concat_value_2');
+    assert(*data[2] == 0x04050607080000000000000010111213, 'concat_value_3');
+    assert(*data[3] == 0x14151617180000000000000001020304, 'concat_value_4');
+    assert(*data[4] == 0x05060708090000000000000000000102, 'concat_value_5');
+    assert(*data[5] == 0x0304050607015401855d7796176b05d1, 'concat_value_6');
+    assert(*data[6] == 0x60196ff92381eb7910f5446c2e0e04e1, 'concat_value_7');
+    assert(*data[7] == 0x3db2194a4f0102030405060708091011, 'concat_value_8');
+    assert(*data[8] == 0x121314015401855d7796176b05d16019, 'concat_value_9');
+    assert(*data[9] == 0x6ff92381eb7910f5446c2e0e04e13db2, 'concat_value_10');
+    assert(*data[10] == 0x194a4f00000000000000000000000000, 'concat_value_11');
+
+    // concat empty_bytes
+    let empty_bytes = BytesTrait::new(0, array![]);
+    bytes.concat(@empty_bytes);
+
+    assert(size == 163, 'concat_size');
+    assert(*data[0] == 0x10111213141516171810111213141516, 'concat_value_1');
+    assert(*data[1] == 0x17180101020102030400000001000003, 'concat_value_2');
+    assert(*data[2] == 0x04050607080000000000000010111213, 'concat_value_3');
+    assert(*data[3] == 0x14151617180000000000000001020304, 'concat_value_4');
+    assert(*data[4] == 0x05060708090000000000000000000102, 'concat_value_5');
+    assert(*data[5] == 0x0304050607015401855d7796176b05d1, 'concat_value_6');
+    assert(*data[6] == 0x60196ff92381eb7910f5446c2e0e04e1, 'concat_value_7');
+    assert(*data[7] == 0x3db2194a4f0102030405060708091011, 'concat_value_8');
+    assert(*data[8] == 0x121314015401855d7796176b05d16019, 'concat_value_9');
+    assert(*data[9] == 0x6ff92381eb7910f5446c2e0e04e13db2, 'concat_value_10');
+    assert(*data[10] == 0x194a4f00000000000000000000000000, 'concat_value_11');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_bytes_keccak() {
+    // Calculating keccak by Python
+    // from Crypto.Hash import keccak
+    // k = keccak.new(digest_bits=256)
+    // k.update(bytes.fromhex(''))
+    // print(k.hexdigest())
+
+    // empty
+    let bytes = BytesTrait::new(0, array![]);
+    let hash: u256 = 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470;
+    let res = bytes.keccak();
+    assert(res == hash, 'bytes_keccak_0');
+
+    // u256{low: 1, high: 0}
+    let mut array = ArrayTrait::<u128>::new();
+    array.append(0);
+    array.append(1);
+    let bytes: Bytes = BytesTrait::new(32, array);
+    let res = bytes.keccak();
+    let hash: u256 = 0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6;
+    assert(res == hash, 'bytes_keccak_1');
+
+    // test_bytes_append bytes
+    let mut array = ArrayTrait::<u128>::new();
+    array.append(0x10111213141516171810111213141516);
+    array.append(0x17180101020102030400000001000003);
+    array.append(0x04050607080000000000000010111213);
+    array.append(0x14151617180000000000000001020304);
+    array.append(0x05060708090000000000000000000102);
+    array.append(0x0304050607015401855d7796176b05d1);
+    array.append(0x60196ff92381eb7910f5446c2e0e04e1);
+    array.append(0x3db2194a4f0000000000000000000000);
+
+    let bytes: Bytes = BytesTrait::new(117, array);
+
+    let hash: u256 = 0xcb1bcb5098bb2f588b82ea341e3b1148b7d1eeea2552d624b30f4240b5b85995;
+    let res = bytes.keccak();
+    assert(res == hash, 'bytes_keccak_2');
+}
+
+#[test]
+#[available_gas(20000000000)]
+fn test_bytes_sha256() {
+    // empty
+    let bytes = BytesTrait::new(0, array![]);
+    let hash: u256 = 0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855;
+    let res = bytes.sha256();
+    assert(res == hash, 'bytes_sha256_0');
+
+    // u256{low: 1, high: 0}
+    // 0x0000000000000000000000000000000000000000000000000000000000000001
+    let mut array = ArrayTrait::<u128>::new();
+    array.append(0);
+    array.append(1);
+    let bytes: Bytes = BytesTrait::new(32, array);
+    let res = bytes.sha256();
+    let hash: u256 = 0xec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5;
+    assert(res == hash, 'bytes_sha256_1');
+
+    // test_bytes_append bytes
+    let mut array = ArrayTrait::<u128>::new();
+    array.append(0x10111213141516171810111213141516);
+    array.append(0x17180101020102030400000001000003);
+    array.append(0x04050607080000000000000010111213);
+    array.append(0x14151617180000000000000001020304);
+    array.append(0x05060708090000000000000000000102);
+    array.append(0x0304050607015401855d7796176b05d1);
+    array.append(0x60196ff92381eb7910f5446c2e0e04e1);
+    array.append(0x3db2194a4f0000000000000000000000);
+
+    let bytes: Bytes = BytesTrait::new(117, array);
+
+    let hash: u256 = 0xc3ab2c0ce2c246454f265f531ab14f210215ce72b91c23338405c273dc14ce1d;
+    let res = bytes.sha256();
+    assert(res == hash, 'bytes_sha256_2');
+}

--- a/src/bytes/src/utils.cairo
+++ b/src/bytes/src/utils.cairo
@@ -1,0 +1,532 @@
+use keccak::{u128_to_u64, u128_split as u128_split_to_u64, cairo_keccak};
+use integer::u128_byte_reverse;
+use alexandria_data_structures::array_ext::ArrayTraitExt;
+
+// Computes the keccak256 of multiple uint128 values.
+// The values are interpreted as big-endian.
+// https://github.com/starkware-libs/cairo/blob/main/corelib/src/keccak.cairo
+fn keccak_u128s_be(mut input: Span<u128>, n_bytes: usize) -> u256 {
+    let mut keccak_input: Array::<u64> = ArrayTrait::new();
+    let mut size = n_bytes;
+    loop {
+        match input.pop_front() {
+            Option::Some(v) => {
+                let value_size = uint_min(size, 16);
+                keccak_add_uint128_be(ref keccak_input, *v, value_size);
+                size -= value_size;
+            },
+            Option::None(_) => {
+                break ();
+            },
+        };
+    };
+
+    let aligned = n_bytes % 8 == 0;
+    if aligned {
+        u256_reverse_endian(cairo_keccak(ref keccak_input, 0, 0))
+    } else {
+        let last_input_num_bytes = n_bytes % 8;
+        let last_input_word = *keccak_input[keccak_input.len() - 1];
+        let mut inputs = u64_array_slice(@keccak_input, 0, keccak_input.len() - 1);
+        u256_reverse_endian(cairo_keccak(ref inputs, last_input_word, last_input_num_bytes))
+    }
+}
+
+// return the minimal value
+// support u8, u16, u32, u64, u128, u256
+fn uint_min<T, impl TDrop: Drop<T>, impl TPartialOrd: PartialOrd<T>, impl TCopy: Copy<T>>(
+    l: T, r: T
+) -> T {
+    if l <= r {
+        return l;
+    } else {
+        return r;
+    }
+}
+
+fn u256_reverse_endian(input: u256) -> u256 {
+    let low = u128_byte_reverse(input.high);
+    let high = u128_byte_reverse(input.low);
+    u256 { low, high }
+}
+
+fn keccak_add_uint128_be(ref keccak_input: Array::<u64>, value: u128, value_size: usize) {
+    if value_size == 16 {
+        let (high, low) = u128_split_to_u64(u128_byte_reverse(value));
+        keccak_input.append(low);
+        keccak_input.append(high);
+    } else {
+        let reversed_value = u128_byte_reverse(value);
+        let (reversed_value, _) = u128_split(reversed_value, 16, value_size);
+        if value_size <= 8 {
+            keccak_input.append(u128_to_u64(reversed_value));
+        } else {
+            let (high, low) = DivRem::div_rem(
+                reversed_value, u128_fast_pow2(64).try_into().unwrap()
+            );
+            keccak_input.append(u128_to_u64(low));
+            keccak_input.append(u128_to_u64(high));
+        }
+    }
+}
+
+fn update_u256_array_at(arr: @Array<u256>, index: usize, value: u256) -> Array<u256> {
+    assert(index < arr.len(), 'index out of range');
+    let mut new_arr: Array<u256> = array![];
+    let mut i = 0;
+
+    loop {
+        if i == arr.len() {
+            break ();
+        }
+        if i == index {
+            new_arr.append(value);
+        } else {
+            new_arr.append(*arr[i]);
+        }
+        i += 1;
+    };
+    new_arr
+}
+
+// Convert sha256 result(Array<u8>) to u256
+// result length MUST be 32
+fn u8_array_to_u256(arr: Span<u8>) -> u256 {
+    assert(arr.len() == 32, 'too large');
+    let mut i = 0;
+    let mut high: u128 = 0;
+    let mut low: u128 = 0;
+    // process high
+    loop {
+        if i >= arr.len() {
+            break ();
+        }
+        if i == 16 {
+            break ();
+        }
+        high = u128_join(high, (*arr[i]).into(), 1);
+        i += 1;
+    };
+    // process low
+    loop {
+        if i >= arr.len() {
+            break ();
+        }
+        if i == 32 {
+            break ();
+        }
+        low = u128_join(low, (*arr[i]).into(), 1);
+        i += 1;
+    };
+
+    u256 { low, high }
+}
+
+fn u64_array_slice(src: @Array<u64>, mut begin: usize, end: usize) -> Array<u64> {
+    let mut slice = ArrayTrait::new();
+    let len = begin + end;
+    loop {
+        if begin >= len {
+            break ();
+        }
+        if begin >= src.len() {
+            break ();
+        }
+
+        slice.append(*src[begin]);
+        begin += 1;
+    };
+    slice
+}
+
+/// Returns the slice of an array.
+/// * `arr` - The array to slice.
+/// * `begin` - The index to start the slice at.
+/// * `end` - The index to end the slice at (not included).
+/// # Returns
+/// * `Array<u128>` - The slice of the array.
+fn u128_array_slice(src: @Array<u128>, mut begin: usize, end: usize) -> Array<u128> {
+    let mut slice = ArrayTrait::new();
+    let len = begin + end;
+    loop {
+        if begin >= len {
+            break ();
+        }
+        if begin >= src.len() {
+            break ();
+        }
+
+        slice.append(*src[begin]);
+        begin += 1;
+    };
+    slice
+}
+
+// Split a u128 into two parts, [0, left_size-1] and [left_size, end]
+// Parameters:
+//  - value: data of u128
+//  - value_size: the size of `value` in bytes
+//  - left_size: the size of left part in bytes
+// Returns:
+//  - letf: [0, left_size-1] of the origin u128
+//  - right: [left_size, end] of the origin u128 which size is (value_size - left_size)
+// Examples:
+// u128_split(0x01020304, 4, 0) -> (0, 0x01020304)
+// u128_split(0x01020304, 4, 1) -> (0x01, 0x020304)
+// u128_split(0x0001020304, 5, 1) -> (0x00, 0x01020304)
+fn u128_split(value: u128, value_size: usize, left_size: usize) -> (u128, u128) {
+    assert(value_size <= 16, 'value_size can not be gt 16');
+    assert(left_size <= value_size, 'size can not be gt value_size');
+
+    if left_size == 0 {
+        return (0_u128, value);
+    } else {
+        let (left, right) = DivRem::div_rem(
+            value, u128_fast_pow2((value_size - left_size) * 8).try_into().unwrap()
+        );
+        return (left, right);
+    }
+}
+
+// Read sub value from u128 just like substr in other language
+// Parameters:
+//  - value: data of u128
+//  - value_size: the size of data in bytes
+//  - offset: the offset of sub value
+//  - size: the size of sub value in bytes
+// Returns:
+//  - sub_value: the sub value of origin u128
+// Examples:
+// u128_sub_value(0x000001020304, 6, 1, 3) -> 0x000102
+fn u128_sub_value(value: u128, value_size: usize, offset: usize, size: usize) -> u128 {
+    assert(value_size != 0, 'value_size can not be 0');
+    assert(size != 0, 'size can not be 0');
+    assert(offset + size <= value_size, 'too long');
+
+    if size == value_size {
+        return value;
+    }
+
+    let (_, right) = u128_split(value, value_size, offset);
+    let (sub_value, _) = u128_split(right, value_size - offset, size);
+    sub_value
+}
+
+// Join two u128 into one
+// Parameters:
+//  - left: the left part of u128
+//  - right: the right part of u128
+//  - right_size: the size of right part in bytes
+// Returns:
+//  - value: the joined u128
+// Examples: 
+// u128_join(0x010203, 0xaabb, 2) -> 0x010203aabb
+// u128_join(0x010203, 0, 2) -> 0x0102030000
+fn u128_join(left: u128, right: u128, right_size: usize) -> u128 {
+    let left_size = u128_bytes_len(left);
+    assert(left_size + right_size <= 16, 'left shift overflow');
+    let shit = u128_fast_pow2(right_size * 8);
+    left * shit + right
+}
+
+// Return the bytes len represent in u128
+// Examples:
+// u128_bytes_len(0x0102) -> 2
+fn u128_bytes_len(value: u128) -> usize {
+    if value <= 0xff_u128 {
+        1_usize
+    } else if value <= 0xffff_u128 {
+        2_usize
+    } else if value <= 0xffffff_u128 {
+        3_usize
+    } else if value <= 0xffffffff_u128 {
+        4_usize
+    } else if value <= 0xffffffffff_u128 {
+        5_usize
+    } else if value <= 0xffffffffffff_u128 {
+        6_usize
+    } else if value <= 0xffffffffffffff_u128 {
+        7_usize
+    } else if value <= 0xffffffffffffffff_u128 {
+        8_usize
+    } else if value <= 0xffffffffffffffffff_u128 {
+        9_usize
+    } else if value <= 0xffffffffffffffffffff_u128 {
+        10_usize
+    } else if value <= 0xffffffffffffffffffffff_u128 {
+        11_usize
+    } else if value <= 0xffffffffffffffffffffffff_u128 {
+        12_usize
+    } else if value <= 0xffffffffffffffffffffffffff_u128 {
+        13_usize
+    } else if value <= 0xffffffffffffffffffffffffffff_u128 {
+        14_usize
+    } else if value <= 0xffffffffffffffffffffffffffffff_u128 {
+        15_usize
+    } else {
+        16_usize
+    }
+}
+
+// return 2^exp where exp in [0, 127]
+fn u128_fast_pow2(exp: usize) -> u128 {
+    assert(exp <= 127, 'invalid exp');
+
+    if exp == 0_usize {
+        1_u128
+    } else if exp == 1_usize {
+        2_u128
+    } else if exp == 2_usize {
+        4_u128
+    } else if exp == 3_usize {
+        8_u128
+    } else if exp == 4_usize {
+        16_u128
+    } else if exp == 5_usize {
+        32_u128
+    } else if exp == 6_usize {
+        64_u128
+    } else if exp == 7_usize {
+        128_u128
+    } else if exp == 8_usize {
+        256_u128
+    } else if exp == 9_usize {
+        512_u128
+    } else if exp == 10_usize {
+        1024_u128
+    } else if exp == 11_usize {
+        2048_u128
+    } else if exp == 12_usize {
+        4096_u128
+    } else if exp == 13_usize {
+        8192_u128
+    } else if exp == 14_usize {
+        16384_u128
+    } else if exp == 15_usize {
+        32768_u128
+    } else if exp == 16_usize {
+        65536_u128
+    } else if exp == 17_usize {
+        131072_u128
+    } else if exp == 18_usize {
+        262144_u128
+    } else if exp == 19_usize {
+        524288_u128
+    } else if exp == 20_usize {
+        1048576_u128
+    } else if exp == 21_usize {
+        2097152_u128
+    } else if exp == 22_usize {
+        4194304_u128
+    } else if exp == 23_usize {
+        8388608_u128
+    } else if exp == 24_usize {
+        16777216_u128
+    } else if exp == 25_usize {
+        33554432_u128
+    } else if exp == 26_usize {
+        67108864_u128
+    } else if exp == 27_usize {
+        134217728_u128
+    } else if exp == 28_usize {
+        268435456_u128
+    } else if exp == 29_usize {
+        536870912_u128
+    } else if exp == 30_usize {
+        1073741824_u128
+    } else if exp == 31_usize {
+        2147483648_u128
+    } else if exp == 32_usize {
+        4294967296_u128
+    } else if exp == 33_usize {
+        8589934592_u128
+    } else if exp == 34_usize {
+        17179869184_u128
+    } else if exp == 35_usize {
+        34359738368_u128
+    } else if exp == 36_usize {
+        68719476736_u128
+    } else if exp == 37_usize {
+        137438953472_u128
+    } else if exp == 38_usize {
+        274877906944_u128
+    } else if exp == 39_usize {
+        549755813888_u128
+    } else if exp == 40_usize {
+        1099511627776_u128
+    } else if exp == 41_usize {
+        2199023255552_u128
+    } else if exp == 42_usize {
+        4398046511104_u128
+    } else if exp == 43_usize {
+        8796093022208_u128
+    } else if exp == 44_usize {
+        17592186044416_u128
+    } else if exp == 45_usize {
+        35184372088832_u128
+    } else if exp == 46_usize {
+        70368744177664_u128
+    } else if exp == 47_usize {
+        140737488355328_u128
+    } else if exp == 48_usize {
+        281474976710656_u128
+    } else if exp == 49_usize {
+        562949953421312_u128
+    } else if exp == 50_usize {
+        1125899906842624_u128
+    } else if exp == 51_usize {
+        2251799813685248_u128
+    } else if exp == 52_usize {
+        4503599627370496_u128
+    } else if exp == 53_usize {
+        9007199254740992_u128
+    } else if exp == 54_usize {
+        18014398509481984_u128
+    } else if exp == 55_usize {
+        36028797018963968_u128
+    } else if exp == 56_usize {
+        72057594037927936_u128
+    } else if exp == 57_usize {
+        144115188075855872_u128
+    } else if exp == 58_usize {
+        288230376151711744_u128
+    } else if exp == 59_usize {
+        576460752303423488_u128
+    } else if exp == 60_usize {
+        1152921504606846976_u128
+    } else if exp == 61_usize {
+        2305843009213693952_u128
+    } else if exp == 62_usize {
+        4611686018427387904_u128
+    } else if exp == 63_usize {
+        9223372036854775808_u128
+    } else if exp == 64_usize {
+        18446744073709551616_u128
+    } else if exp == 65_usize {
+        36893488147419103232_u128
+    } else if exp == 66_usize {
+        73786976294838206464_u128
+    } else if exp == 67_usize {
+        147573952589676412928_u128
+    } else if exp == 68_usize {
+        295147905179352825856_u128
+    } else if exp == 69_usize {
+        590295810358705651712_u128
+    } else if exp == 70_usize {
+        1180591620717411303424_u128
+    } else if exp == 71_usize {
+        2361183241434822606848_u128
+    } else if exp == 72_usize {
+        4722366482869645213696_u128
+    } else if exp == 73_usize {
+        9444732965739290427392_u128
+    } else if exp == 74_usize {
+        18889465931478580854784_u128
+    } else if exp == 75_usize {
+        37778931862957161709568_u128
+    } else if exp == 76_usize {
+        75557863725914323419136_u128
+    } else if exp == 77_usize {
+        151115727451828646838272_u128
+    } else if exp == 78_usize {
+        302231454903657293676544_u128
+    } else if exp == 79_usize {
+        604462909807314587353088_u128
+    } else if exp == 80_usize {
+        1208925819614629174706176_u128
+    } else if exp == 81_usize {
+        2417851639229258349412352_u128
+    } else if exp == 82_usize {
+        4835703278458516698824704_u128
+    } else if exp == 83_usize {
+        9671406556917033397649408_u128
+    } else if exp == 84_usize {
+        19342813113834066795298816_u128
+    } else if exp == 85_usize {
+        38685626227668133590597632_u128
+    } else if exp == 86_usize {
+        77371252455336267181195264_u128
+    } else if exp == 87_usize {
+        154742504910672534362390528_u128
+    } else if exp == 88_usize {
+        309485009821345068724781056_u128
+    } else if exp == 89_usize {
+        618970019642690137449562112_u128
+    } else if exp == 90_usize {
+        1237940039285380274899124224_u128
+    } else if exp == 91_usize {
+        2475880078570760549798248448_u128
+    } else if exp == 92_usize {
+        4951760157141521099596496896_u128
+    } else if exp == 93_usize {
+        9903520314283042199192993792_u128
+    } else if exp == 94_usize {
+        19807040628566084398385987584_u128
+    } else if exp == 95_usize {
+        39614081257132168796771975168_u128
+    } else if exp == 96_usize {
+        79228162514264337593543950336_u128
+    } else if exp == 97_usize {
+        158456325028528675187087900672_u128
+    } else if exp == 98_usize {
+        316912650057057350374175801344_u128
+    } else if exp == 99_usize {
+        633825300114114700748351602688_u128
+    } else if exp == 100_usize {
+        1267650600228229401496703205376_u128
+    } else if exp == 101_usize {
+        2535301200456458802993406410752_u128
+    } else if exp == 102_usize {
+        5070602400912917605986812821504_u128
+    } else if exp == 103_usize {
+        10141204801825835211973625643008_u128
+    } else if exp == 104_usize {
+        20282409603651670423947251286016_u128
+    } else if exp == 105_usize {
+        40564819207303340847894502572032_u128
+    } else if exp == 106_usize {
+        81129638414606681695789005144064_u128
+    } else if exp == 107_usize {
+        162259276829213363391578010288128_u128
+    } else if exp == 108_usize {
+        324518553658426726783156020576256_u128
+    } else if exp == 109_usize {
+        649037107316853453566312041152512_u128
+    } else if exp == 110_usize {
+        1298074214633706907132624082305024_u128
+    } else if exp == 111_usize {
+        2596148429267413814265248164610048_u128
+    } else if exp == 112_usize {
+        5192296858534827628530496329220096_u128
+    } else if exp == 113_usize {
+        10384593717069655257060992658440192_u128
+    } else if exp == 114_usize {
+        20769187434139310514121985316880384_u128
+    } else if exp == 115_usize {
+        41538374868278621028243970633760768_u128
+    } else if exp == 116_usize {
+        83076749736557242056487941267521536_u128
+    } else if exp == 117_usize {
+        166153499473114484112975882535043072_u128
+    } else if exp == 118_usize {
+        332306998946228968225951765070086144_u128
+    } else if exp == 119_usize {
+        664613997892457936451903530140172288_u128
+    } else if exp == 120_usize {
+        1329227995784915872903807060280344576_u128
+    } else if exp == 121_usize {
+        2658455991569831745807614120560689152_u128
+    } else if exp == 122_usize {
+        5316911983139663491615228241121378304_u128
+    } else if exp == 123_usize {
+        10633823966279326983230456482242756608_u128
+    } else if exp == 124_usize {
+        21267647932558653966460912964485513216_u128
+    } else if exp == 125_usize {
+        42535295865117307932921825928971026432_u128
+    } else if exp == 126_usize {
+        85070591730234615865843651857942052864_u128
+    } else {
+        170141183460469231731687303715884105728_u128
+    }
+}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`bytes` is an implementation similar to Solidity bytes written in Cairo 1.
It is notable for its built-in implementation of `Keccak` and `Sha256` hash functions, offering convenience for migrating EVM Contracts written in Solidity to the Starknet ecosystem.

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Add bytes implementation
- Add bytes unit tests

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

The implementation of `bytes` differs from `byte_array` in corelib. Each bytes array element stores 16 bytes and is designed to calculate byte stream hashes more quickly by trading more space for less computational cost.

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
