### PR TITLE
feat: byte appender and byte reader support for list storage structure

### DIFF
--- a/Scarb.lock
+++ b/Scarb.lock
@@ -21,6 +21,7 @@ name = "alexandria_data_structures"
 version = "0.2.0"
 dependencies = [
  "alexandria_encoding",
+ "alexandria_storage",
 ]
 
 [[package]]

--- a/src/data_structures/Scarb.toml
+++ b/src/data_structures/Scarb.toml
@@ -9,3 +9,4 @@ fmt.workspace = true
 
 [dependencies]
 alexandria_encoding = { path = "../encoding" }
+alexandria_storage = { path = "../storage" }

--- a/src/data_structures/src/lib.cairo
+++ b/src/data_structures/src/lib.cairo
@@ -3,6 +3,7 @@ mod bit_array;
 mod byte_appender;
 mod byte_array_ext;
 mod byte_reader;
+mod list_ext;
 mod queue;
 mod stack;
 

--- a/src/data_structures/src/list_ext.cairo
+++ b/src/data_structures/src/list_ext.cairo
@@ -1,0 +1,74 @@
+use alexandria_data_structures::byte_appender::{ByteAppenderImpl, ByteAppenderSupportTrait};
+use alexandria_data_structures::byte_reader::{ByteReaderImpl, Len};
+use alexandria_storage::list::{AListIndexViewImpl, List, ListTrait};
+use bytes_31::{one_shift_left_bytes_u128};
+
+impl ListU8LenImpl of Len<List<u8>> {
+    #[inline(always)]
+    fn len(self: @List<u8>) -> usize {
+        ListTrait::<u8>::len(self)
+    }
+}
+
+impl ListU8IndexView of IndexView<List<u8>, usize, @u8> {
+    #[inline(always)]
+    fn index(self: @List<u8>, index: usize) -> @u8 {
+        @AListIndexViewImpl::<u8>::index(self, index)
+    }
+}
+impl ListU8ReaderImpl = ByteReaderImpl<List<u8>>;
+
+impl ByteAppenderSupportListU8Impl of ByteAppenderSupportTrait<List<u8>> {
+    fn append_bytes_be(ref self: List<u8>, bytes: felt252, mut count: usize) {
+        assert(count <= 31, 'count too big');
+        let u256{low, high } = bytes.into();
+        loop {
+            if count <= 16 {
+                break;
+            }
+            let next = (high / one_shift_left_bytes_u128(count - 17)) % 0x100;
+            // Unwrap safe by definition of modulus operation 0x100
+            self.append(next.try_into().unwrap());
+            count -= 1;
+        };
+        loop {
+            if count == 0 {
+                break;
+            }
+            let next = (low / one_shift_left_bytes_u128(count - 1)) % 0x100;
+            // Unwrap safe by definition of modulus operation 0x100
+            self.append(next.try_into().unwrap());
+            count -= 1;
+        };
+    }
+
+    fn append_bytes_le(ref self: List<u8>, bytes: felt252, count: usize) {
+        assert(count <= 31, 'count too big');
+        let u256{mut low, mut high } = bytes.into();
+        let mut current = 0;
+        let mut index = 0;
+        loop {
+            if index == count {
+                break;
+            }
+            if count <= 16 {
+                current = low;
+            } else {
+                current = high;
+            }
+            loop {
+                if index == 16 || index == count {
+                    break;
+                }
+                let (remaining_bytes, next) = DivRem::div_rem(
+                    current, 0x100_u128.try_into().unwrap()
+                );
+                current = remaining_bytes;
+                // Unwrap safe by definition of remainder from division by 0x100
+                self.append(next.try_into().unwrap());
+                index += 1;
+            };
+        };
+    }
+}
+impl ListU8ByteAppenderImpl = ByteAppenderImpl<List<u8>>;

--- a/src/data_structures/src/tests.cairo
+++ b/src/data_structures/src/tests.cairo
@@ -3,6 +3,7 @@ mod bit_array_test;
 mod byte_appender_test;
 mod byte_array_ext_test;
 mod byte_reader_test;
+mod list_ext_test;
 mod queue_test;
 mod stack_test;
 mod vec_test;

--- a/src/data_structures/src/tests/list_ext_test.cairo
+++ b/src/data_structures/src/tests/list_ext_test.cairo
@@ -1,0 +1,42 @@
+use alexandria_data_structures::byte_appender::ByteAppender;
+use alexandria_data_structures::byte_reader::ByteReader;
+use alexandria_data_structures::list_ext::{ListU8ByteAppenderImpl, ListU8ReaderImpl};
+use alexandria_storage::list::ListTrait;
+use alexandria_storage::tests::list_test::tests::{deploy_mock};
+use alexandria_storage::tests::list_test::{
+    AListHolder, AListHolder::numbersContractMemberStateTrait
+};
+use integer::BoundedInt;
+use starknet::testing::set_contract_address;
+
+#[test]
+#[available_gas(20000000)]
+fn list_append_read() {
+    let contract = deploy_mock();
+    set_contract_address(contract.contract_address);
+    let mut contract_state = AListHolder::unsafe_new_contract_state();
+    let numbers_address = contract_state.numbers.address();
+    let mut list = ListTrait::<u8>::new(0, numbers_address);
+    list.append_i8(BoundedInt::min() + 1);
+    list.append_i16(BoundedInt::min() + 2);
+    list.append_i32(BoundedInt::min() + 3);
+    list.append_i64(BoundedInt::min() + 4);
+    list.append_i128(BoundedInt::min() + 5);
+    list.append_u16(BoundedInt::max() - 1);
+    list.append_u32(BoundedInt::max() - 2);
+    list.append_u64(BoundedInt::max() - 3);
+    list.append_u128(BoundedInt::max() - 4);
+    list.append_u256(BoundedInt::max() - 5);
+
+    let mut reader = list.reader();
+    assert(reader.read_i8().unwrap() == BoundedInt::min() + 1, 'test fail');
+    assert(reader.read_i16().unwrap() == BoundedInt::min() + 2, 'test fail');
+    assert(reader.read_i32().unwrap() == BoundedInt::min() + 3, 'test fail');
+    assert(reader.read_i64().unwrap() == BoundedInt::min() + 4, 'test fail');
+    assert(reader.read_i128().unwrap() == BoundedInt::min() + 5, 'test fail');
+    assert(reader.read_u16().unwrap() == BoundedInt::max() - 1, 'test fail');
+    assert(reader.read_u32().unwrap() == BoundedInt::max() - 2, 'test fail');
+    assert(reader.read_u64().unwrap() == BoundedInt::max() - 3, 'test fail');
+    assert(reader.read_u128().unwrap() == BoundedInt::max() - 4, 'test fail');
+    assert(reader.read_u256().unwrap() == BoundedInt::max() - 5, 'test fail');
+}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds support for writing (appender) arbitrary signed and unsigned integer values onto a `List<u8>` of bytes
- Adds reader support from a list of bytes
- Is this actually useful or will the List need to pack bytes onto a `bytes31` first and then `List<bytes31>`?
- Will contracts support storing `ByteArray` directly?

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
