### PR TITLE
bugfix: fixed infinite loop bug on bubble sort

### DIFF
--- a/src/sorting/src/bubble_sort.cairo
+++ b/src/sorting/src/bubble_sort.cairo
@@ -26,7 +26,7 @@ fn bubble_sort_elements<T, +Copy<T>, +Drop<T>, +PartialOrd<T>>(mut array: Array<
             idx2 = 1;
             sorted_iteration = 0;
         } else {
-            if *array[idx1] < *array[idx2] {
+            if *array[idx1] <= *array[idx2] {
                 sorted_array.append(*array[idx1]);
                 idx1 = idx2;
                 idx2 += 1;

--- a/src/sorting/src/tests/bubble_sort_test.cairo
+++ b/src/sorting/src/tests/bubble_sort_test.cairo
@@ -44,3 +44,14 @@ fn bubblesort_test_pre_sorted() {
 
     assert(is_equal(sorted.span(), correct.span()), 'invalid result');
 }
+
+#[test]
+#[available_gas(2000000)]
+fn bubblesort_test_2_same_values() {
+    let mut data = array![1_u32, 2_u32, 2_u32, 4_u32];
+    let mut correct = array![1_u32, 2_u32, 2_u32, 4_u32];
+
+    let sorted = bubble_sort::bubble_sort_elements(data);
+
+    assert(is_equal(sorted.span(), correct.span()), 'invalid result');
+}


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Issue Number: #217 

## What is the new behavior?

- Bubble sort don't infinite loop anymore when there is equal values

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

Also added a test to ensure the problem doesn't happen again
