### PR TITLE
chore: bump version

### DIFF
--- a/Scarb.lock
+++ b/Scarb.lock
@@ -62,4 +62,4 @@ version = "0.1.0"
 
 [[package]]
 name = "alexandria_storage"
-version = "0.2.0"
+version = "0.3.0"

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -13,7 +13,7 @@ members = [
     "src/bytes",
 ]
 name = "alexandria"
-version = "0.1.0"
+version = "0.2.0"
 description = "Community maintained Cairo and Starknet libraries"
 homepage = "https://github.com/keep-starknet-strange/alexandria/"
 

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -13,7 +13,7 @@ members = [
     "src/bytes",
 ]
 name = "alexandria"
-version = "0.2.0"
+version = "0.1.0"
 description = "Community maintained Cairo and Starknet libraries"
 homepage = "https://github.com/keep-starknet-strange/alexandria/"
 

--- a/src/storage/Scarb.toml
+++ b/src/storage/Scarb.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alexandria_storage"
-version = "0.2.0"
+version = "0.3.0"
 description = "Starknet storage utilities"
 homepage = "https://github.com/keep-starknet-strange/alexandria/tree/src/storage"
 


### PR DESCRIPTION
Bumped the version of the package following breaking changes in the API brought by #209 