### PR TITLE
Fix ToAsciiArrayTrait::to_ascii_array return reversed array

### DIFF
--- a/src/ascii/src/interger.cairo
+++ b/src/ascii/src/interger.cairo
@@ -29,8 +29,7 @@ impl ToAsciiArrayTraitImpl<
 > of ToAsciiArrayTrait<T> {
     fn to_ascii_array(self: T) -> Array<felt252> {
         let mut new_arr = self.to_inverse_ascii_array();
-        new_arr.reverse();
-        new_arr
+        new_arr.reverse()
     }
 
     fn to_inverse_ascii_array(self: T) -> Array<felt252> {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, when I use `ToAsciiArrayTrait::to_ascii_array()`, it behaves the same as `ToAsciiArrayTrait::to_inverse_ascii_array()` and returns reversed array (123.to_ascii_array() == array!['3', '2', '1']).
The reason behind it is that `to_ascii_array()` reverses the array but returns the unmodified array (because `ArrayTraitExt::reverse()` does not mutate)

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- to_ascii_array() now returns ascii array with a correct order (123.to_ascii_array() == array!['1', '2', '3'])

## Does this introduce a breaking change?

- [ ] Yes, for code that relied on this buggy behavior
- [ ] No, for any other code

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
