### PR TITLE
Simplify naming in `i257`

### DIFF
--- a/src/math/src/signed_u256.cairo
+++ b/src/math/src/signed_u256.cairo
@@ -5,8 +5,8 @@
 // The is_negative field is true for negative integers, and false for non-negative integers.
 #[derive(Serde, Copy, Drop, Hash)]
 struct i257 {
-    is_negative: bool,
     abs: u256,
+    is_negative: bool,
 }
 
 #[inline(always)]

--- a/src/math/src/signed_u256.cairo
+++ b/src/math/src/signed_u256.cairo
@@ -3,46 +3,30 @@
 // i257 represents a 129-bit integer.
 // The abs field holds the absolute value of the integer.
 // The is_negative field is true for negative integers, and false for non-negative integers.
-#[derive(Copy, Drop)]
+#[derive(Serde, Copy, Drop, Hash)]
 struct i257 {
     is_negative: bool,
     abs: u256,
 }
 
-
-// Checks if the given i257 integer is zero and has the correct sign.
-// # Arguments
-// * `x` - The i257 integer to check.
-// # Panics
-// Panics if `x` is zero and is not negative
-fn i257_assert_no_negative_zero(x: i257) {
-    if x.abs == 0 {
-        assert(!x.is_negative, 'negative zero');
+#[inline(always)]
+fn i257_new(abs: u256, is_negative: bool) -> i257 {
+    if abs == 0 {
+        i257 { abs, is_negative: false }
+    } else {
+        i257 { abs, is_negative }
     }
 }
 
+impl I128Default of Default<i257> {
+    fn default() -> i257 {
+        Zeroable::zero()
+    }
+}
 // Implements the Add trait for i257.
 impl i257Add of Add<i257> {
     fn add(lhs: i257, rhs: i257) -> i257 {
-        i257_assert_no_negative_zero(lhs);
-        i257_assert_no_negative_zero(rhs);
-        // If both integers have the same sign, 
-        // the sum of their absolute values can be returned.
-        if lhs.is_negative == rhs.is_negative {
-            let sum = lhs.abs + rhs.abs;
-            i257 { abs: sum, is_negative: lhs.is_negative }
-        } else {
-            // If the integers have different signs, 
-            // the larger absolute value is subtracted from the smaller one.
-            let (larger, smaller) = if lhs.abs >= rhs.abs {
-                (lhs, rhs)
-            } else {
-                (rhs, lhs)
-            };
-            let difference = larger.abs - smaller.abs;
-
-            i257 { abs: difference, is_negative: larger.is_negative }
-        }
+        i257_add(lhs, rhs)
     }
 }
 
@@ -57,16 +41,7 @@ impl i257AddEq of AddEq<i257> {
 // Implements the Sub trait for i257.
 impl i257Sub of Sub<i257> {
     fn sub(lhs: i257, rhs: i257) -> i257 {
-        i257_assert_no_negative_zero(lhs);
-        i257_assert_no_negative_zero(rhs);
-
-        if rhs.abs == 0 {
-            return lhs;
-        }
-
-        // The subtraction of `lhs` to `rhs` is achieved by negating `rhs` sign and adding it to `lhs`.
-        let neg_b = i257 { abs: rhs.abs, is_negative: !rhs.is_negative };
-        lhs + neg_b
+        i257_sub(lhs, rhs)
     }
 }
 
@@ -81,14 +56,7 @@ impl i257SubEq of SubEq<i257> {
 // Implements the Mul trait for i257.
 impl i257Mul of Mul<i257> {
     fn mul(lhs: i257, rhs: i257) -> i257 {
-        i257_assert_no_negative_zero(lhs);
-        i257_assert_no_negative_zero(rhs);
-
-        // The sign of the product is the XOR of the signs of the operands.
-        let is_negative = lhs.is_negative ^ rhs.is_negative;
-        // The product is the product of the absolute values of the operands.
-        let abs = lhs.abs * rhs.abs;
-        i257 { abs, is_negative }
+        i257_mul(lhs, rhs)
     }
 }
 
@@ -97,43 +65,6 @@ impl i257MulEq of MulEq<i257> {
     #[inline(always)]
     fn mul_eq(ref self: i257, other: i257) {
         self = Mul::mul(self, other);
-    }
-}
-
-// Divides the first i257 by the second i257.
-// # Arguments
-// * `lhs` - The i257 dividend.
-// * `rhs` - The i257 divisor.
-// # Returns
-// * `i257` - The quotient of `lhs` and `rhs`.
-fn i257_div(lhs: i257, rhs: i257) -> i257 {
-    i257_assert_no_negative_zero(lhs);
-    // Check that the divisor is not zero.
-    assert(rhs.abs != 0, 'b can not be 0');
-
-    // The sign of the quotient is the XOR of the signs of the operands.
-    let is_negative = lhs.is_negative ^ rhs.is_negative;
-
-    if !is_negative {
-        // If the operands are positive, the quotient is simply their absolute value quotient.
-        return i257 { abs: lhs.abs / rhs.abs, is_negative };
-    }
-
-    // If the operands have different signs, rounding is necessary.
-    // First, check if the quotient is an integer.
-    if lhs.abs % rhs.abs == 0 {
-        return i257 { abs: lhs.abs / rhs.abs, is_negative };
-    }
-
-    // If the quotient is not an integer, multiply the dividend by 10 to move the decimal point over.
-    let quotient = (lhs.abs * 10) / rhs.abs;
-    let last_digit = quotient % 10;
-
-    // Check the last digit to determine rounding direction.
-    if (last_digit <= 5) {
-        i257 { abs: quotient / 10, is_negative }
-    } else {
-        i257 { abs: (quotient / 10) + 1, is_negative }
     }
 }
 
@@ -152,19 +83,6 @@ impl i257DivEq of DivEq<i257> {
     }
 }
 
-// Calculates the remainder of the division of a first i257 by a second i257.
-// # Arguments
-// * `lhs` - The i257 dividend.
-// * `rhs` - The i257 divisor.
-// # Returns
-// * `i257` - The remainder of dividing `lhs` by `rhs`.
-fn i257_rem(lhs: i257, rhs: i257) -> i257 {
-    i257_assert_no_negative_zero(lhs);
-    // Check that the divisor is not zero.
-    assert(rhs.abs != 0, 'b can not be 0');
-    lhs - (rhs * (lhs / rhs))
-}
-
 // Implements the Rem trait for i257.
 impl i257Rem of Rem<i257> {
     fn rem(lhs: i257, rhs: i257) -> i257 {
@@ -178,18 +96,6 @@ impl i257RemEq of RemEq<i257> {
     fn rem_eq(ref self: i257, other: i257) {
         self = Rem::rem(self, other);
     }
-}
-
-// Calculates both the quotient and the remainder of the division of a first i257 by a second i257.
-// # Arguments
-// * `lhs` - The i257 dividend.
-// * `rhs` - The i257 divisor.
-// # Returns
-// * `(i257, i257)` - A tuple containing the quotient and the remainder of dividing `lhs` by `rhs`.
-fn i257_div_rem(lhs: i257, rhs: i257) -> (i257, i257) {
-    let quotient = i257_div(lhs, rhs);
-    let remainder = i257_rem(lhs, rhs);
-    (quotient, remainder)
 }
 
 // Implements the PartialEq trait for i257.
@@ -234,11 +140,167 @@ impl i257PartialOrd of PartialOrd<i257> {
     }
 }
 
+
+// Divides the first i257 by the second i257.
+
 // Implements the Neg trait for i257.
 impl i257Neg of Neg<i257> {
     fn neg(a: i257) -> i257 {
-        i257 { abs: a.abs, is_negative: !a.is_negative }
+        i257_neg(a)
     }
+}
+
+impl i257Zeroable of Zeroable<i257> {
+    fn zero() -> i257 {
+        i257_new(0, false)
+    }
+    fn is_zero(self: i257) -> bool {
+        self == Zeroable::zero()
+    }
+    fn is_non_zero(self: i257) -> bool {
+        self != Zeroable::zero()
+    }
+}
+
+// Checks if the given i257 integer is zero and has the correct sign.
+// # Arguments
+// * `x` - The i257 integer to check.
+// # Panics
+// Panics if `x` is zero and is not negative
+fn i257_assert_no_negative_zero(x: i257) {
+    if x.abs == 0 {
+        assert(!x.is_negative, 'negative zero');
+    }
+}
+
+// Adds two i257 integers.
+// # Arguments
+// * `a` - The first i257 to add.
+// * `b` - The second i257 to add.
+// # Returns
+// * `i257` - The sum of `a` and `b`.
+fn i257_add(lhs: i257, rhs: i257) -> i257 {
+    i257_assert_no_negative_zero(lhs);
+    i257_assert_no_negative_zero(rhs);
+    // If both integers have the same sign, 
+    // the sum of their absolute values can be returned.
+    if lhs.is_negative == rhs.is_negative {
+        let sum = lhs.abs + rhs.abs;
+        i257 { abs: sum, is_negative: lhs.is_negative }
+    } else {
+        // If the integers have different signs, 
+        // the larger absolute value is subtracted from the smaller one.
+        let (larger, smaller) = if lhs.abs >= rhs.abs {
+            (lhs, rhs)
+        } else {
+            (rhs, lhs)
+        };
+        let difference = larger.abs - smaller.abs;
+
+        i257 { abs: difference, is_negative: larger.is_negative }
+    }
+}
+
+// Subtracts two i257 integers.
+// # Arguments
+// * `lhs` - The first i257 to subtract.
+// * `rhs` - The second i257 to subtract.
+// # Returns
+// * `i257` - The difference of `a` and `b`.
+fn i257_sub(lhs: i257, rhs: i257) -> i257 {
+    i257_assert_no_negative_zero(lhs);
+    i257_assert_no_negative_zero(rhs);
+
+    if rhs.abs == 0 {
+        return lhs;
+    }
+
+    // The subtraction of `lhs` to `rhs` is achieved by negating `rhs` sign and adding it to `lhs`.
+    let neg_b = i257 { abs: rhs.abs, is_negative: !rhs.is_negative };
+    lhs + neg_b
+}
+
+// Multiplies two i257 integers.
+// 
+// # Arguments
+//
+// * `lhs` - The first i257 to multiply.
+// * `rhs` - The second i257 to multiply.
+//
+// # Returns
+//
+// * `i257` - The product of `a` and `b`.
+fn i257_mul(lhs: i257, rhs: i257) -> i257 {
+    i257_assert_no_negative_zero(lhs);
+    i257_assert_no_negative_zero(rhs);
+
+    // The sign of the product is the XOR of the signs of the operands.
+    let is_negative = lhs.is_negative ^ rhs.is_negative;
+    // The product is the product of the absolute values of the operands.
+    let abs = lhs.abs * rhs.abs;
+    i257 { abs, is_negative }
+}
+
+// Divides the first i257 by the second i128.
+// # Arguments
+// * `lhs` - The i257 dividend.
+// * `rhs` - The i257 divisor.
+// # Returns
+// * `i257` - The quotient of `lhs` and `rhs`.
+fn i257_div(lhs: i257, rhs: i257) -> i257 {
+    i257_assert_no_negative_zero(lhs);
+    // Check that the divisor is not zero.
+    assert(rhs.abs != 0, 'b can not be 0');
+
+    // The sign of the quotient is the XOR of the signs of the operands.
+    let is_negative = lhs.is_negative ^ rhs.is_negative;
+
+    if !is_negative {
+        // If the operands are positive, the quotient is simply their absolute value quotient.
+        return i257 { abs: lhs.abs / rhs.abs, is_negative };
+    }
+
+    // If the operands have different signs, rounding is necessary.
+    // First, check if the quotient is an integer.
+    if lhs.abs % rhs.abs == 0 {
+        return i257 { abs: lhs.abs / rhs.abs, is_negative };
+    }
+
+    // If the quotient is not an integer, multiply the dividend by 10 to move the decimal point over.
+    let quotient = (lhs.abs * 10) / rhs.abs;
+    let last_digit = quotient % 10;
+
+    // Check the last digit to determine rounding direction.
+    if last_digit <= 5 {
+        i257 { abs: quotient / 10, is_negative }
+    } else {
+        i257 { abs: (quotient / 10) + 1, is_negative }
+    }
+}
+
+// Calculates the remainder of the division of a first i257 by a second i257.
+// # Arguments
+// * `lhs` - The i257 dividend.
+// * `rhs` - The i257 divisor.
+// # Returns
+// * `i257` - The remainder of dividing `lhs` by `rhs`.
+fn i257_rem(lhs: i257, rhs: i257) -> i257 {
+    i257_assert_no_negative_zero(lhs);
+    // Check that the divisor is not zero.
+    assert(rhs.abs != 0, 'b can not be 0');
+    lhs - (rhs * (lhs / rhs))
+}
+
+// Calculates both the quotient and the remainder of the division of a first i257 by a second i257.
+// # Arguments
+// * `lhs` - The i257 dividend.
+// * `rhs` - The i257 divisor.
+// # Returns
+// * `(i257, i257)` - A tuple containing the quotient and the remainder of dividing `lhs` by `rhs`.
+fn i257_div_rem(lhs: i257, rhs: i257) -> (i257, i257) {
+    let quotient = i257_div(lhs, rhs);
+    let remainder = i257_rem(lhs, rhs);
+    (quotient, remainder)
 }
 
 // Computes the absolute value of the given i257 integer.
@@ -262,6 +324,11 @@ fn i257_max(lhs: i257, rhs: i257) -> i257 {
     } else {
         rhs
     }
+}
+
+fn i257_neg(x: i257) -> i257 {
+    // The negation of an integer is obtained by flipping its is_negative.
+    i257_new(x.abs, !x.is_negative)
 }
 
 // Computes the minimum between two i257 integers.

--- a/src/math/src/signed_u256.cairo
+++ b/src/math/src/signed_u256.cairo
@@ -26,26 +26,25 @@ impl I128Default of Default<i257> {
 // Implements the Add trait for i257.
 impl i257Add of Add<i257> {
     fn add(lhs: i257, rhs: i257) -> i257 {
-    i257_assert_no_negative_zero(lhs);
-    i257_assert_no_negative_zero(rhs);
-    // If both integers have the same sign, 
-    // the sum of their absolute values can be returned.
-    if lhs.is_negative == rhs.is_negative {
-        let sum = lhs.abs + rhs.abs;
-        i257 { abs: sum, is_negative: lhs.is_negative }
-    } else {
-        // If the integers have different signs, 
-        // the larger absolute value is subtracted from the smaller one.
-        let (larger, smaller) = if lhs.abs >= rhs.abs {
-            (lhs, rhs)
+        i257_assert_no_negative_zero(lhs);
+        i257_assert_no_negative_zero(rhs);
+        // If both integers have the same sign, 
+        // the sum of their absolute values can be returned.
+        if lhs.is_negative == rhs.is_negative {
+            let sum = lhs.abs + rhs.abs;
+            i257 { abs: sum, is_negative: lhs.is_negative }
         } else {
-            (rhs, lhs)
-        };
-        let difference = larger.abs - smaller.abs;
+            // If the integers have different signs, 
+            // the larger absolute value is subtracted from the smaller one.
+            let (larger, smaller) = if lhs.abs >= rhs.abs {
+                (lhs, rhs)
+            } else {
+                (rhs, lhs)
+            };
+            let difference = larger.abs - smaller.abs;
 
-        i257 { abs: difference, is_negative: larger.is_negative }
-    }
-
+            i257 { abs: difference, is_negative: larger.is_negative }
+        }
     }
 }
 
@@ -60,17 +59,16 @@ impl i257AddEq of AddEq<i257> {
 // Implements the Sub trait for i257.
 impl i257Sub of Sub<i257> {
     fn sub(lhs: i257, rhs: i257) -> i257 {
-    i257_assert_no_negative_zero(lhs);
-    i257_assert_no_negative_zero(rhs);
+        i257_assert_no_negative_zero(lhs);
+        i257_assert_no_negative_zero(rhs);
 
-    if rhs.abs == 0 {
-        return lhs;
-    }
+        if rhs.abs == 0 {
+            return lhs;
+        }
 
-    // The subtraction of `lhs` to `rhs` is achieved by negating `rhs` sign and adding it to `lhs`.
-    let neg_b = i257 { abs: rhs.abs, is_negative: !rhs.is_negative };
-    lhs + neg_b
-
+        // The subtraction of `lhs` to `rhs` is achieved by negating `rhs` sign and adding it to `lhs`.
+        let neg_b = i257 { abs: rhs.abs, is_negative: !rhs.is_negative };
+        lhs + neg_b
     }
 }
 
@@ -85,15 +83,14 @@ impl i257SubEq of SubEq<i257> {
 // Implements the Mul trait for i257.
 impl i257Mul of Mul<i257> {
     fn mul(lhs: i257, rhs: i257) -> i257 {
-    i257_assert_no_negative_zero(lhs);
-    i257_assert_no_negative_zero(rhs);
+        i257_assert_no_negative_zero(lhs);
+        i257_assert_no_negative_zero(rhs);
 
-    // The sign of the product is the XOR of the signs of the operands.
-    let is_negative = lhs.is_negative ^ rhs.is_negative;
-    // The product is the product of the absolute values of the operands.
-    let abs = lhs.abs * rhs.abs;
-    i257 { abs, is_negative }
-
+        // The sign of the product is the XOR of the signs of the operands.
+        let is_negative = lhs.is_negative ^ rhs.is_negative;
+        // The product is the product of the absolute values of the operands.
+        let abs = lhs.abs * rhs.abs;
+        i257 { abs, is_negative }
     }
 }
 

--- a/src/math/src/signed_u256.cairo
+++ b/src/math/src/signed_u256.cairo
@@ -26,7 +26,26 @@ impl I128Default of Default<i257> {
 // Implements the Add trait for i257.
 impl i257Add of Add<i257> {
     fn add(lhs: i257, rhs: i257) -> i257 {
-        i257_add(lhs, rhs)
+    i257_assert_no_negative_zero(lhs);
+    i257_assert_no_negative_zero(rhs);
+    // If both integers have the same sign, 
+    // the sum of their absolute values can be returned.
+    if lhs.is_negative == rhs.is_negative {
+        let sum = lhs.abs + rhs.abs;
+        i257 { abs: sum, is_negative: lhs.is_negative }
+    } else {
+        // If the integers have different signs, 
+        // the larger absolute value is subtracted from the smaller one.
+        let (larger, smaller) = if lhs.abs >= rhs.abs {
+            (lhs, rhs)
+        } else {
+            (rhs, lhs)
+        };
+        let difference = larger.abs - smaller.abs;
+
+        i257 { abs: difference, is_negative: larger.is_negative }
+    }
+
     }
 }
 
@@ -41,7 +60,17 @@ impl i257AddEq of AddEq<i257> {
 // Implements the Sub trait for i257.
 impl i257Sub of Sub<i257> {
     fn sub(lhs: i257, rhs: i257) -> i257 {
-        i257_sub(lhs, rhs)
+    i257_assert_no_negative_zero(lhs);
+    i257_assert_no_negative_zero(rhs);
+
+    if rhs.abs == 0 {
+        return lhs;
+    }
+
+    // The subtraction of `lhs` to `rhs` is achieved by negating `rhs` sign and adding it to `lhs`.
+    let neg_b = i257 { abs: rhs.abs, is_negative: !rhs.is_negative };
+    lhs + neg_b
+
     }
 }
 
@@ -56,7 +85,15 @@ impl i257SubEq of SubEq<i257> {
 // Implements the Mul trait for i257.
 impl i257Mul of Mul<i257> {
     fn mul(lhs: i257, rhs: i257) -> i257 {
-        i257_mul(lhs, rhs)
+    i257_assert_no_negative_zero(lhs);
+    i257_assert_no_negative_zero(rhs);
+
+    // The sign of the product is the XOR of the signs of the operands.
+    let is_negative = lhs.is_negative ^ rhs.is_negative;
+    // The product is the product of the absolute values of the operands.
+    let abs = lhs.abs * rhs.abs;
+    i257 { abs, is_negative }
+
     }
 }
 
@@ -171,74 +208,6 @@ fn i257_assert_no_negative_zero(x: i257) {
     if x.abs == 0 {
         assert(!x.is_negative, 'negative zero');
     }
-}
-
-// Adds two i257 integers.
-// # Arguments
-// * `a` - The first i257 to add.
-// * `b` - The second i257 to add.
-// # Returns
-// * `i257` - The sum of `a` and `b`.
-fn i257_add(lhs: i257, rhs: i257) -> i257 {
-    i257_assert_no_negative_zero(lhs);
-    i257_assert_no_negative_zero(rhs);
-    // If both integers have the same sign, 
-    // the sum of their absolute values can be returned.
-    if lhs.is_negative == rhs.is_negative {
-        let sum = lhs.abs + rhs.abs;
-        i257 { abs: sum, is_negative: lhs.is_negative }
-    } else {
-        // If the integers have different signs, 
-        // the larger absolute value is subtracted from the smaller one.
-        let (larger, smaller) = if lhs.abs >= rhs.abs {
-            (lhs, rhs)
-        } else {
-            (rhs, lhs)
-        };
-        let difference = larger.abs - smaller.abs;
-
-        i257 { abs: difference, is_negative: larger.is_negative }
-    }
-}
-
-// Subtracts two i257 integers.
-// # Arguments
-// * `lhs` - The first i257 to subtract.
-// * `rhs` - The second i257 to subtract.
-// # Returns
-// * `i257` - The difference of `a` and `b`.
-fn i257_sub(lhs: i257, rhs: i257) -> i257 {
-    i257_assert_no_negative_zero(lhs);
-    i257_assert_no_negative_zero(rhs);
-
-    if rhs.abs == 0 {
-        return lhs;
-    }
-
-    // The subtraction of `lhs` to `rhs` is achieved by negating `rhs` sign and adding it to `lhs`.
-    let neg_b = i257 { abs: rhs.abs, is_negative: !rhs.is_negative };
-    lhs + neg_b
-}
-
-// Multiplies two i257 integers.
-// 
-// # Arguments
-//
-// * `lhs` - The first i257 to multiply.
-// * `rhs` - The second i257 to multiply.
-//
-// # Returns
-//
-// * `i257` - The product of `a` and `b`.
-fn i257_mul(lhs: i257, rhs: i257) -> i257 {
-    i257_assert_no_negative_zero(lhs);
-    i257_assert_no_negative_zero(rhs);
-
-    // The sign of the product is the XOR of the signs of the operands.
-    let is_negative = lhs.is_negative ^ rhs.is_negative;
-    // The product is the product of the absolute values of the operands.
-    let abs = lhs.abs * rhs.abs;
-    i257 { abs, is_negative }
 }
 
 // Divides the first i257 by the second i128.

--- a/src/math/src/signed_u256.cairo
+++ b/src/math/src/signed_u256.cairo
@@ -102,6 +102,43 @@ impl i257MulEq of MulEq<i257> {
     }
 }
 
+// Divides the first i257 by the second i128.
+// # Arguments
+// * `lhs` - The i257 dividend.
+// * `rhs` - The i257 divisor.
+// # Returns
+// * `i257` - The quotient of `lhs` and `rhs`.
+fn i257_div(lhs: i257, rhs: i257) -> i257 {
+    i257_assert_no_negative_zero(lhs);
+    // Check that the divisor is not zero.
+    assert(rhs.abs != 0, 'b can not be 0');
+
+    // The sign of the quotient is the XOR of the signs of the operands.
+    let is_negative = lhs.is_negative ^ rhs.is_negative;
+
+    if !is_negative {
+        // If the operands are positive, the quotient is simply their absolute value quotient.
+        return i257 { abs: lhs.abs / rhs.abs, is_negative };
+    }
+
+    // If the operands have different signs, rounding is necessary.
+    // First, check if the quotient is an integer.
+    if lhs.abs % rhs.abs == 0 {
+        return i257 { abs: lhs.abs / rhs.abs, is_negative };
+    }
+
+    // If the quotient is not an integer, multiply the dividend by 10 to move the decimal point over.
+    let quotient = (lhs.abs * 10) / rhs.abs;
+    let last_digit = quotient % 10;
+
+    // Check the last digit to determine rounding direction.
+    if last_digit <= 5 {
+        i257 { abs: quotient / 10, is_negative }
+    } else {
+        i257 { abs: (quotient / 10) + 1, is_negative }
+    }
+}
+
 // Implements the Div trait for i257.
 impl i257Div of Div<i257> {
     fn div(lhs: i257, rhs: i257) -> i257 {
@@ -117,6 +154,19 @@ impl i257DivEq of DivEq<i257> {
     }
 }
 
+// Calculates the remainder of the division of a first i257 by a second i257.
+// # Arguments
+// * `lhs` - The i257 dividend.
+// * `rhs` - The i257 divisor.
+// # Returns
+// * `i257` - The remainder of dividing `lhs` by `rhs`.
+fn i257_rem(lhs: i257, rhs: i257) -> i257 {
+    i257_assert_no_negative_zero(lhs);
+    // Check that the divisor is not zero.
+    assert(rhs.abs != 0, 'b can not be 0');
+    lhs - (rhs * (lhs / rhs))
+}
+
 // Implements the Rem trait for i257.
 impl i257Rem of Rem<i257> {
     fn rem(lhs: i257, rhs: i257) -> i257 {
@@ -130,6 +180,18 @@ impl i257RemEq of RemEq<i257> {
     fn rem_eq(ref self: i257, other: i257) {
         self = Rem::rem(self, other);
     }
+}
+
+// Calculates both the quotient and the remainder of the division of a first i257 by a second i257.
+// # Arguments
+// * `lhs` - The i257 dividend.
+// * `rhs` - The i257 divisor.
+// # Returns
+// * `(i257, i257)` - A tuple containing the quotient and the remainder of dividing `lhs` by `rhs`.
+fn i257_div_rem(lhs: i257, rhs: i257) -> (i257, i257) {
+    let quotient = i257_div(lhs, rhs);
+    let remainder = i257_rem(lhs, rhs);
+    (quotient, remainder)
 }
 
 // Implements the PartialEq trait for i257.
@@ -205,68 +267,6 @@ fn i257_assert_no_negative_zero(x: i257) {
     if x.abs == 0 {
         assert(!x.is_negative, 'negative zero');
     }
-}
-
-// Divides the first i257 by the second i128.
-// # Arguments
-// * `lhs` - The i257 dividend.
-// * `rhs` - The i257 divisor.
-// # Returns
-// * `i257` - The quotient of `lhs` and `rhs`.
-fn i257_div(lhs: i257, rhs: i257) -> i257 {
-    i257_assert_no_negative_zero(lhs);
-    // Check that the divisor is not zero.
-    assert(rhs.abs != 0, 'b can not be 0');
-
-    // The sign of the quotient is the XOR of the signs of the operands.
-    let is_negative = lhs.is_negative ^ rhs.is_negative;
-
-    if !is_negative {
-        // If the operands are positive, the quotient is simply their absolute value quotient.
-        return i257 { abs: lhs.abs / rhs.abs, is_negative };
-    }
-
-    // If the operands have different signs, rounding is necessary.
-    // First, check if the quotient is an integer.
-    if lhs.abs % rhs.abs == 0 {
-        return i257 { abs: lhs.abs / rhs.abs, is_negative };
-    }
-
-    // If the quotient is not an integer, multiply the dividend by 10 to move the decimal point over.
-    let quotient = (lhs.abs * 10) / rhs.abs;
-    let last_digit = quotient % 10;
-
-    // Check the last digit to determine rounding direction.
-    if last_digit <= 5 {
-        i257 { abs: quotient / 10, is_negative }
-    } else {
-        i257 { abs: (quotient / 10) + 1, is_negative }
-    }
-}
-
-// Calculates the remainder of the division of a first i257 by a second i257.
-// # Arguments
-// * `lhs` - The i257 dividend.
-// * `rhs` - The i257 divisor.
-// # Returns
-// * `i257` - The remainder of dividing `lhs` by `rhs`.
-fn i257_rem(lhs: i257, rhs: i257) -> i257 {
-    i257_assert_no_negative_zero(lhs);
-    // Check that the divisor is not zero.
-    assert(rhs.abs != 0, 'b can not be 0');
-    lhs - (rhs * (lhs / rhs))
-}
-
-// Calculates both the quotient and the remainder of the division of a first i257 by a second i257.
-// # Arguments
-// * `lhs` - The i257 dividend.
-// * `rhs` - The i257 divisor.
-// # Returns
-// * `(i257, i257)` - A tuple containing the quotient and the remainder of dividing `lhs` by `rhs`.
-fn i257_div_rem(lhs: i257, rhs: i257) -> (i257, i257) {
-    let quotient = i257_div(lhs, rhs);
-    let remainder = i257_rem(lhs, rhs);
-    (quotient, remainder)
 }
 
 // Computes the absolute value of the given i257 integer.

--- a/src/math/src/tests/signed_u256_test.cairo
+++ b/src/math/src/tests/signed_u256_test.cairo
@@ -1,247 +1,247 @@
-use alexandria_math::signed_u256::{i257, i257_div_rem};
+use alexandria_math::signed_u256::{i257, i257_div_rem, i257_assert_no_negative_zero};
 
 #[test]
 fn i257_test_add() {
     // Test addition of two positive integers
-    let a = i257 { inner: 42_u256, sign: false };
-    let b = i257 { inner: 13_u256, sign: false };
+    let a = i257 { abs: 42, is_negative: false };
+    let b = i257 { abs: 13, is_negative: false };
     let result = a + b;
-    assert(result.inner == 55_u256, '42 + 13 = 55');
-    assert(result.sign == false, '42 + 13 -> positive');
+    assert(result.abs == 55, '42 + 13 = 55');
+    assert(result.is_negative == false, '42 + 13 -> positive');
 
     // Test addition of two negative integers
-    let a = i257 { inner: 42_u256, sign: true };
-    let b = i257 { inner: 13_u256, sign: true };
+    let a = i257 { abs: 42, is_negative: true };
+    let b = i257 { abs: 13, is_negative: true };
     let result = a + b;
-    assert(result.inner == 55_u256, '-42 - 13 = -55');
-    assert(result.sign == true, '-42 - 13 -> negative');
+    assert(result.abs == 55, '-42 - 13 = -55');
+    assert(result.is_negative == true, '-42 - 13 -> negative');
 
     // Test addition of a positive integer and a negative integer with the same magnitude
-    let a = i257 { inner: 42_u256, sign: false };
-    let b = i257 { inner: 42_u256, sign: true };
+    let a = i257 { abs: 42, is_negative: false };
+    let b = i257 { abs: 42, is_negative: true };
     let result = a + b;
-    assert(result.inner == 0_u256, '42 - 42 = 0');
-    assert(result.sign == false, '42 - 42 -> positive');
+    assert(result.abs == 0, '42 - 42 = 0');
+    assert(result.is_negative == false, '42 - 42 -> positive');
 
     // Test addition of a positive integer and a negative integer with different magnitudes
-    let a = i257 { inner: 42_u256, sign: false };
-    let b = i257 { inner: 13_u256, sign: true };
+    let a = i257 { abs: 42, is_negative: false };
+    let b = i257 { abs: 13, is_negative: true };
     let result = a + b;
-    assert(result.inner == 29_u256, '42 - 13 = 29');
-    assert(result.sign == false, '42 - 13 -> positive');
+    assert(result.abs == 29, '42 - 13 = 29');
+    assert(result.is_negative == false, '42 - 13 -> positive');
 
     // Test addition of a negative integer and a positive integer with different magnitudes
-    let a = i257 { inner: 42_u256, sign: true };
-    let b = i257 { inner: 13_u256, sign: false };
+    let a = i257 { abs: 42, is_negative: true };
+    let b = i257 { abs: 13, is_negative: false };
     let result = a + b;
-    assert(result.inner == 29_u256, '-42 + 13 = -29');
-    assert(result.sign == true, '-42 + 13 -> negative');
+    assert(result.abs == 29, '-42 + 13 = -29');
+    assert(result.is_negative == true, '-42 + 13 -> negative');
 }
 
 #[test]
 fn i257_test_sub() {
     // Test subtraction of two positive integers with larger first
-    let a = i257 { inner: 42_u256, sign: false };
-    let b = i257 { inner: 13_u256, sign: false };
+    let a = i257 { abs: 42, is_negative: false };
+    let b = i257 { abs: 13, is_negative: false };
     let result = a - b;
-    assert(result.inner == 29_u256, '42 - 13 = 29');
-    assert(result.sign == false, '42 - 13 -> positive');
+    assert(result.abs == 29, '42 - 13 = 29');
+    assert(result.is_negative == false, '42 - 13 -> positive');
 
     // Test subtraction of two positive integers with larger second
-    let a = i257 { inner: 13_u256, sign: false };
-    let b = i257 { inner: 42_u256, sign: false };
+    let a = i257 { abs: 13, is_negative: false };
+    let b = i257 { abs: 42, is_negative: false };
     let result = a - b;
-    assert(result.inner == 29_u256, '13 - 42 = -29');
-    assert(result.sign == true, '13 - 42 -> negative');
+    assert(result.abs == 29, '13 - 42 = -29');
+    assert(result.is_negative == true, '13 - 42 -> negative');
 
     // Test subtraction of two negative integers with larger first
-    let a = i257 { inner: 42_u256, sign: true };
-    let b = i257 { inner: 13_u256, sign: true };
+    let a = i257 { abs: 42, is_negative: true };
+    let b = i257 { abs: 13, is_negative: true };
     let result = a - b;
-    assert(result.inner == 29_u256, '-42 - -13 = 29');
-    assert(result.sign == true, '-42 - -13 -> negative');
+    assert(result.abs == 29, '-42 - -13 = 29');
+    assert(result.is_negative == true, '-42 - -13 -> negative');
 
     // Test subtraction of two negative integers with larger second
-    let a = i257 { inner: 13_u256, sign: true };
-    let b = i257 { inner: 42_u256, sign: true };
+    let a = i257 { abs: 13, is_negative: true };
+    let b = i257 { abs: 42, is_negative: true };
     let result = a - b;
-    assert(result.inner == 29_u256, '-13 - -42 = 29');
-    assert(result.sign == false, '-13 - -42 -> positive');
+    assert(result.abs == 29, '-13 - -42 = 29');
+    assert(result.is_negative == false, '-13 - -42 -> positive');
 
     // Test subtraction of a positive integer and a negative integer with the same magnitude
-    let a = i257 { inner: 42_u256, sign: false };
-    let b = i257 { inner: 42_u256, sign: true };
+    let a = i257 { abs: 42, is_negative: false };
+    let b = i257 { abs: 42, is_negative: true };
     let result = a - b;
-    assert(result.inner == 84_u256, '42 - -42 = 84');
-    assert(result.sign == false, '42 - -42 -> postive');
+    assert(result.abs == 84, '42 - -42 = 84');
+    assert(result.is_negative == false, '42 - -42 -> postive');
 
     // Test subtraction of a negative integer and a positive integer with the same magnitude
-    let a = i257 { inner: 42_u256, sign: true };
-    let b = i257 { inner: 42_u256, sign: false };
+    let a = i257 { abs: 42, is_negative: true };
+    let b = i257 { abs: 42, is_negative: false };
     let result = a - b;
-    assert(result.inner == 84_u256, '-42 - 42 = -84');
-    assert(result.sign == true, '-42 - 42 -> negative');
+    assert(result.abs == 84, '-42 - 42 = -84');
+    assert(result.is_negative == true, '-42 - 42 -> negative');
 
     // Test subtraction of a positive integer and a negative integer with different magnitudes
-    let a = i257 { inner: 100_u256, sign: false };
-    let b = i257 { inner: 42_u256, sign: true };
+    let a = i257 { abs: 100, is_negative: false };
+    let b = i257 { abs: 42, is_negative: true };
     let result = a - b;
-    assert(result.inner == 142_u256, '100 - - 42 = 142');
-    assert(result.sign == false, '100 - - 42 -> postive');
+    assert(result.abs == 142, '100 - - 42 = 142');
+    assert(result.is_negative == false, '100 - - 42 -> postive');
 
     // Test subtraction of a negative integer and a positive integer with different magnitudes
-    let a = i257 { inner: 42_u256, sign: true };
-    let b = i257 { inner: 100_u256, sign: false };
+    let a = i257 { abs: 42, is_negative: true };
+    let b = i257 { abs: 100, is_negative: false };
     let result = a - b;
-    assert(result.inner == 142_u256, '-42 - 100 = -142');
-    assert(result.sign == true, '-42 - 100 -> negative');
+    assert(result.abs == 142, '-42 - 100 = -142');
+    assert(result.is_negative == true, '-42 - 100 -> negative');
 
     // Test subtraction resulting in zero
-    let a = i257 { inner: 42_u256, sign: false };
-    let b = i257 { inner: 42_u256, sign: false };
+    let a = i257 { abs: 42, is_negative: false };
+    let b = i257 { abs: 42, is_negative: false };
     let result = a - b;
-    assert(result.inner == 0_u256, '42 - 42 = 0');
-    assert(result.sign == false, '42 - 42 -> positive');
+    assert(result.abs == 0, '42 - 42 = 0');
+    assert(result.is_negative == false, '42 - 42 -> positive');
 }
 
 
 #[test]
 fn i257_test_mul() {
     // Test multiplication of positive integers
-    let a = i257 { inner: 10_u256, sign: false };
-    let b = i257 { inner: 5_u256, sign: false };
+    let a = i257 { abs: 10, is_negative: false };
+    let b = i257 { abs: 5, is_negative: false };
     let result = a * b;
-    assert(result.inner == 50_u256, '10 * 5 = 50');
-    assert(result.sign == false, '10 * 5 -> positive');
+    assert(result.abs == 50, '10 * 5 = 50');
+    assert(result.is_negative == false, '10 * 5 -> positive');
 
     // Test multiplication of negative integers
-    let a = i257 { inner: 10_u256, sign: true };
-    let b = i257 { inner: 5_u256, sign: true };
+    let a = i257 { abs: 10, is_negative: true };
+    let b = i257 { abs: 5, is_negative: true };
     let result = a * b;
-    assert(result.inner == 50_u256, '-10 * -5 = 50');
-    assert(result.sign == false, '-10 * -5 -> positive');
+    assert(result.abs == 50, '-10 * -5 = 50');
+    assert(result.is_negative == false, '-10 * -5 -> positive');
 
     // Test multiplication of positive and negative integers
-    let a = i257 { inner: 10_u256, sign: false };
-    let b = i257 { inner: 5_u256, sign: true };
+    let a = i257 { abs: 10, is_negative: false };
+    let b = i257 { abs: 5, is_negative: true };
     let result = a * b;
-    assert(result.inner == 50_u256, '10 * -5 = -50');
-    assert(result.sign == true, '10 * -5 -> negative');
+    assert(result.abs == 50, '10 * -5 = -50');
+    assert(result.is_negative == true, '10 * -5 -> negative');
 
     // Test multiplication by zero
-    let a = i257 { inner: 10_u256, sign: false };
-    let b = i257 { inner: 0_u256, sign: false };
-    let expected = i257 { inner: 0_u256, sign: false };
+    let a = i257 { abs: 10, is_negative: false };
+    let b = i257 { abs: 0, is_negative: false };
+    let expected = i257 { abs: 0, is_negative: false };
     let result = a * b;
-    assert(result.inner == 0_u256, '10 * 0 = 0');
-    assert(result.sign == false, '10 * 0 -> positive');
+    assert(result.abs == 0, '10 * 0 = 0');
+    assert(result.is_negative == false, '10 * 0 -> positive');
 }
 
 #[test]
 fn i257_test_div_no_rem() {
     // Test division of positive integers
-    let a = i257 { inner: 10_u256, sign: false };
-    let b = i257 { inner: 5_u256, sign: false };
+    let a = i257 { abs: 10, is_negative: false };
+    let b = i257 { abs: 5, is_negative: false };
     let result = a / b;
-    assert(result.inner == 2_u256, '10 // 5 = 2');
-    assert(result.sign == false, '10 // 5 -> positive');
+    assert(result.abs == 2, '10 // 5 = 2');
+    assert(result.is_negative == false, '10 // 5 -> positive');
 
     // Test division of negative integers
-    let a = i257 { inner: 10_u256, sign: true };
-    let b = i257 { inner: 5_u256, sign: true };
+    let a = i257 { abs: 10, is_negative: true };
+    let b = i257 { abs: 5, is_negative: true };
     let result = a / b;
-    assert(result.inner == 2_u256, '-10 // -5 = 2');
-    assert(result.sign == false, '-10 // -5 -> positive');
+    assert(result.abs == 2, '-10 // -5 = 2');
+    assert(result.is_negative == false, '-10 // -5 -> positive');
 
     // Test division of positive and negative integers
-    let a = i257 { inner: 10_u256, sign: false };
-    let b = i257 { inner: 5_u256, sign: true };
+    let a = i257 { abs: 10, is_negative: false };
+    let b = i257 { abs: 5, is_negative: true };
     let result = a / b;
-    assert(result.inner == 2_u256, '10 // -5 = -2');
-    assert(result.sign == true, '10 // -5 -> negative');
+    assert(result.abs == 2, '10 // -5 = -2');
+    assert(result.is_negative == true, '10 // -5 -> negative');
 
     // Test division with a = zero
-    let a = i257 { inner: 0_u256, sign: false };
-    let b = i257 { inner: 10_u256, sign: false };
+    let a = i257 { abs: 0, is_negative: false };
+    let b = i257 { abs: 10, is_negative: false };
     let result = a / b;
-    assert(result.inner == 0_u256, '0 // 10 = 0');
-    assert(result.sign == false, '0 // 10 -> positive');
+    assert(result.abs == 0, '0 // 10 = 0');
+    assert(result.is_negative == false, '0 // 10 -> positive');
 
     // Test division with a = zero
-    let a = i257 { inner: 0_u256, sign: false };
-    let b = i257 { inner: 10_u256, sign: false };
+    let a = i257 { abs: 0, is_negative: false };
+    let b = i257 { abs: 10, is_negative: false };
     let result = a / b;
-    assert(result.inner == 0_u256, '0 // 10 = 0');
-    assert(result.sign == false, '0 // 10 -> positive');
+    assert(result.abs == 0, '0 // 10 = 0');
+    assert(result.is_negative == false, '0 // 10 -> positive');
 }
 
 #[test]
 fn i257_test_div_rem() {
     // Test division and remainder of positive integers
-    let a = i257 { inner: 13_u256, sign: false };
-    let b = i257 { inner: 5_u256, sign: false };
+    let a = i257 { abs: 13, is_negative: false };
+    let b = i257 { abs: 5, is_negative: false };
     let (q, r) = i257_div_rem(a, b);
-    assert(q.inner == 2_u256 && r.inner == 3_u256, '13 // 5 = 2 r 3');
-    assert(q.sign == false && r.sign == false, '13 // 5 -> positive');
+    assert(q.abs == 2 && r.abs == 3, '13 // 5 = 2 r 3');
+    assert(q.is_negative == false && r.is_negative == false, '13 // 5 -> positive');
 
     // Test division and remainder of negative integers
-    let a = i257 { inner: 13_u256, sign: true };
-    let b = i257 { inner: 5_u256, sign: true };
+    let a = i257 { abs: 13, is_negative: true };
+    let b = i257 { abs: 5, is_negative: true };
     let (q, r) = i257_div_rem(a, b);
-    assert(q.inner == 2_u256 && r.inner == 3_u256, '-13 // -5 = 2 r -3');
-    assert(q.sign == false && r.sign == true, '-13 // -5 -> positive');
+    assert(q.abs == 2 && r.abs == 3, '-13 // -5 = 2 r -3');
+    assert(q.is_negative == false && r.is_negative == true, '-13 // -5 -> positive');
 
     // Test division and remainder of positive and negative integers
-    let a = i257 { inner: 13_u256, sign: false };
-    let b = i257 { inner: 5_u256, sign: true };
+    let a = i257 { abs: 13, is_negative: false };
+    let b = i257 { abs: 5, is_negative: true };
     let (q, r) = i257_div_rem(a, b);
-    assert(q.inner == 3_u256 && r.inner == 2_u256, '13 // -5 = -3 r -2');
-    assert(q.sign == true && r.sign == true, '13 // -5 -> negative');
+    assert(q.abs == 3 && r.abs == 2, '13 // -5 = -3 r -2');
+    assert(q.is_negative == true && r.is_negative == true, '13 // -5 -> negative');
 
     // Test division with a = zero
-    let a = i257 { inner: 0_u256, sign: false };
-    let b = i257 { inner: 10_u256, sign: false };
+    let a = i257 { abs: 0, is_negative: false };
+    let b = i257 { abs: 10, is_negative: false };
     let (q, r) = i257_div_rem(a, b);
-    assert(q.inner == 0_u256 && r.inner == 0_u256, '0 // 10 = 0 r 0');
-    assert(q.sign == false && r.sign == false, '0 // 10 -> positive');
+    assert(q.abs == 0 && r.abs == 0, '0 // 10 = 0 r 0');
+    assert(q.is_negative == false && r.is_negative == false, '0 // 10 -> positive');
 
     // Test division and remainder with a negative dividend and positive divisor
-    let a = i257 { inner: 13_u256, sign: true };
-    let b = i257 { inner: 5_u256, sign: false };
+    let a = i257 { abs: 13, is_negative: true };
+    let b = i257 { abs: 5, is_negative: false };
     let (q, r) = i257_div_rem(a, b);
-    assert(q.inner == 3_u256 && r.inner == 2_u256, '-13 // 5 = -3 r 2');
-    assert(q.sign == true && r.sign == false, '-13 // 5 -> negative');
+    assert(q.abs == 3 && r.abs == 2, '-13 // 5 = -3 r 2');
+    assert(q.is_negative == true && r.is_negative == false, '-13 // 5 -> negative');
 }
 
 #[test]
 fn i257_test_partial_ord() {
     // Test two postive integers
-    let a = i257 { inner: 13_u256, sign: false };
-    let b = i257 { inner: 5_u256, sign: false };
+    let a = i257 { abs: 13, is_negative: false };
+    let b = i257 { abs: 5, is_negative: false };
     assert(a > b, '13 > 5');
     assert(a >= b, '13 >= 5');
     assert(b < a, '5 < 13');
     assert(b <= a, '5 <= 13');
 
     // Test `a` postive and `b` negative
-    let a = i257 { inner: 13_u256, sign: false };
-    let b = i257 { inner: 5_u256, sign: true };
+    let a = i257 { abs: 13, is_negative: false };
+    let b = i257 { abs: 5, is_negative: true };
     assert(a > b, '13 > -5');
     assert(a >= b, '13 >= -5');
     assert(b < a, '-5 < 13');
     assert(b <= a, '-5 <= 13');
 
     // Test `a` negative and `b` postive
-    let a = i257 { inner: 13_u256, sign: true };
-    let b = i257 { inner: 5_u256, sign: false };
+    let a = i257 { abs: 13, is_negative: true };
+    let b = i257 { abs: 5, is_negative: false };
     assert(b > a, '5 > -13');
     assert(b >= a, '5 >= -13');
     assert(a < b, '-13 < 5');
     assert(a <= b, '5 <= -13');
 
     // Test `a` negative and `b` negative
-    let a = i257 { inner: 13_u256, sign: true };
-    let b = i257 { inner: 5_u256, sign: true };
+    let a = i257 { abs: 13, is_negative: true };
+    let b = i257 { abs: 5, is_negative: true };
     assert(b > a, '-5 > -13');
     assert(b >= a, '-13 >= -5');
     assert(a < b, '-13 < -5');
@@ -251,73 +251,73 @@ fn i257_test_partial_ord() {
 #[test]
 fn i257_test_eq_not_eq() {
     // Test two postive integers
-    let a = i257 { inner: 13_u256, sign: false };
-    let b = i257 { inner: 5_u256, sign: false };
+    let a = i257 { abs: 13, is_negative: false };
+    let b = i257 { abs: 5, is_negative: false };
     assert(a != b, '13 != 5');
 
     // Test `a` postive and `b` negative
-    let a = i257 { inner: 13_u256, sign: false };
-    let b = i257 { inner: 5_u256, sign: true };
+    let a = i257 { abs: 13, is_negative: false };
+    let b = i257 { abs: 5, is_negative: true };
     assert(a != b, '13 != -5');
 
     // Test `a` negative and `b` postive
-    let a = i257 { inner: 13_u256, sign: true };
-    let b = i257 { inner: 5_u256, sign: false };
+    let a = i257 { abs: 13, is_negative: true };
+    let b = i257 { abs: 5, is_negative: false };
     assert(a != b, '-13 != 5');
 
     // Test `a` negative and `b` negative
-    let a = i257 { inner: 13_u256, sign: true };
-    let b = i257 { inner: 5_u256, sign: true };
+    let a = i257 { abs: 13, is_negative: true };
+    let b = i257 { abs: 5, is_negative: true };
     assert(a != b, '-13 != -5');
 }
 
 #[test]
 fn i257_test_equality() {
     // Test equal with two positive integers
-    let a = i257 { inner: 13_u256, sign: false };
-    let b = i257 { inner: 13_u256, sign: false };
+    let a = i257 { abs: 13, is_negative: false };
+    let b = i257 { abs: 13, is_negative: false };
     assert(a == b, '13 == 13');
 
     // Test equal with two negative integers
-    let a = i257 { inner: 13_u256, sign: true };
-    let b = i257 { inner: 13_u256, sign: true };
+    let a = i257 { abs: 13, is_negative: true };
+    let b = i257 { abs: 13, is_negative: true };
     assert(a == b, '-13 == -13');
 
     // Test not equal with two postive integers
-    let a = i257 { inner: 13_u256, sign: false };
-    let b = i257 { inner: 5_u256, sign: false };
+    let a = i257 { abs: 13, is_negative: false };
+    let b = i257 { abs: 5, is_negative: false };
     assert(a != b, '13 != 5');
 
     // Test not equal with `a` postive and `b` negative
-    let a = i257 { inner: 13_u256, sign: false };
-    let b = i257 { inner: 5_u256, sign: true };
+    let a = i257 { abs: 13, is_negative: false };
+    let b = i257 { abs: 5, is_negative: true };
     assert(a != b, '13 != -5');
 
     // Test not equal with `a` negative and `b` postive
-    let a = i257 { inner: 13_u256, sign: true };
-    let b = i257 { inner: 5_u256, sign: false };
+    let a = i257 { abs: 13, is_negative: true };
+    let b = i257 { abs: 5, is_negative: false };
     assert(a != b, '-13 != 5');
 
     // Test not equal with `a` negative and `b` negative
-    let a = i257 { inner: 13_u256, sign: true };
-    let b = i257 { inner: 5_u256, sign: true };
+    let a = i257 { abs: 13, is_negative: true };
+    let b = i257 { abs: 5, is_negative: true };
     assert(a != b, '-13 != -5');
 }
 
 #[test]
 #[should_panic]
 fn i257_test_check_sign_zero() {
-    let x = i257 { inner: 0_u256, sign: true };
-    alexandria_math::signed_u256::i257_check_sign_zero(x);
+    let x = i257 { abs: 0, is_negative: true };
+    i257_assert_no_negative_zero(x);
 }
 
 #[test]
 fn i257_test_into() {
-    let x: i257 = 35_u256.into();
-    assert(x.inner == 35, 'incorrect into value');
-    assert(x.sign == false, 'incorrect into sign');
+    let x: i257 = 35.into();
+    assert(x.abs == 35, 'incorrect into value');
+    assert(x.is_negative == false, 'incorrect into sign');
 
     let y: i257 = 258973.into();
-    assert(y.inner == 258973, 'incorrect into value');
-    assert(y.sign == false, 'incorrect into sign');
+    assert(y.abs == 258973, 'incorrect into value');
+    assert(y.is_negative == false, 'incorrect into sign');
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the new behavior?

While code like the following is eventually understandable, it isn't as clearly obvious as the proposed one:

Before:

```rust
fn foo(value: i257) {
  let mut x: u256 = 42;
  if value.sign == true {
    x += value.inner;
  }
}
```

After: 

```rust
fn foo(value: i257) {
  let mut x: u256 = 42;
  if value.is_negative {
    x += value.abs;
  }
}
```

## Does this introduce a breaking change?

- [X] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
