### PR TITLE
Fix: handel warnings

### DIFF
--- a/src/bytes/src/bytes.cairo
+++ b/src/bytes/src/bytes.cairo
@@ -490,7 +490,7 @@ impl BytesImpl of BytesTrait {
         // process last array element for right
         let sub_bytes_last_element_size = *other.size % BYTES_PER_ELEMENT;
         if sub_bytes_last_element_size > 0 {
-            let (new_offset, value) = other.read_u128_packed(offset, sub_bytes_last_element_size);
+            let (_, value) = other.read_u128_packed(offset, sub_bytes_last_element_size);
             self.append_u128_packed(value, sub_bytes_last_element_size);
         }
     }

--- a/src/data_structures/src/array_ext.cairo
+++ b/src/data_structures/src/array_ext.cairo
@@ -49,7 +49,7 @@ impl ArrayImpl<T, +Copy<T>, +Drop<T>> of ArrayTraitExt<T> {
                 break;
             }
             match self.pop_front() {
-                Option::Some(v) => { n -= 1; },
+                Option::Some(_) => { n -= 1; },
                 Option::None => { break; },
             };
         };
@@ -135,7 +135,7 @@ impl SpanImpl<T, +Copy<T>, +Drop<T>> of SpanTraitExt<T> {
                 break;
             }
             match self.pop_front() {
-                Option::Some(v) => { n -= 1; },
+                Option::Some(_) => { n -= 1; },
                 Option::None => { break; },
             };
         };
@@ -147,7 +147,7 @@ impl SpanImpl<T, +Copy<T>, +Drop<T>> of SpanTraitExt<T> {
                 break;
             }
             match self.pop_back() {
-                Option::Some(v) => { n -= 1; },
+                Option::Some(_) => { n -= 1; },
                 Option::None => { break; },
             };
         };

--- a/src/data_structures/src/byte_appender.cairo
+++ b/src/data_structures/src/byte_appender.cairo
@@ -23,7 +23,7 @@ trait ByteAppenderSupportTrait<T> {
 impl ByteAppenderSupportArrayU8Impl of ByteAppenderSupportTrait<Array<u8>> {
     fn append_bytes_be(ref self: Array<u8>, bytes: felt252, mut count: usize) {
         assert(count <= 16, 'count too big');
-        let u256{low, high } = bytes.into();
+        let u256{low, high: _high } = bytes.into();
         loop {
             if count == 0 {
                 break;
@@ -37,7 +37,7 @@ impl ByteAppenderSupportArrayU8Impl of ByteAppenderSupportTrait<Array<u8>> {
 
     fn append_bytes_le(ref self: Array<u8>, bytes: felt252, count: usize) {
         assert(count <= 16, 'count too big');
-        let u256{mut low, high } = bytes.into();
+        let u256{mut low, high: _high } = bytes.into();
         let mut index = 0;
         loop {
             if index == count {
@@ -61,7 +61,7 @@ impl ByteAppenderSupportByteArrayImpl of ByteAppenderSupportTrait<ByteArray> {
     #[inline(always)]
     fn append_bytes_le(ref self: ByteArray, bytes: felt252, count: usize) {
         assert(count <= 16, 'count too big');
-        let u256{low, high } = bytes.into();
+        let u256{low, high: _high } = bytes.into();
         let (reversed, _) = reversing(low, count, 0x100);
         self.append_word(reversed.into(), count);
     }

--- a/src/linalg/src/dot.cairo
+++ b/src/linalg/src/dot.cairo
@@ -13,7 +13,6 @@ fn dot<T, +Mul<T>, +AddEq<T>, +Zeroable<T>, +Copy<T>, +Drop<T>,>(
     assert(xs.len() == ys.len(), 'Arrays must have the same len');
 
     // [Compute] Dot product in a loop
-    let mut index = 0;
     let mut value = Zeroable::zero();
     loop {
         match xs.pop_front() {

--- a/src/math/src/ed25519.cairo
+++ b/src/math/src/ed25519.cairo
@@ -95,7 +95,6 @@ impl SpanU8IntoU256 of Into<Span<u8>, u256> {
             return 0;
         }
         let mut ret: u256 = 0;
-        let mut i = 0;
         let two_pow_0 = 1;
         let two_pow_1 = 256;
         let two_pow_2 = 65536;
@@ -225,8 +224,6 @@ impl PointIntoExtendedHomogeneousPoint of Into<Point, ExtendedHomogeneousPoint> 
 fn point_mult(mut scalar: u256, mut P: ExtendedHomogeneousPoint) -> ExtendedHomogeneousPoint {
     let mut Q = ExtendedHomogeneousPoint { X: 0, Y: 1, Z: 1, T: 0 };
     let zero_u512 = Default::default();
-    let one_u512 = u512 { limb0: 1, limb1: 0, limb2: 0, limb3: 0 };
-    let two_non_zero: NonZero<u256> = integer::u256_try_as_non_zero(2).unwrap();
 
     // Double and add method
     loop {

--- a/src/math/src/keccak256.cairo
+++ b/src/math/src/keccak256.cairo
@@ -53,7 +53,7 @@ fn keccak256(mut self: Span<u8>) -> u256 {
             break (value, n_bytes);
         };
         let mut current_word = self.slice(0, 8);
-        let (value, n_bytes) = U64Trait::from_le_bytes(current_word);
+        let (value, _) = U64Trait::from_le_bytes(current_word);
         words64.append(value);
         self = self.slice(8, self.len() - 8);
     };

--- a/src/math/src/sha512.cairo
+++ b/src/math/src/sha512.cairo
@@ -323,9 +323,6 @@ fn sha512(mut data: Array<u8>) -> Array<u8> {
 
     let mut data = from_u8Array_to_WordArray(data);
 
-    let mut h = get_h();
-    let mut k = get_k();
-
     let hash = digest_hash(data.span(), msg_len);
     from_WordArray_to_u8array(hash.span())
 }

--- a/src/merkle_tree/src/storage_proof.cairo
+++ b/src/merkle_tree/src/storage_proof.cairo
@@ -82,9 +82,6 @@ fn verify(
 }
 
 fn traverse(expected_path: felt252, proof: Array<TrieNode>) -> (felt252, felt252) {
-    let mut path: felt252 = 0;
-    let mut remaining_depth: u8 = 251;
-
     let mut nodes = proof.span();
     let expected_path_u256: u256 = expected_path.into();
 

--- a/src/storage/src/list.cairo
+++ b/src/storage/src/list.cairo
@@ -228,7 +228,7 @@ impl ListImpl<T, +Copy<T>, +Drop<T>, +Store<T>> of ListTrait<T> {
     #[inline(always)]
     fn clean(ref self: List<T>) {
         self.len = 0;
-        Store::write(self.address_domain, self.base, self.len);
+        Store::write(self.address_domain, self.base, self.len).unwrap_syscall();
     }
 
     fn pop_front(ref self: List<T>) -> SyscallResult<Option<T>> {


### PR DESCRIPTION
This PR handles compiler warnings which are a new feature of the upcoming Cairo version. Today, it's visible only when compiling with the nightly version, i.e. building Alexandria after running the following (and removing the hardcoded Scarb version from .tools_versions):

```
asdf install scarb nightly-2024-01-13
asdb global scarb nightly-2024-01-13
```

## Pull Request type

- [x] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

ATM after running `Scarb build` with the nightly version, we get ~20 warnings. Most are due to unused variables, some due to unconsumed `Result`.

## What is the new behavior?

No warnings after compilation with nightly.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No