### PR TITLE
Chore: Cleaning all imports

### DIFF
--- a/Scarb.toml
+++ b/Scarb.toml
@@ -20,5 +20,8 @@ homepage = "https://github.com/keep-starknet-strange/alexandria/"
 [workspace.dependencies]
 starknet = "=2.3.1"
 
+[workspace.tool.fmt]
+sort-module-level-items = true
+
 [scripts]
 all = "scarb build && scarb test"

--- a/src/ascii/Scarb.toml
+++ b/src/ascii/Scarb.toml
@@ -4,5 +4,8 @@ version = "0.1.0"
 description = "utilities for working with ascii values"
 homepage = "https://github.com/keep-starknet-strange/alexandria/tree/main/src/ascii"
 
+[tool]
+fmt.workspace = true
+
 [dependencies]
 alexandria_data_structures = { path = "../data_structures" }

--- a/src/ascii/src/integer.cairo
+++ b/src/ascii/src/integer.cairo
@@ -1,8 +1,4 @@
-use option::OptionTrait;
 use alexandria_data_structures::array_ext::ArrayTraitExt;
-use array::{ArrayTrait, SpanTrait};
-use traits::{Into, TryInto, DivRem};
-use zeroable::Zeroable;
 
 trait ToAsciiTrait<T, U> {
     fn to_ascii(self: T) -> U;
@@ -33,7 +29,7 @@ impl ToAsciiArrayTraitImpl<
     }
 
     fn to_inverse_ascii_array(self: T) -> Array<felt252> {
-        let mut new_arr = ArrayTrait::new();
+        let mut new_arr = array![];
         if self <= 9.try_into().unwrap() {
             new_arr.append(self.into() + 48);
             return new_arr;
@@ -101,7 +97,7 @@ impl BigIntegerToAsciiTraitImpl<
     +Copy<T>,
 > of ToAsciiTrait<T, Array<felt252>> {
     fn to_ascii(self: T) -> Array<felt252> {
-        let mut data = ArrayTrait::new();
+        let mut data = array![];
         if self <= 9.try_into().unwrap() {
             data.append(self.into() + 48);
             return data;
@@ -151,7 +147,7 @@ impl U256ToAsciiArrayTraitImpl of ToAsciiArrayTrait<u256> {
     }
 
     fn to_inverse_ascii_array(self: u256) -> Array<felt252> {
-        let mut new_arr = ArrayTrait::new();
+        let mut new_arr = array![];
         if self <= 9 {
             new_arr.append(self.try_into().expect('number overflow felt252') + 48);
             return new_arr;
@@ -173,7 +169,7 @@ impl U256ToAsciiArrayTraitImpl of ToAsciiArrayTrait<u256> {
 
 impl U256ToAsciiTraitImpl of ToAsciiTrait<u256, Array<felt252>> {
     fn to_ascii(self: u256) -> Array<felt252> {
-        let mut data = ArrayTrait::new();
+        let mut data = array![];
         if self <= 9 {
             data.append(self.try_into().expect('number overflow felt252') + 48);
             return data;

--- a/src/ascii/src/lib.cairo
+++ b/src/ascii/src/lib.cairo
@@ -1,5 +1,5 @@
 mod integer;
-use integer::{ToAsciiTrait, ToAsciiArrayTrait};
 
 #[cfg(test)]
 mod tests;
+use integer::{ToAsciiTrait, ToAsciiArrayTrait};

--- a/src/ascii/src/tests/test_ascii_integer.cairo
+++ b/src/ascii/src/tests/test_ascii_integer.cairo
@@ -1,7 +1,5 @@
-use array::ArrayTrait;
-use traits::{Into, TryInto};
-use integer::BoundedInt;
 use alexandria_ascii::ToAsciiTrait;
+use integer::BoundedInt;
 
 #[test]
 #[available_gas(2000000000)]

--- a/src/bytes/Scarb.toml
+++ b/src/bytes/Scarb.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 description = "An implementation similar to Solidity bytes written in Cairo 1"
 homepage = "https://github.com/keep-starknet-strange/alexandria/tree/main/src/bytes"
 
+[tool]
+fmt.workspace = true
+
 [dependencies]
 alexandria_math = { path = "../math" }
 alexandria_data_structures = { path = "../data_structures" }

--- a/src/bytes/src/bytes.cairo
+++ b/src/bytes/src/bytes.cairo
@@ -1,14 +1,8 @@
-use clone::Clone;
-use array::ArrayTrait;
-use traits::Into;
-use traits::TryInto;
-use traits::DivRem;
-use option::OptionTrait;
-use starknet::{ContractAddress, Felt252TryIntoContractAddress};
-use alexandria_math::sha256::sha256;
 use alexandria_bytes::utils::{
     u128_join, read_sub_u128, u128_split, u128_array_slice, keccak_u128s_be, u8_array_to_u256
 };
+use alexandria_math::sha256::sha256;
+use starknet::ContractAddress;
 
 /// Bytes is a dynamic array of u128, where each element contains 16 bytes.
 const BYTES_PER_ELEMENT: usize = 16;
@@ -120,11 +114,11 @@ impl BytesImpl of BytesTrait {
 
     #[inline(always)]
     fn new_empty() -> Bytes {
-        Bytes { size: 0_usize, data: ArrayTrait::<u128>::new() }
+        Bytes { size: 0_usize, data: array![] }
     }
 
     fn zero(size: usize) -> Bytes {
-        let mut data = ArrayTrait::<u128>::new();
+        let mut data = array![];
         let (data_index, mut data_len) = DivRem::div_rem(
             size, BYTES_PER_ELEMENT.try_into().expect('Division by 0')
         );
@@ -222,7 +216,7 @@ impl BytesImpl of BytesTrait {
         self: @Bytes, offset: usize, array_length: usize, element_size: usize
     ) -> (usize, Array<u128>) {
         assert(offset + array_length * element_size <= self.size(), 'out of bound');
-        let mut array = ArrayTrait::<u128>::new();
+        let mut array = array![];
 
         if array_length == 0 {
             return (offset, array);
@@ -340,7 +334,7 @@ impl BytesImpl of BytesTrait {
             return (offset, BytesTrait::new_empty());
         }
 
-        let mut array = ArrayTrait::<u128>::new();
+        let mut array = array![];
 
         // read full array element for sub_bytes
         let mut offset = offset;
@@ -519,7 +513,7 @@ impl BytesImpl of BytesTrait {
 
     /// sha256 hash
     fn sha256(self: @Bytes) -> u256 {
-        let mut hash_data: Array<u8> = ArrayTrait::new();
+        let mut hash_data: Array<u8> = array![];
         let mut i: usize = 0;
         let mut offset: usize = 0;
         loop {

--- a/src/bytes/src/bytes.cairo
+++ b/src/bytes/src/bytes.cairo
@@ -305,7 +305,7 @@ impl BytesImpl of BytesTrait {
     /// read a u256 array from Bytes
     fn read_u256_array(self: @Bytes, offset: usize, array_length: usize) -> (usize, Array<u256>) {
         assert(offset + array_length * 32 <= self.size(), 'out of bound');
-        let mut array = ArrayTrait::<u256>::new();
+        let mut array = array![];
 
         if array_length == 0 {
             return (offset, array);

--- a/src/bytes/src/lib.cairo
+++ b/src/bytes/src/lib.cairo
@@ -1,7 +1,7 @@
 mod bytes;
-mod utils;
-
-use bytes::{Bytes, BytesTrait};
 
 #[cfg(test)]
 mod tests;
+mod utils;
+
+use bytes::{Bytes, BytesTrait};

--- a/src/bytes/src/tests/test_bytes.cairo
+++ b/src/bytes/src/tests/test_bytes.cairo
@@ -1,8 +1,6 @@
-use traits::Into;
-use array::ArrayTrait;
-use starknet::{ContractAddress, ContractAddressIntoFelt252, contract_address_const};
 use alexandria_bytes::{Bytes, BytesTrait};
 use debug::PrintTrait;
+use starknet::{ContractAddress};
 
 #[test]
 #[available_gas(20000000)]
@@ -81,10 +79,11 @@ fn test_bytes_update() {
 #[test]
 #[available_gas(20000000)]
 fn test_bytes_read_u128_packed() {
-    let mut array = ArrayTrait::<u128>::new();
-    array.append(0x01020304050607080910111213141516);
-    array.append(0x01020304050607080910111213141516);
-    array.append(0x01020304050607080910000000000000);
+    let mut array = array![
+        0x01020304050607080910111213141516,
+        0x01020304050607080910111213141516,
+        0x01020304050607080910000000000000
+    ];
 
     let bytes = BytesTrait::new(42, array);
 
@@ -113,10 +112,11 @@ fn test_bytes_read_u128_packed() {
 #[available_gas(20000000)]
 #[should_panic(expected: ('out of bound',))]
 fn test_bytes_read_u128_packed_out_of_bound() {
-    let mut array = ArrayTrait::<u128>::new();
-    array.append(0x01020304050607080910111213141516);
-    array.append(0x01020304050607080910111213141516);
-    array.append(0x01020304050607080910000000000000);
+    let mut array = array![
+        0x01020304050607080910111213141516,
+        0x01020304050607080910111213141516,
+        0x01020304050607080910000000000000
+    ];
 
     let bytes = BytesTrait::new(42, array);
 
@@ -127,10 +127,11 @@ fn test_bytes_read_u128_packed_out_of_bound() {
 #[available_gas(20000000)]
 #[should_panic(expected: ('too large',))]
 fn test_bytes_read_u128_packed_too_large() {
-    let mut array = ArrayTrait::<u128>::new();
-    array.append(0x01020304050607080910111213141516);
-    array.append(0x01020304050607080910111213141516);
-    array.append(0x01020304050607080910000000000000);
+    let mut array = array![
+        0x01020304050607080910111213141516,
+        0x01020304050607080910111213141516,
+        0x01020304050607080910000000000000
+    ];
 
     let bytes = BytesTrait::new(42, array);
 
@@ -140,10 +141,11 @@ fn test_bytes_read_u128_packed_too_large() {
 #[test]
 #[available_gas(20000000)]
 fn test_bytes_read_u128_array_packed() {
-    let mut array = ArrayTrait::<u128>::new();
-    array.append(0x01020304050607080910111213141516);
-    array.append(0x01020304050607080910111213141516);
-    array.append(0x01020304050607080910000000000000);
+    let mut array = array![
+        0x01020304050607080910111213141516,
+        0x01020304050607080910111213141516,
+        0x01020304050607080910000000000000
+    ];
 
     let bytes = BytesTrait::new(42, array);
 
@@ -165,10 +167,11 @@ fn test_bytes_read_u128_array_packed() {
 #[available_gas(20000000)]
 #[should_panic(expected: ('out of bound',))]
 fn test_bytes_read_u128_array_packed_out_of_bound() {
-    let mut array = ArrayTrait::<u128>::new();
-    array.append(0x01020304050607080910111213141516);
-    array.append(0x01020304050607080910111213141516);
-    array.append(0x01020304050607080910000000000000);
+    let mut array = array![
+        0x01020304050607080910111213141516,
+        0x01020304050607080910111213141516,
+        0x01020304050607080910000000000000
+    ];
 
     let bytes = BytesTrait::new(42, array);
 
@@ -179,10 +182,11 @@ fn test_bytes_read_u128_array_packed_out_of_bound() {
 #[available_gas(20000000)]
 #[should_panic(expected: ('too large',))]
 fn test_bytes_read_u128_array_packed_too_large() {
-    let mut array = ArrayTrait::<u128>::new();
-    array.append(0x01020304050607080910111213141516);
-    array.append(0x01020304050607080910111213141516);
-    array.append(0x01020304050607080910000000000000);
+    let mut array = array![
+        0x01020304050607080910111213141516,
+        0x01020304050607080910111213141516,
+        0x01020304050607080910000000000000
+    ];
 
     let bytes = BytesTrait::new(42, array);
 
@@ -192,10 +196,11 @@ fn test_bytes_read_u128_array_packed_too_large() {
 #[test]
 #[available_gas(20000000)]
 fn test_bytes_read_felt252_packed() {
-    let mut array = ArrayTrait::<u128>::new();
-    array.append(0x01020304050607080910111213141516);
-    array.append(0x01020304050607080910111213141516);
-    array.append(0x01020304050607080910000000000000);
+    let mut array = array![
+        0x01020304050607080910111213141516,
+        0x01020304050607080910111213141516,
+        0x01020304050607080910000000000000
+    ];
 
     let bytes = BytesTrait::new(42, array);
 
@@ -208,10 +213,11 @@ fn test_bytes_read_felt252_packed() {
 #[available_gas(20000000)]
 #[should_panic(expected: ('out of bound',))]
 fn test_bytes_read_felt252_packed_out_of_bound() {
-    let mut array = ArrayTrait::<u128>::new();
-    array.append(0x01020304050607080910111213141516);
-    array.append(0x01020304050607080910111213141516);
-    array.append(0x01020304050607080910000000000000);
+    let mut array = array![
+        0x01020304050607080910111213141516,
+        0x01020304050607080910111213141516,
+        0x01020304050607080910000000000000
+    ];
 
     let bytes = BytesTrait::new(42, array);
 
@@ -222,10 +228,11 @@ fn test_bytes_read_felt252_packed_out_of_bound() {
 #[available_gas(20000000)]
 #[should_panic(expected: ('too large',))]
 fn test_bytes_read_felt252_packed_too_large() {
-    let mut array = ArrayTrait::<u128>::new();
-    array.append(0x01020304050607080910111213141516);
-    array.append(0x01020304050607080910111213141516);
-    array.append(0x01020304050607080910000000000000);
+    let mut array = array![
+        0x01020304050607080910111213141516,
+        0x01020304050607080910111213141516,
+        0x01020304050607080910000000000000
+    ];
 
     let bytes = BytesTrait::new(42, array);
 
@@ -235,10 +242,11 @@ fn test_bytes_read_felt252_packed_too_large() {
 #[test]
 #[available_gas(20000000)]
 fn test_bytes_read_u8() {
-    let mut array = ArrayTrait::<u128>::new();
-    array.append(0x01020304050607080910111213141516);
-    array.append(0x01020304050607080910111213141516);
-    array.append(0x01020304050607080910000000000000);
+    let mut array = array![
+        0x01020304050607080910111213141516,
+        0x01020304050607080910111213141516,
+        0x01020304050607080910000000000000
+    ];
 
     let bytes = BytesTrait::new(42, array);
 
@@ -250,10 +258,11 @@ fn test_bytes_read_u8() {
 #[test]
 #[available_gas(20000000)]
 fn test_bytes_read_u16() {
-    let mut array = ArrayTrait::<u128>::new();
-    array.append(0x01020304050607080910111213141516);
-    array.append(0x01020304050607080910111213141516);
-    array.append(0x01020304050607080910000000000000);
+    let mut array = array![
+        0x01020304050607080910111213141516,
+        0x01020304050607080910111213141516,
+        0x01020304050607080910000000000000
+    ];
 
     let bytes = BytesTrait::new(42, array);
 
@@ -265,10 +274,11 @@ fn test_bytes_read_u16() {
 #[test]
 #[available_gas(20000000)]
 fn test_bytes_read_u32() {
-    let mut array = ArrayTrait::<u128>::new();
-    array.append(0x01020304050607080910111213141516);
-    array.append(0x01020304050607080910111213141516);
-    array.append(0x01020304050607080910000000000000);
+    let mut array = array![
+        0x01020304050607080910111213141516,
+        0x01020304050607080910111213141516,
+        0x01020304050607080910000000000000
+    ];
 
     let bytes = BytesTrait::new(42, array);
 
@@ -280,10 +290,11 @@ fn test_bytes_read_u32() {
 #[test]
 #[available_gas(20000000)]
 fn test_bytes_read_usize() {
-    let mut array = ArrayTrait::<u128>::new();
-    array.append(0x01020304050607080910111213141516);
-    array.append(0x01020304050607080910111213141516);
-    array.append(0x01020304050607080910000000000000);
+    let mut array = array![
+        0x01020304050607080910111213141516,
+        0x01020304050607080910111213141516,
+        0x01020304050607080910000000000000
+    ];
 
     let bytes = BytesTrait::new(42, array);
 
@@ -295,10 +306,11 @@ fn test_bytes_read_usize() {
 #[test]
 #[available_gas(20000000)]
 fn test_bytes_read_u64() {
-    let mut array = ArrayTrait::<u128>::new();
-    array.append(0x01020304050607080910111213141516);
-    array.append(0x01020304050607080910111213141516);
-    array.append(0x01020304050607080910000000000000);
+    let mut array = array![
+        0x01020304050607080910111213141516,
+        0x01020304050607080910111213141516,
+        0x01020304050607080910000000000000
+    ];
 
     let bytes = BytesTrait::new(42, array);
 
@@ -310,10 +322,11 @@ fn test_bytes_read_u64() {
 #[test]
 #[available_gas(20000000)]
 fn test_bytes_read_u128() {
-    let mut array = ArrayTrait::<u128>::new();
-    array.append(0x01020304050607080910111213141516);
-    array.append(0x01020304050607080910111213141516);
-    array.append(0x01020304050607080910000000000000);
+    let mut array = array![
+        0x01020304050607080910111213141516,
+        0x01020304050607080910111213141516,
+        0x01020304050607080910000000000000
+    ];
 
     let bytes = BytesTrait::new(42, array);
 
@@ -325,10 +338,11 @@ fn test_bytes_read_u128() {
 #[test]
 #[available_gas(20000000)]
 fn test_bytes_read_u256() {
-    let mut array = ArrayTrait::<u128>::new();
-    array.append(0x01020304050607080910111213141516);
-    array.append(0x01020304050607080910111213141516);
-    array.append(0x01020304050607080910000000000000);
+    let mut array = array![
+        0x01020304050607080910111213141516,
+        0x01020304050607080910111213141516,
+        0x01020304050607080910000000000000
+    ];
 
     let bytes = BytesTrait::new(42, array);
 
@@ -341,13 +355,14 @@ fn test_bytes_read_u256() {
 #[test]
 #[available_gas(20000000)]
 fn test_bytes_read_u256_array() {
-    let mut array = ArrayTrait::<u128>::new();
-    array.append(0x01020304050607080910111213141516);
-    array.append(0x16151413121110090807060504030201);
-    array.append(0x16151413121110090807060504030201);
-    array.append(0x01020304050607080910111213141516);
-    array.append(0x01020304050607080910111213141516);
-    array.append(0x16151413121110090000000000000000);
+    let mut array = array![
+        0x01020304050607080910111213141516,
+        0x16151413121110090807060504030201,
+        0x16151413121110090807060504030201,
+        0x01020304050607080910111213141516,
+        0x01020304050607080910111213141516,
+        0x16151413121110090000000000000000
+    ];
 
     let bytes = BytesTrait::new(88, array);
 
@@ -364,7 +379,7 @@ fn test_bytes_read_u256_array() {
 #[test]
 #[available_gas(20000000)]
 fn test_bytes_read_address() {
-    let mut array = ArrayTrait::<u128>::new();
+    let mut array = array![];
     array.append(0x01020304050607080910111213140154);
     array.append(0x01855d7796176b05d160196ff92381eb);
     array.append(0x7910f5446c2e0e04e13db2194a4f0000);
@@ -380,7 +395,7 @@ fn test_bytes_read_address() {
 #[test]
 #[available_gas(20000000)]
 fn test_bytes_read_bytes() {
-    let mut array = ArrayTrait::<u128>::new();
+    let mut array = array![];
     array.append(0x01020304050607080910111213140154);
     array.append(0x01855d7796176b05d160196ff92381eb);
     array.append(0x7910f5446c2e0e04e13db2194a4f0000);
@@ -499,9 +514,9 @@ fn test_bytes_append() {
     bytes = Bytes { size: size, data: data };
 
     // append_address
-    let address = contract_address_const::<
-        0x015401855d7796176b05d160196ff92381eb7910f5446c2e0e04e13db2194a4f
-    >();
+    let address = 0x015401855d7796176b05d160196ff92381eb7910f5446c2e0e04e13db2194a4f
+        .try_into()
+        .unwrap();
     bytes.append_address(address);
     let Bytes{size, mut data } = bytes;
     assert(size == 117, 'append_address_size');
@@ -605,7 +620,7 @@ fn test_bytes_keccak() {
     assert(res == hash, 'bytes_keccak_0');
 
     // u256{low: 1, high: 0}
-    let mut array = ArrayTrait::<u128>::new();
+    let mut array = array![];
     array.append(0);
     array.append(1);
     let bytes: Bytes = BytesTrait::new(32, array);
@@ -614,7 +629,7 @@ fn test_bytes_keccak() {
     assert(res == hash, 'bytes_keccak_1');
 
     // test_bytes_append bytes
-    let mut array = ArrayTrait::<u128>::new();
+    let mut array = array![];
     array.append(0x10111213141516171810111213141516);
     array.append(0x17180101020102030400000001000003);
     array.append(0x04050607080000000000000010111213);
@@ -642,7 +657,7 @@ fn test_bytes_sha256() {
 
     // u256{low: 1, high: 0}
     // 0x0000000000000000000000000000000000000000000000000000000000000001
-    let mut array = ArrayTrait::<u128>::new();
+    let mut array = array![];
     array.append(0);
     array.append(1);
     let bytes: Bytes = BytesTrait::new(32, array);
@@ -651,7 +666,7 @@ fn test_bytes_sha256() {
     assert(res == hash, 'bytes_sha256_1');
 
     // test_bytes_append bytes
-    let mut array = ArrayTrait::<u128>::new();
+    let mut array = array![];
     array.append(0x10111213141516171810111213141516);
     array.append(0x17180101020102030400000001000003);
     array.append(0x04050607080000000000000010111213);

--- a/src/bytes/src/tests/test_bytes.cairo
+++ b/src/bytes/src/tests/test_bytes.cairo
@@ -1,6 +1,5 @@
 use alexandria_bytes::{Bytes, BytesTrait};
-use debug::PrintTrait;
-use starknet::{ContractAddress};
+use starknet::ContractAddress;
 
 #[test]
 #[available_gas(20000000)]

--- a/src/bytes/src/utils.cairo
+++ b/src/bytes/src/utils.cairo
@@ -1,12 +1,12 @@
-use keccak::{u128_to_u64, u128_split as u128_split_to_u64, cairo_keccak};
-use integer::u128_byte_reverse;
 use alexandria_data_structures::array_ext::ArrayTraitExt;
+use integer::u128_byte_reverse;
+use keccak::{u128_to_u64, u128_split as u128_split_to_u64, cairo_keccak};
 
 /// Computes the keccak256 of multiple uint128 values.
 /// The values are interpreted as big-endian.
 /// https://github.com/starkware-libs/cairo/blob/main/corelib/src/keccak.cairo
 fn keccak_u128s_be(mut input: Span<u128>, n_bytes: usize) -> u256 {
-    let mut keccak_input: Array::<u64> = ArrayTrait::new();
+    let mut keccak_input: Array::<u64> = array![];
     let mut size = n_bytes;
     loop {
         match input.pop_front() {
@@ -119,7 +119,7 @@ fn u8_array_to_u256(arr: Span<u8>) -> u256 {
 }
 
 fn u64_array_slice(src: @Array<u64>, mut begin: usize, end: usize) -> Array<u64> {
-    let mut slice = ArrayTrait::new();
+    let mut slice = array![];
     let len = begin + end;
     loop {
         if begin >= len {
@@ -142,7 +142,7 @@ fn u64_array_slice(src: @Array<u64>, mut begin: usize, end: usize) -> Array<u64>
 /// # Returns
 /// * `Array<u128>` - The slice of the array.
 fn u128_array_slice(src: @Array<u128>, mut begin: usize, end: usize) -> Array<u128> {
-    let mut slice = ArrayTrait::new();
+    let mut slice = array![];
     let len = begin + end;
     loop {
         if begin >= len {

--- a/src/data_structures/Scarb.toml
+++ b/src/data_structures/Scarb.toml
@@ -4,5 +4,8 @@ version = "0.1.0"
 description = "A set of Cairo data structure libraries and algorithms"
 homepage = "https://github.com/keep-starknet-strange/alexandria/tree/main/src/data_structures"
 
+[tool]
+fmt.workspace = true
+
 [dependencies]
 alexandria_encoding = { path = "../encoding" }

--- a/src/data_structures/src/array_ext.cairo
+++ b/src/data_structures/src/array_ext.cairo
@@ -1,6 +1,3 @@
-use array::{ArrayTrait, SpanTrait};
-use option::{Option, OptionTrait};
-
 trait ArrayTraitExt<T> {
     fn append_all(ref self: Array<T>, ref arr: Array<T>);
     fn pop_front_n(ref self: Array<T>, n: usize);

--- a/src/data_structures/src/bit_array.cairo
+++ b/src/data_structures/src/bit_array.cairo
@@ -1,9 +1,9 @@
 use array::{serialize_array_helper, deserialize_array_helper};
+use byte_array::BYTES_IN_BYTES31_MINUS_ONE;
 use bytes_31::{
     one_shift_left_bytes_u128, one_shift_left_bytes_felt252, bytes31, BYTES_IN_U128,
     BYTES_IN_BYTES31,
 };
-use byte_array::BYTES_IN_BYTES31_MINUS_ONE;
 use integer::u512;
 use serde::into_felt252_based::SerdeImpl;
 use traits::DivRem;

--- a/src/data_structures/src/bit_array.cairo
+++ b/src/data_structures/src/bit_array.cairo
@@ -6,7 +6,6 @@ use bytes_31::{
 };
 use integer::u512;
 use serde::into_felt252_based::SerdeImpl;
-use traits::DivRem;
 
 const SELECT_BIT: u128 = 0b10;
 

--- a/src/data_structures/src/byte_array_ext.cairo
+++ b/src/data_structures/src/byte_array_ext.cairo
@@ -3,9 +3,8 @@ use alexandria_encoding::reversible::ArrayReversibleBytes;
 use array::{serialize_array_helper, deserialize_array_helper};
 use byte_array::ByteArray;
 use bytes_31::{one_shift_left_bytes_felt252, one_shift_left_bytes_u128, BYTES_IN_BYTES31};
-use core::serde::into_felt252_based::SerdeImpl;
 use integer::u512;
-use traits::DivRem;
+use serde::into_felt252_based::SerdeImpl;
 
 trait ByteArrayTraitExt {
     /// Appends an unsigned 16 bit integer encoded in big endian

--- a/src/data_structures/src/byte_array_ext.cairo
+++ b/src/data_structures/src/byte_array_ext.cairo
@@ -3,9 +3,9 @@ use alexandria_encoding::reversible::ArrayReversibleBytes;
 use array::{serialize_array_helper, deserialize_array_helper};
 use byte_array::ByteArray;
 use bytes_31::{one_shift_left_bytes_felt252, one_shift_left_bytes_u128, BYTES_IN_BYTES31};
+use core::serde::into_felt252_based::SerdeImpl;
 use integer::u512;
 use traits::DivRem;
-use core::serde::into_felt252_based::SerdeImpl;
 
 trait ByteArrayTraitExt {
     /// Appends an unsigned 16 bit integer encoded in big endian

--- a/src/data_structures/src/byte_array_reader.cairo
+++ b/src/data_structures/src/byte_array_reader.cairo
@@ -1,7 +1,6 @@
 use alexandria_data_structures::byte_array_ext::ByteArrayTraitExt;
 use byte_array::ByteArray;
 use bytes_31::one_shift_left_bytes_felt252;
-use core::clone::Clone;
 use integer::u512;
 
 /// A read-only snapshot of an underlying ByteArray that maintains

--- a/src/data_structures/src/byte_array_reader.cairo
+++ b/src/data_structures/src/byte_array_reader.cairo
@@ -1,8 +1,8 @@
-use integer::u512;
-use bytes_31::one_shift_left_bytes_felt252;
-use byte_array::ByteArray;
 use alexandria_data_structures::byte_array_ext::ByteArrayTraitExt;
+use byte_array::ByteArray;
+use bytes_31::one_shift_left_bytes_felt252;
 use core::clone::Clone;
+use integer::u512;
 
 /// A read-only snapshot of an underlying ByteArray that maintains
 /// sequential access to the integers encoded in the array

--- a/src/data_structures/src/lib.cairo
+++ b/src/data_structures/src/lib.cairo
@@ -4,7 +4,7 @@ mod byte_array_ext;
 mod byte_array_reader;
 mod queue;
 mod stack;
-mod vec;
 
 #[cfg(test)]
 mod tests;
+mod vec;

--- a/src/data_structures/src/queue.cairo
+++ b/src/data_structures/src/queue.cairo
@@ -1,6 +1,3 @@
-// Core lib imports
-use array::ArrayTrait;
-
 const ZERO_USIZE: usize = 0;
 
 struct Queue<T> {

--- a/src/data_structures/src/stack.cairo
+++ b/src/data_structures/src/stack.cairo
@@ -15,9 +15,9 @@
 
 // Core lib imports
 use dict::Felt252DictTrait;
+use nullable::NullableTrait;
 use option::OptionTrait;
 use traits::Into;
-use nullable::NullableTrait;
 
 trait StackTrait<S, T> {
     /// Creates a new Stack instance.

--- a/src/data_structures/src/stack.cairo
+++ b/src/data_structures/src/stack.cairo
@@ -13,12 +13,6 @@
 //! let item = stack.pop();
 //! ```
 
-// Core lib imports
-use dict::Felt252DictTrait;
-use nullable::NullableTrait;
-use option::OptionTrait;
-use traits::Into;
-
 trait StackTrait<S, T> {
     /// Creates a new Stack instance.
     fn new() -> S;

--- a/src/data_structures/src/tests/array_ext_test.cairo
+++ b/src/data_structures/src/tests/array_ext_test.cairo
@@ -1,6 +1,6 @@
-use core::option::OptionTrait;
-use array::{ArrayTrait, SpanTrait};
 use alexandria_data_structures::array_ext::{ArrayTraitExt, SpanTraitExt};
+use array::{ArrayTrait, SpanTrait};
+use core::option::OptionTrait;
 
 // dedup
 

--- a/src/data_structures/src/tests/array_ext_test.cairo
+++ b/src/data_structures/src/tests/array_ext_test.cairo
@@ -1,6 +1,4 @@
 use alexandria_data_structures::array_ext::{ArrayTraitExt, SpanTraitExt};
-use array::{ArrayTrait, SpanTrait};
-use core::option::OptionTrait;
 
 // dedup
 

--- a/src/data_structures/src/tests/bit_array_test.cairo
+++ b/src/data_structures/src/tests/bit_array_test.cairo
@@ -1,7 +1,7 @@
 use alexandria_data_structures::bit_array::{BitArray, BitArrayTrait, shift_bit};
-use integer::u512;
-use integer::BoundedInt;
 use bytes_31::one_shift_left_bytes_felt252;
+use integer::BoundedInt;
+use integer::u512;
 
 #[test]
 #[available_gas(30000000)]

--- a/src/data_structures/src/tests/byte_array_reader_test.cairo
+++ b/src/data_structures/src/tests/byte_array_reader_test.cairo
@@ -1,6 +1,7 @@
-use alexandria_data_structures::byte_array_ext::ByteArrayTraitExt;
-use alexandria_data_structures::byte_array_reader::ByteArrayReaderTrait;
 use alexandria_data_structures::tests::byte_array_ext_test::test_byte_array_64;
+use alexandria_data_structures::{
+    byte_array_ext::ByteArrayTraitExt, byte_array_reader::ByteArrayReaderTrait
+};
 use integer::u512;
 
 #[test]

--- a/src/data_structures/src/tests/byte_array_reader_test.cairo
+++ b/src/data_structures/src/tests/byte_array_reader_test.cairo
@@ -1,7 +1,7 @@
-use integer::u512;
 use alexandria_data_structures::byte_array_ext::ByteArrayTraitExt;
 use alexandria_data_structures::byte_array_reader::ByteArrayReaderTrait;
 use alexandria_data_structures::tests::byte_array_ext_test::test_byte_array_64;
+use integer::u512;
 
 #[test]
 #[available_gas(10000000)]

--- a/src/data_structures/src/tests/queue_test.cairo
+++ b/src/data_structures/src/tests/queue_test.cairo
@@ -1,8 +1,7 @@
+use alexandria_data_structures::queue::{Queue, QueueTrait};
 use array::ArrayTrait;
 use box::BoxTrait;
 use option::OptionTrait;
-
-use alexandria_data_structures::queue::{Queue, QueueTrait};
 
 #[test]
 #[available_gas(2000000)]

--- a/src/data_structures/src/tests/queue_test.cairo
+++ b/src/data_structures/src/tests/queue_test.cairo
@@ -1,7 +1,4 @@
 use alexandria_data_structures::queue::{Queue, QueueTrait};
-use array::ArrayTrait;
-use box::BoxTrait;
-use option::OptionTrait;
 
 #[test]
 #[available_gas(2000000)]

--- a/src/data_structures/src/tests/stack_test.cairo
+++ b/src/data_structures/src/tests/stack_test.cairo
@@ -1,10 +1,9 @@
-// Core lib imports
-use traits::{Into, TryInto};
-use option::OptionTrait;
-use integer::Felt252IntoU256;
-
 // Internal imports
 use alexandria_data_structures::stack::{StackTrait, Felt252Stack, NullableStack};
+use integer::Felt252IntoU256;
+use option::OptionTrait;
+// Core lib imports
+use traits::{Into, TryInto};
 
 
 fn stack_new_test<S, T, impl Stack: StackTrait<S, T>>(stack: @S) {

--- a/src/data_structures/src/tests/stack_test.cairo
+++ b/src/data_structures/src/tests/stack_test.cairo
@@ -1,9 +1,5 @@
 // Internal imports
 use alexandria_data_structures::stack::{StackTrait, Felt252Stack, NullableStack};
-use integer::Felt252IntoU256;
-use option::OptionTrait;
-// Core lib imports
-use traits::{Into, TryInto};
 
 
 fn stack_new_test<S, T, impl Stack: StackTrait<S, T>>(stack: @S) {

--- a/src/data_structures/src/tests/vec_test.cairo
+++ b/src/data_structures/src/tests/vec_test.cairo
@@ -1,9 +1,5 @@
 // Internal imports
 use alexandria_data_structures::vec::{Felt252Vec, NullableVec, VecTrait};
-use option::OptionTrait;
-use result::ResultTrait;
-// Core lib imports
-use traits::{Index, Into, TryInto};
 
 fn vec_new_test<V, T, impl Vec: VecTrait<V, T>>(vec: @V) {
     assert(vec.len() == 0, 'vec length should be 0');

--- a/src/data_structures/src/tests/vec_test.cairo
+++ b/src/data_structures/src/tests/vec_test.cairo
@@ -1,10 +1,9 @@
-// Core lib imports
-use traits::{Index, Into, TryInto};
-use option::OptionTrait;
-use result::ResultTrait;
-
 // Internal imports
 use alexandria_data_structures::vec::{Felt252Vec, NullableVec, VecTrait};
+use option::OptionTrait;
+use result::ResultTrait;
+// Core lib imports
+use traits::{Index, Into, TryInto};
 
 fn vec_new_test<V, T, impl Vec: VecTrait<V, T>>(vec: @V) {
     assert(vec.len() == 0, 'vec length should be 0');

--- a/src/data_structures/src/vec.cairo
+++ b/src/data_structures/src/vec.cairo
@@ -12,12 +12,6 @@
 //! ...
 //! ```
 
-// Core lib imports
-use core::nullable::NullableTrait;
-use dict::Felt252DictTrait;
-use option::OptionTrait;
-use traits::{Index, Into};
-
 trait VecTrait<V, T> {
     /// Creates a new V instance.
     /// Returns

--- a/src/encoding/Scarb.toml
+++ b/src/encoding/Scarb.toml
@@ -4,5 +4,8 @@ version = "0.1.0"
 description = "Encoding utilities"
 homepage = "https://github.com/keep-starknet-strange/alexandria/tree/main/src/encoding"
 
+[tool]
+fmt.workspace = true
+
 [dependencies]
 alexandria_math = { path = "../math" }

--- a/src/encoding/src/base64.cairo
+++ b/src/encoding/src/base64.cairo
@@ -1,8 +1,5 @@
 use alexandria_math::BitShift;
-use array::ArrayTrait;
 use integer::BoundedInt;
-use option::OptionTrait;
-use traits::{Into, TryInto};
 
 const U6_MAX: u128 = 0x3F;
 

--- a/src/encoding/src/base64.cairo
+++ b/src/encoding/src/base64.cairo
@@ -1,9 +1,8 @@
+use alexandria_math::BitShift;
 use array::ArrayTrait;
 use integer::BoundedInt;
 use option::OptionTrait;
 use traits::{Into, TryInto};
-
-use alexandria_math::BitShift;
 
 const U6_MAX: u128 = 0x3F;
 

--- a/src/encoding/src/reversible.cairo
+++ b/src/encoding/src/reversible.cairo
@@ -1,5 +1,4 @@
 use integer::u512;
-use traits::DivRem;
 
 const SELECT_BYTE: u16 = 0x100;
 const SELECT_BIT: u8 = 0b10;

--- a/src/encoding/src/tests/base64_test.cairo
+++ b/src/encoding/src/tests/base64_test.cairo
@@ -1,6 +1,4 @@
 use alexandria_encoding::base64::{Base64Encoder, Base64Decoder, Base64UrlEncoder, Base64UrlDecoder};
-use array::ArrayTrait;
-use debug::PrintTrait;
 
 #[test]
 #[available_gas(2000000000)]

--- a/src/encoding/src/tests/base64_test.cairo
+++ b/src/encoding/src/tests/base64_test.cairo
@@ -1,6 +1,6 @@
+use alexandria_encoding::base64::{Base64Encoder, Base64Decoder, Base64UrlEncoder, Base64UrlDecoder};
 use array::ArrayTrait;
 use debug::PrintTrait;
-use alexandria_encoding::base64::{Base64Encoder, Base64Decoder, Base64UrlEncoder, Base64UrlDecoder};
 
 #[test]
 #[available_gas(2000000000)]

--- a/src/encoding/src/tests/reversible_test.cairo
+++ b/src/encoding/src/tests/reversible_test.cairo
@@ -1,6 +1,4 @@
 use alexandria_encoding::reversible::{ReversibleBits, ReversibleBytes};
-
-use debug::PrintTrait;
 use integer::u512;
 
 #[test]

--- a/src/encoding/src/tests/reversible_test.cairo
+++ b/src/encoding/src/tests/reversible_test.cairo
@@ -1,7 +1,7 @@
 use alexandria_encoding::reversible::{ReversibleBits, ReversibleBytes};
-use integer::u512;
 
 use debug::PrintTrait;
+use integer::u512;
 
 #[test]
 #[available_gas(1000000)]

--- a/src/linalg/Scarb.toml
+++ b/src/linalg/Scarb.toml
@@ -3,3 +3,6 @@ name = "alexandria_linalg"
 version = "0.1.0"
 description = "A set of linear algebra libraries and algorithms"
 homepage = "https://github.com/keep-starknet-strange/alexandria/tree/main/src/linalg"
+
+[tool]
+fmt.workspace = true

--- a/src/linalg/src/dot.cairo
+++ b/src/linalg/src/dot.cairo
@@ -1,6 +1,6 @@
-use core::option::OptionTrait;
 //! Dot product of two arrays
 use array::SpanTrait;
+use core::option::OptionTrait;
 
 /// Compute the dot product for 2 given arrays.
 /// # Arguments

--- a/src/linalg/src/dot.cairo
+++ b/src/linalg/src/dot.cairo
@@ -1,6 +1,4 @@
 //! Dot product of two arrays
-use array::SpanTrait;
-use core::option::OptionTrait;
 
 /// Compute the dot product for 2 given arrays.
 /// # Arguments

--- a/src/linalg/src/tests/dot_test.cairo
+++ b/src/linalg/src/tests/dot_test.cairo
@@ -1,5 +1,5 @@
-use array::ArrayTrait;
 use alexandria_linalg::dot::dot;
+use array::ArrayTrait;
 
 #[test]
 #[available_gas(2000000)]

--- a/src/linalg/src/tests/dot_test.cairo
+++ b/src/linalg/src/tests/dot_test.cairo
@@ -1,5 +1,4 @@
 use alexandria_linalg::dot::dot;
-use array::ArrayTrait;
 
 #[test]
 #[available_gas(2000000)]

--- a/src/math/Scarb.toml
+++ b/src/math/Scarb.toml
@@ -4,6 +4,9 @@ version = "0.2.0"
 description = "A set of math libraries and algorithms"
 homepage = "https://github.com/keep-starknet-strange/alexandria/tree/main/src/math"
 
+[tool]
+fmt.workspace = true
+
 [dependencies]
 # dependency due to ArrayTraitExt::concat in ed25519.cairo
 alexandria_data_structures = { path = "../data_structures" }

--- a/src/math/src/collatz_sequence.cairo
+++ b/src/math/src/collatz_sequence.cairo
@@ -1,5 +1,4 @@
 //! # Collatz Sequence
-use array::ArrayTrait;
 
 /// Generates the Collatz sequence for a given number.
 /// # Arguments

--- a/src/math/src/ed25519.cairo
+++ b/src/math/src/ed25519.cairo
@@ -1,12 +1,12 @@
-use array::{ArrayTrait, SpanTrait};
-use traits::{Into, TryInto};
-use option::OptionTrait;
-use integer::u512;
-use alexandria_math::sha512::{sha512, SHA512_LEN};
+use alexandria_data_structures::array_ext::ArrayTraitExt;
 use alexandria_math::mod_arithmetics::{
     add_mod, sub_mod, mult_mod, div_mod, pow_mod, add_inverse_mod
 };
-use alexandria_data_structures::array_ext::ArrayTraitExt;
+use alexandria_math::sha512::{sha512, SHA512_LEN};
+use array::{ArrayTrait, SpanTrait};
+use integer::u512;
+use option::OptionTrait;
+use traits::{Into, TryInto};
 
 // As per RFC-8032: https://datatracker.ietf.org/doc/html/rfc8032#section-5.1.7
 // Variable namings in this function refer to naming in the RFC

--- a/src/math/src/ed25519.cairo
+++ b/src/math/src/ed25519.cairo
@@ -3,10 +3,7 @@ use alexandria_math::mod_arithmetics::{
     add_mod, sub_mod, mult_mod, div_mod, pow_mod, add_inverse_mod
 };
 use alexandria_math::sha512::{sha512, SHA512_LEN};
-use array::{ArrayTrait, SpanTrait};
 use integer::u512;
-use option::OptionTrait;
-use traits::{Into, TryInto};
 
 // As per RFC-8032: https://datatracker.ietf.org/doc/html/rfc8032#section-5.1.7
 // Variable namings in this function refer to naming in the RFC

--- a/src/math/src/fast_power.cairo
+++ b/src/math/src/fast_power.cairo
@@ -1,7 +1,4 @@
 //! # Fast power algorithm
-use array::ArrayTrait;
-use option::OptionTrait;
-use traits::{Into, TryInto};
 
 // Calculate the ( base ^ power ) mod modulus
 // using the fast powering algorithm # Arguments

--- a/src/math/src/gcd_of_n_numbers.cairo
+++ b/src/math/src/gcd_of_n_numbers.cairo
@@ -1,6 +1,4 @@
 //! # GCD for N numbers
-use array::SpanTrait;
-use option::OptionTrait;
 
 // Calculate the greatest common dividor for n numbers
 // # Arguments

--- a/src/math/src/karatsuba.cairo
+++ b/src/math/src/karatsuba.cairo
@@ -1,9 +1,6 @@
 //! # Karatsuba Multiplication.
 use cmp::max;
-
-// Internal imports.
 use super::{pow, count_digits_of_base};
-use traits::Into;
 
 /// Algorithm to multiply two numbers in O(n^1.6) running time
 /// # Arguments

--- a/src/math/src/karatsuba.cairo
+++ b/src/math/src/karatsuba.cairo
@@ -1,9 +1,9 @@
 //! # Karatsuba Multiplication.
 use cmp::max;
-use traits::Into;
 
 // Internal imports.
 use super::{pow, count_digits_of_base};
+use traits::Into;
 
 /// Algorithm to multiply two numbers in O(n^1.6) running time
 /// # Arguments

--- a/src/math/src/lib.cairo
+++ b/src/math/src/lib.cairo
@@ -16,13 +16,10 @@ mod sha512;
 #[cfg(test)]
 mod tests;
 mod zellers_congruence;
-use debug::PrintTrait;
 use integer::{
     u8_wide_mul, u16_wide_mul, u32_wide_mul, u64_wide_mul, u128_wide_mul, u256_overflow_mul,
     BoundedInt
 };
-use option::OptionTrait;
-use traits::Into;
 
 /// Raise a number to a power.
 /// O(log n) time complexity.

--- a/src/math/src/lib.cairo
+++ b/src/math/src/lib.cairo
@@ -1,10 +1,28 @@
-use option::OptionTrait;
-use traits::Into;
+mod aliquot_sum;
+mod armstrong_number;
+mod collatz_sequence;
+mod ed25519;
+mod extended_euclidean_algorithm;
+mod fast_power;
+mod fibonacci;
+mod gcd_of_n_numbers;
+mod karatsuba;
+mod keccak256;
+mod mod_arithmetics;
+mod perfect_number;
+mod sha256;
+mod sha512;
+
+#[cfg(test)]
+mod tests;
+mod zellers_congruence;
+use debug::PrintTrait;
 use integer::{
     u8_wide_mul, u16_wide_mul, u32_wide_mul, u64_wide_mul, u128_wide_mul, u256_overflow_mul,
     BoundedInt
 };
-use debug::PrintTrait;
+use option::OptionTrait;
+use traits::Into;
 
 /// Raise a number to a power.
 /// O(log n) time complexity.
@@ -110,22 +128,3 @@ impl U256BitShift of BitShift<u256> {
         x / pow(2, n)
     }
 }
-
-mod aliquot_sum;
-mod armstrong_number;
-mod collatz_sequence;
-mod ed25519;
-mod extended_euclidean_algorithm;
-mod fast_power;
-mod fibonacci;
-mod gcd_of_n_numbers;
-mod karatsuba;
-mod mod_arithmetics;
-mod perfect_number;
-mod sha256;
-mod sha512;
-mod zellers_congruence;
-mod keccak256;
-
-#[cfg(test)]
-mod tests;

--- a/src/math/src/mod_arithmetics.cairo
+++ b/src/math/src/mod_arithmetics.cairo
@@ -1,6 +1,4 @@
 use integer::u512;
-use option::OptionTrait;
-use traits::{Into, TryInto};
 
 /// Function that performs modular addition.
 /// # Arguments

--- a/src/math/src/mod_arithmetics.cairo
+++ b/src/math/src/mod_arithmetics.cairo
@@ -1,6 +1,6 @@
+use integer::u512;
 use option::OptionTrait;
 use traits::{Into, TryInto};
-use integer::u512;
 
 /// Function that performs modular addition.
 /// # Arguments

--- a/src/math/src/perfect_number.cairo
+++ b/src/math/src/perfect_number.cairo
@@ -1,5 +1,4 @@
 //! # Perfect Number.
-use array::ArrayTrait;
 
 /// Algorithm to determine if a number is a perfect number
 /// # Arguments

--- a/src/math/src/sha256.cairo
+++ b/src/math/src/sha256.cairo
@@ -1,9 +1,4 @@
-use array::{ArrayTrait, SpanTrait};
-use clone::Clone;
-use core::traits::TryInto;
 use integer::{u32_wrapping_add, BoundedInt};
-use option::OptionTrait;
-use traits::Into;
 
 fn ch(x: u32, y: u32, z: u32) -> u32 {
     (x & y) ^ ((x ^ BoundedInt::<u32>::max().into()) & z)

--- a/src/math/src/sha256.cairo
+++ b/src/math/src/sha256.cairo
@@ -1,6 +1,6 @@
-use core::traits::TryInto;
 use array::{ArrayTrait, SpanTrait};
 use clone::Clone;
+use core::traits::TryInto;
 use integer::{u32_wrapping_add, BoundedInt};
 use option::OptionTrait;
 use traits::Into;

--- a/src/math/src/sha512.cairo
+++ b/src/math/src/sha512.cairo
@@ -1,9 +1,9 @@
-use integer::{u64_wrapping_add, bitwise, BoundedInt};
-use traits::{Into, TryInto};
-use option::OptionTrait;
 use array::{ArrayTrait, SpanTrait};
+use integer::{u64_wrapping_add, bitwise, BoundedInt};
+use option::OptionTrait;
 
 use super::BitShift;
+use traits::{Into, TryInto};
 
 // Variable naming is compliant to RFC-6234 (https://datatracker.ietf.org/doc/html/rfc6234)
 

--- a/src/math/src/sha512.cairo
+++ b/src/math/src/sha512.cairo
@@ -1,9 +1,5 @@
-use array::{ArrayTrait, SpanTrait};
 use integer::{u64_wrapping_add, bitwise, BoundedInt};
-use option::OptionTrait;
-
 use super::BitShift;
-use traits::{Into, TryInto};
 
 // Variable naming is compliant to RFC-6234 (https://datatracker.ietf.org/doc/html/rfc6234)
 

--- a/src/math/src/tests.cairo
+++ b/src/math/src/tests.cairo
@@ -12,5 +12,5 @@ mod mod_arithmetics_test;
 mod perfect_number_test;
 mod sha256_test;
 mod sha512_test;
-mod zellers_congruence_test;
 mod test_keccak256;
+mod zellers_congruence_test;

--- a/src/math/src/tests/collatz_sequence_test.cairo
+++ b/src/math/src/tests/collatz_sequence_test.cairo
@@ -1,7 +1,4 @@
 use alexandria_math::collatz_sequence::sequence;
-use array::ArrayTrait;
-// Core library imports.
-use option::OptionTrait;
 
 #[test]
 #[available_gas(2000000)]

--- a/src/math/src/tests/collatz_sequence_test.cairo
+++ b/src/math/src/tests/collatz_sequence_test.cairo
@@ -1,8 +1,7 @@
+use alexandria_math::collatz_sequence::sequence;
+use array::ArrayTrait;
 // Core library imports.
 use option::OptionTrait;
-use array::ArrayTrait;
-
-use alexandria_math::collatz_sequence::sequence;
 
 #[test]
 #[available_gas(2000000)]

--- a/src/math/src/tests/ed25519_test.cairo
+++ b/src/math/src/tests/ed25519_test.cairo
@@ -1,9 +1,4 @@
 use alexandria_math::ed25519::{p, Point, verify_signature, SpanU8TryIntoPoint};
-use array::ArrayTrait;
-use core::array::SpanTrait;
-use core::option::OptionTrait;
-use debug::PrintTrait;
-use traits::TryInto;
 
 fn gen_msg() -> Span<u8> {
     // Hello World!

--- a/src/math/src/tests/ed25519_test.cairo
+++ b/src/math/src/tests/ed25519_test.cairo
@@ -1,7 +1,7 @@
-use core::option::OptionTrait;
-use core::array::SpanTrait;
 use alexandria_math::ed25519::{p, Point, verify_signature, SpanU8TryIntoPoint};
 use array::ArrayTrait;
+use core::array::SpanTrait;
+use core::option::OptionTrait;
 use debug::PrintTrait;
 use traits::TryInto;
 

--- a/src/math/src/tests/gcd_of_n_numbers_test.cairo
+++ b/src/math/src/tests/gcd_of_n_numbers_test.cairo
@@ -1,5 +1,5 @@
-use array::ArrayTrait;
 use alexandria_math::gcd_of_n_numbers::gcd;
+use array::ArrayTrait;
 
 #[test]
 #[available_gas(1000000000)]

--- a/src/math/src/tests/gcd_of_n_numbers_test.cairo
+++ b/src/math/src/tests/gcd_of_n_numbers_test.cairo
@@ -1,5 +1,4 @@
 use alexandria_math::gcd_of_n_numbers::gcd;
-use array::ArrayTrait;
 
 #[test]
 #[available_gas(1000000000)]

--- a/src/math/src/tests/math_test.cairo
+++ b/src/math/src/tests/math_test.cairo
@@ -1,5 +1,5 @@
 use alexandria_math::{pow, BitShift, count_digits_of_base};
-use integer::{BoundedInt};
+use integer::BoundedInt;
 
 // Test power function
 #[test]

--- a/src/math/src/tests/perfect_number_test.cairo
+++ b/src/math/src/tests/perfect_number_test.cairo
@@ -1,8 +1,7 @@
+use alexandria_math::perfect_number::{is_perfect_number, perfect_numbers};
+use array::ArrayTrait;
 // Core library imports.
 use option::OptionTrait;
-use array::ArrayTrait;
-
-use alexandria_math::perfect_number::{is_perfect_number, perfect_numbers};
 
 // is_perfect_number
 #[test]

--- a/src/math/src/tests/perfect_number_test.cairo
+++ b/src/math/src/tests/perfect_number_test.cairo
@@ -1,7 +1,4 @@
 use alexandria_math::perfect_number::{is_perfect_number, perfect_numbers};
-use array::ArrayTrait;
-// Core library imports.
-use option::OptionTrait;
 
 // is_perfect_number
 #[test]

--- a/src/math/src/tests/sha256_test.cairo
+++ b/src/math/src/tests/sha256_test.cairo
@@ -1,7 +1,4 @@
 use alexandria_math::sha256;
-use array::ArrayTrait;
-
-use debug::PrintTrait;
 
 #[test]
 #[available_gas(2000000000)]

--- a/src/math/src/tests/sha256_test.cairo
+++ b/src/math/src/tests/sha256_test.cairo
@@ -1,6 +1,8 @@
 use alexandria_math::sha256;
 use array::ArrayTrait;
 
+use debug::PrintTrait;
+
 #[test]
 #[available_gas(2000000000)]
 fn sha256_empty_test() {
@@ -450,8 +452,6 @@ fn sha256_lorem_ipsum_test() {
     assert(*result[30] == 0xEA, 'invalid result');
     assert(*result[31] == 0x44, 'invalid result');
 }
-
-use debug::PrintTrait;
 #[test]
 #[available_gas(10_000_000_000)]
 fn sha256_url() {

--- a/src/math/src/tests/sha256_test.cairo
+++ b/src/math/src/tests/sha256_test.cairo
@@ -92,7 +92,7 @@ fn sha256_lorem_ipsum_test() {
     // Lorem ipsum, or lsipsum as it is sometimes known, is dummy text used in laying out print, graphic or web designs.
     // The passage is attributed to an unknown typesetter in the 15th century who is thought to have scrambled parts of
     // Cicero's De Finibus Bonorum et Malorum for use in a type specimen book. It usually begins with
-    let mut input = ArrayTrait::<u8>::new();
+    let mut input = array![];
     input.append('L');
     input.append('o');
     input.append('r');

--- a/src/math/src/tests/sha512_test.cairo
+++ b/src/math/src/tests/sha512_test.cairo
@@ -1,5 +1,4 @@
 use alexandria_math::sha512::{WordOperations, sha512, Word64, Word64WordOperations};
-use array::ArrayTrait;
 
 fn get_lorem_ipsum() -> Array<u8> {
     let mut input: Array<u8> = array![

--- a/src/math/src/tests/sha512_test.cairo
+++ b/src/math/src/tests/sha512_test.cairo
@@ -1,5 +1,5 @@
-use array::ArrayTrait;
 use alexandria_math::sha512::{WordOperations, sha512, Word64, Word64WordOperations};
+use array::ArrayTrait;
 
 fn get_lorem_ipsum() -> Array<u8> {
     let mut input: Array<u8> = array![

--- a/src/math/src/tests/test_keccak256.cairo
+++ b/src/math/src/tests/test_keccak256.cairo
@@ -1,5 +1,4 @@
 use alexandria_math::keccak256::keccak256;
-use debug::PrintTrait;
 
 #[test]
 #[available_gas(2000000)]

--- a/src/math/src/tests/zellers_congruence_test.cairo
+++ b/src/math/src/tests/zellers_congruence_test.cairo
@@ -1,5 +1,5 @@
-use option::OptionTrait;
 use alexandria_math::zellers_congruence::day_of_week;
+use option::OptionTrait;
 
 
 // Define a test case function to avoid code duplication.

--- a/src/math/src/tests/zellers_congruence_test.cairo
+++ b/src/math/src/tests/zellers_congruence_test.cairo
@@ -1,6 +1,4 @@
 use alexandria_math::zellers_congruence::day_of_week;
-use option::OptionTrait;
-
 
 // Define a test case function to avoid code duplication.
 fn test_case(day: u128, month: u128, year: u128, expected: u128, error_expected: bool) {

--- a/src/merkle_tree/Scarb.toml
+++ b/src/merkle_tree/Scarb.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 description = "Merkle tree related stuff"
 homepage = "https://github.com/keep-starknet-strange/alexandria/tree/src/merkle_tree"
 
-[dependencies]
-starknet.workspace = true
+[tool]
+fmt.workspace = true

--- a/src/merkle_tree/src/merkle_tree.cairo
+++ b/src/merkle_tree/src/merkle_tree.cairo
@@ -40,8 +40,8 @@ struct Hasher {}
 /// Hasher impls.
 
 mod pedersen {
-    use pedersen::PedersenTrait;
     use hash::HashStateTrait;
+    use pedersen::PedersenTrait;
     use super::{Hasher, HasherTrait};
 
     impl PedersenHasherImpl of HasherTrait<Hasher> {
@@ -57,8 +57,8 @@ mod pedersen {
 }
 
 mod poseidon {
-    use poseidon::PoseidonTrait;
     use hash::HashStateTrait;
+    use poseidon::PoseidonTrait;
     use super::{Hasher, HasherTrait};
 
     impl PoseidonHasherImpl of HasherTrait<Hasher> {

--- a/src/merkle_tree/src/storage_proof.cairo
+++ b/src/merkle_tree/src/storage_proof.cairo
@@ -1,6 +1,6 @@
+use hash::HashStateTrait;
 use pedersen::PedersenTrait;
 use poseidon::PoseidonTrait;
-use hash::HashStateTrait;
 
 #[derive(Drop)]
 struct BinaryNode {

--- a/src/numeric/Scarb.toml
+++ b/src/numeric/Scarb.toml
@@ -3,3 +3,6 @@ name = "alexandria_numeric"
 version = "0.1.0"
 description = "A set of numerical analysis libraries and algorithms"
 homepage = "https://github.com/keep-starknet-strange/alexandria/tree/main/src/numeric"
+
+[tool]
+fmt.workspace = true

--- a/src/numeric/src/cumsum.cairo
+++ b/src/numeric/src/cumsum.cairo
@@ -1,6 +1,4 @@
 //! The cumulative sum of the elements.
-use array::{SpanTrait, ArrayTrait};
-use option::OptionTrait;
 
 /// Compute the cumulative sum of a sequence.
 /// # Arguments

--- a/src/numeric/src/diff.cairo
+++ b/src/numeric/src/diff.cairo
@@ -1,7 +1,4 @@
 //! The discrete difference of the elements.
-use array::{ArrayTrait, SpanTrait};
-use core::option::OptionTrait;
-use zeroable::Zeroable;
 
 /// Compute the discrete difference of a sorted sequence.
 /// # Arguments

--- a/src/numeric/src/diff.cairo
+++ b/src/numeric/src/diff.cairo
@@ -1,6 +1,6 @@
-use core::option::OptionTrait;
 //! The discrete difference of the elements.
 use array::{ArrayTrait, SpanTrait};
+use core::option::OptionTrait;
 use zeroable::Zeroable;
 
 /// Compute the discrete difference of a sorted sequence.

--- a/src/numeric/src/interpolate.cairo
+++ b/src/numeric/src/interpolate.cairo
@@ -1,7 +1,4 @@
 //! One-dimensional linear interpolation for monotonically increasing sample points.
-use array::SpanTrait;
-use traits::Into;
-use zeroable::Zeroable;
 
 #[derive(Serde, Copy, Drop, PartialEq)]
 enum Interpolation {

--- a/src/numeric/src/lib.cairo
+++ b/src/numeric/src/lib.cairo
@@ -1,7 +1,7 @@
 mod cumsum;
 mod diff;
 mod interpolate;
-mod trapezoidal_rule;
 
 #[cfg(test)]
 mod tests;
+mod trapezoidal_rule;

--- a/src/numeric/src/tests/cumsum_test.cairo
+++ b/src/numeric/src/tests/cumsum_test.cairo
@@ -1,5 +1,4 @@
 use alexandria_numeric::cumsum::cumsum;
-use array::ArrayTrait;
 
 #[test]
 #[available_gas(2000000)]

--- a/src/numeric/src/tests/cumsum_test.cairo
+++ b/src/numeric/src/tests/cumsum_test.cairo
@@ -1,5 +1,5 @@
-use array::ArrayTrait;
 use alexandria_numeric::cumsum::cumsum;
+use array::ArrayTrait;
 
 #[test]
 #[available_gas(2000000)]

--- a/src/numeric/src/tests/diff_test.cairo
+++ b/src/numeric/src/tests/diff_test.cairo
@@ -1,5 +1,5 @@
-use array::ArrayTrait;
 use alexandria_numeric::diff::diff;
+use array::ArrayTrait;
 
 #[test]
 #[available_gas(2000000)]

--- a/src/numeric/src/tests/diff_test.cairo
+++ b/src/numeric/src/tests/diff_test.cairo
@@ -1,5 +1,4 @@
 use alexandria_numeric::diff::diff;
-use array::ArrayTrait;
 
 #[test]
 #[available_gas(2000000)]

--- a/src/numeric/src/tests/interpolate_test.cairo
+++ b/src/numeric/src/tests/interpolate_test.cairo
@@ -1,5 +1,4 @@
 use alexandria_numeric::interpolate::{interpolate, Interpolation, Extrapolation};
-use array::ArrayTrait;
 
 #[test]
 #[available_gas(2000000)]

--- a/src/numeric/src/tests/interpolate_test.cairo
+++ b/src/numeric/src/tests/interpolate_test.cairo
@@ -1,5 +1,5 @@
-use array::ArrayTrait;
 use alexandria_numeric::interpolate::{interpolate, Interpolation, Extrapolation};
+use array::ArrayTrait;
 
 #[test]
 #[available_gas(2000000)]

--- a/src/numeric/src/tests/trapezoidal_rule_test.cairo
+++ b/src/numeric/src/tests/trapezoidal_rule_test.cairo
@@ -1,5 +1,4 @@
 use alexandria_numeric::trapezoidal_rule::trapezoidal_rule;
-use array::ArrayTrait;
 
 #[test]
 #[available_gas(2000000)]

--- a/src/numeric/src/tests/trapezoidal_rule_test.cairo
+++ b/src/numeric/src/tests/trapezoidal_rule_test.cairo
@@ -1,5 +1,5 @@
-use array::ArrayTrait;
 use alexandria_numeric::trapezoidal_rule::trapezoidal_rule;
+use array::ArrayTrait;
 
 #[test]
 #[available_gas(2000000)]

--- a/src/numeric/src/trapezoidal_rule.cairo
+++ b/src/numeric/src/trapezoidal_rule.cairo
@@ -1,7 +1,4 @@
 //! Integrate using the composite trapezoidal rule
-use array::SpanTrait;
-use traits::Into;
-use zeroable::Zeroable;
 
 /// Integrate y(x).
 /// # Arguments

--- a/src/numeric/src/trapezoidal_rule.cairo
+++ b/src/numeric/src/trapezoidal_rule.cairo
@@ -1,7 +1,7 @@
 //! Integrate using the composite trapezoidal rule
 use array::SpanTrait;
-use zeroable::Zeroable;
 use traits::Into;
+use zeroable::Zeroable;
 
 /// Integrate y(x).
 /// # Arguments

--- a/src/searching/Scarb.toml
+++ b/src/searching/Scarb.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 description = "A set of searching algorithms"
 homepage = "https://github.com/keep-starknet-strange/alexandria/tree/src/searching"
 
+[tool]
+fmt.workspace = true
+
 [dependencies]
 # dependency due to VecTrait usage in dijkstra.cairo
 alexandria_data_structures = { path = "../data_structures" }

--- a/src/searching/src/dijkstra.cairo
+++ b/src/searching/src/dijkstra.cairo
@@ -1,10 +1,10 @@
-//! Dijkstra algorithm using priority queue
-use option::OptionTrait;
-use box::BoxTrait;
 use array::{Array, ArrayTrait, SpanTrait};
-use traits::{Into, Index};
+use box::BoxTrait;
 use dict::Felt252DictTrait;
 use nullable::FromNullableResult;
+//! Dijkstra algorithm using priority queue
+use option::OptionTrait;
+use traits::{Into, Index};
 
 
 #[derive(Copy, Drop)]
@@ -39,12 +39,12 @@ impl DestructGraph<T, +Drop<T>, +Felt252DictValue<T>> of Destruct<Graph<T>> {
 
 impl GraphImpl of GraphTrait {
     fn new() -> Graph<Nullable<Span<Node>>> {
-        Graph { nodes: ArrayTrait::new(), adj_nodes: Default::default() }
+        Graph { nodes: array![], adj_nodes: Default::default() }
     }
 
     fn add_edge(ref self: Graph<Nullable<Span<Node>>>, source: u32, dest: u32, weight: u128) {
         let adj_nodes = self.adj_nodes.get(source.into());
-        let mut nodes: Array<Node> = ArrayTrait::new();
+        let mut nodes: Array<Node> = array![];
         let mut is_null: bool = false;
         let node = Node { source, dest, weight };
         let mut span = match match_nullable(adj_nodes) {
@@ -82,8 +82,8 @@ impl GraphImpl of GraphTrait {
 }
 
 fn dijkstra(ref self: Graph<Nullable<Span<Node>>>, source: u32) -> Felt252Dict<u128> {
-    let mut priority_queue = ArrayTrait::new();
-    let mut visited_node = ArrayTrait::new();
+    let mut priority_queue = array![];
+    let mut visited_node = array![];
     let mut dist: Felt252Dict<u128> = Default::default();
     let node_size = self.nodes.len();
     let nodes = self.nodes.span();

--- a/src/searching/src/dijkstra.cairo
+++ b/src/searching/src/dijkstra.cairo
@@ -1,11 +1,5 @@
-use array::{Array, ArrayTrait, SpanTrait};
-use box::BoxTrait;
-use dict::Felt252DictTrait;
 use nullable::FromNullableResult;
 //! Dijkstra algorithm using priority queue
-use option::OptionTrait;
-use traits::{Into, Index};
-
 
 #[derive(Copy, Drop)]
 struct Node {

--- a/src/searching/src/tests/binary_search_test.cairo
+++ b/src/searching/src/tests/binary_search_test.cairo
@@ -1,6 +1,4 @@
 use alexandria_searching::binary_search::binary_search;
-use array::ArrayTrait;
-use option::OptionTrait;
 
 #[test]
 #[available_gas(2000000)]

--- a/src/searching/src/tests/dijkstra_test.cairo
+++ b/src/searching/src/tests/dijkstra_test.cairo
@@ -1,11 +1,11 @@
-use debug::PrintTrait;
-use box::BoxTrait;
-use traits::Into;
-use option::OptionTrait;
+use alexandria_searching::dijkstra::{Graph, Node, GraphTrait};
 use array::{Array, ArrayTrait, SpanTrait};
+use box::BoxTrait;
+use debug::PrintTrait;
 use dict::Felt252DictTrait;
 use nullable::FromNullableResult;
-use alexandria_searching::dijkstra::{Graph, Node, GraphTrait};
+use option::OptionTrait;
+use traits::Into;
 
 
 #[test]

--- a/src/searching/src/tests/dijkstra_test.cairo
+++ b/src/searching/src/tests/dijkstra_test.cairo
@@ -1,11 +1,5 @@
 use alexandria_searching::dijkstra::{Graph, Node, GraphTrait};
-use array::{Array, ArrayTrait, SpanTrait};
-use box::BoxTrait;
-use debug::PrintTrait;
-use dict::Felt252DictTrait;
 use nullable::FromNullableResult;
-use option::OptionTrait;
-use traits::Into;
 
 
 #[test]

--- a/src/sorting/Scarb.toml
+++ b/src/sorting/Scarb.toml
@@ -3,3 +3,6 @@ name = "alexandria_sorting"
 version = "0.1.0"
 description = "A set of sorting algorithms"
 homepage = "https://github.com/keep-starknet-strange/alexandria/tree/src/sorting"
+
+[tool]
+fmt.workspace = true

--- a/src/sorting/src/bubble_sort.cairo
+++ b/src/sorting/src/bubble_sort.cairo
@@ -1,5 +1,4 @@
 //! Bubble sort algorithm
-use array::ArrayTrait;
 
 // Bubble sort
 /// # Arguments

--- a/src/sorting/src/lib.cairo
+++ b/src/sorting/src/lib.cairo
@@ -1,5 +1,5 @@
-mod merge_sort;
 mod bubble_sort;
+mod merge_sort;
 
 #[cfg(test)]
 mod tests;

--- a/src/sorting/src/lib.cairo
+++ b/src/sorting/src/lib.cairo
@@ -4,9 +4,6 @@ mod merge_sort;
 #[cfg(test)]
 mod tests;
 
-use array::SpanTrait;
-use option::OptionTrait;
-
 // Check if two arrays are equal.
 /// * `a` - The first array.
 /// * `b` - The second array.

--- a/src/sorting/src/merge_sort.cairo
+++ b/src/sorting/src/merge_sort.cairo
@@ -1,5 +1,4 @@
 //! Merge Sort
-use array::ArrayTrait;
 
 // Merge Sort
 /// # Arguments

--- a/src/sorting/src/tests/bubble_sort_test.cairo
+++ b/src/sorting/src/tests/bubble_sort_test.cairo
@@ -1,6 +1,5 @@
-use array::ArrayTrait;
-
 use alexandria_sorting::{is_equal, bubble_sort};
+use array::ArrayTrait;
 
 #[test]
 #[available_gas(20000000000000)]

--- a/src/sorting/src/tests/bubble_sort_test.cairo
+++ b/src/sorting/src/tests/bubble_sort_test.cairo
@@ -1,5 +1,4 @@
 use alexandria_sorting::{is_equal, bubble_sort};
-use array::ArrayTrait;
 
 #[test]
 #[available_gas(20000000000000)]

--- a/src/sorting/src/tests/merge_sort_test.cairo
+++ b/src/sorting/src/tests/merge_sort_test.cairo
@@ -1,5 +1,4 @@
 use alexandria_sorting::{is_equal, merge_sort::merge};
-use array::ArrayTrait;
 
 #[test]
 #[available_gas(2000000000)]

--- a/src/sorting/src/tests/merge_sort_test.cairo
+++ b/src/sorting/src/tests/merge_sort_test.cairo
@@ -1,6 +1,5 @@
-use array::ArrayTrait;
-
 use alexandria_sorting::{is_equal, merge_sort::merge};
+use array::ArrayTrait;
 
 #[test]
 #[available_gas(2000000000)]

--- a/src/storage/Scarb.toml
+++ b/src/storage/Scarb.toml
@@ -4,5 +4,8 @@ version = "0.2.0"
 description = "Starknet storage utilities"
 homepage = "https://github.com/keep-starknet-strange/alexandria/tree/src/storage"
 
+[tool]
+fmt.workspace = true
+
 [dependencies]
 starknet.workspace = true

--- a/src/storage/src/list.cairo
+++ b/src/storage/src/list.cairo
@@ -1,13 +1,10 @@
-use array::ArrayTrait;
 use integer::U32DivRem;
-use option::OptionTrait;
 use poseidon::poseidon_hash_span;
 use starknet::storage_access::{
     Store, StorageBaseAddress, storage_address_to_felt252, storage_address_from_base,
-    storage_address_from_base_and_offset, storage_base_address_from_felt252
+    storage_base_address_from_felt252
 };
 use starknet::{storage_read_syscall, storage_write_syscall, SyscallResult, SyscallResultTrait};
-use traits::{Default, DivRem, IndexView, Into, TryInto};
 
 const POW2_8: u32 = 256; // 2^8
 

--- a/src/storage/src/list.cairo
+++ b/src/storage/src/list.cairo
@@ -2,11 +2,11 @@ use array::ArrayTrait;
 use integer::U32DivRem;
 use option::OptionTrait;
 use poseidon::poseidon_hash_span;
-use starknet::{storage_read_syscall, storage_write_syscall, SyscallResult, SyscallResultTrait};
 use starknet::storage_access::{
     Store, StorageBaseAddress, storage_address_to_felt252, storage_address_from_base,
     storage_address_from_base_and_offset, storage_base_address_from_felt252
 };
+use starknet::{storage_read_syscall, storage_write_syscall, SyscallResult, SyscallResultTrait};
 use traits::{Default, DivRem, IndexView, Into, TryInto};
 
 const POW2_8: u32 = 256; // 2^8

--- a/src/storage/src/tests/list_test.cairo
+++ b/src/storage/src/tests/list_test.cairo
@@ -1,4 +1,3 @@
-use option::OptionTrait;
 use starknet::ContractAddress;
 
 #[starknet::interface]
@@ -24,7 +23,6 @@ trait IAListHolder<TContractState> {
 #[starknet::contract]
 mod AListHolder {
     use alexandria_storage::list::{List, ListTrait};
-    use option::OptionTrait;
     use starknet::ContractAddress;
 
     #[storage]
@@ -103,13 +101,8 @@ mod AListHolder {
 
 #[cfg(test)]
 mod tests {
-    use array::{ArrayTrait, SpanTrait};
-    use debug::PrintTrait;
-    use option::OptionTrait;
     use starknet::{ClassHash, ContractAddress, deploy_syscall, SyscallResultTrait};
-
     use super::{AListHolder, IAListHolderDispatcher, IAListHolderDispatcherTrait};
-    use traits::{Default, Into, TryInto};
 
     fn deploy_mock() -> IAListHolderDispatcher {
         let class_hash: ClassHash = AListHolder::TEST_CLASS_HASH.try_into().unwrap();

--- a/src/storage/src/tests/list_test.cairo
+++ b/src/storage/src/tests/list_test.cairo
@@ -107,9 +107,9 @@ mod tests {
     use debug::PrintTrait;
     use option::OptionTrait;
     use starknet::{ClassHash, ContractAddress, deploy_syscall, SyscallResultTrait};
-    use traits::{Default, Into, TryInto};
 
     use super::{AListHolder, IAListHolderDispatcher, IAListHolderDispatcherTrait};
+    use traits::{Default, Into, TryInto};
 
     fn deploy_mock() -> IAListHolderDispatcher {
         let class_hash: ClassHash = AListHolder::TEST_CLASS_HASH.try_into().unwrap();


### PR DESCRIPTION
Just cleaning all now redundant imports + use array![] macro where possible.
Also adding the scarb import format option