### PR TITLE
feat: add Cairo implementations of various linalg algorithms

### DIFF
--- a/Scarb.lock
+++ b/Scarb.lock
@@ -34,6 +34,9 @@ dependencies = [
 [[package]]
 name = "alexandria_linalg"
 version = "0.1.0"
+dependencies = [
+ "alexandria_math",
+]
 
 [[package]]
 name = "alexandria_math"

--- a/src/linalg/README.md
+++ b/src/linalg/README.md
@@ -3,3 +3,11 @@
 ## [Dot product](./src/dot.cairo)
 
 The dot product or scalar product is an algebraic operation that takes two equal-length sequences of numbers (usually coordinate vectors), and returns a single number. Algebraically, the dot product is the sum of the products of the corresponding entries of the two sequences of numbers ([see also](https://en.wikipedia.org/wiki/Dot_product)).
+
+## [Kronecker product](./src/kron.cairo)
+
+The Kronecker product is an an algebraic operation that takes two equal-length sequences of numbers and returns an array of numbers([see also](https://numpy.org/doc/stable/reference/generated/numpy.kron.html)).
+
+## [Norm](./src/norm.cairo)
+
+Calculate the norm of an u128 array ([see also](https://numpy.org/doc/stable/reference/generated/numpy.linalg.norm.html)).

--- a/src/linalg/Scarb.toml
+++ b/src/linalg/Scarb.toml
@@ -6,3 +6,6 @@ homepage = "https://github.com/keep-starknet-strange/alexandria/tree/main/src/li
 
 [tool]
 fmt.workspace = true
+
+[dependencies]
+alexandria_math = { path = "../math" }

--- a/src/linalg/src/kron.cairo
+++ b/src/linalg/src/kron.cairo
@@ -1,0 +1,33 @@
+//! Kronecker product of two arrays
+
+/// Compute the Kronecker product for 2 given arrays.
+/// # Arguments
+/// * `xs` - The first sequence of len L.
+/// * `ys` - The second sequence of len L.
+/// # Returns
+/// * `Array<T>` - The Kronecker product.
+fn kron<T, +Mul<T>, +AddEq<T>, +Zeroable<T>, +Copy<T>, +Drop<T>,>(
+    mut xs: Span<T>, mut ys: Span<T>
+) -> Array<T> {
+    // [Check] Inputs
+    assert(xs.len() == ys.len(), 'Arrays must have the same len');
+
+    // [Compute] Kronecker product in a loop
+    let mut array = array![];
+    loop {
+        match xs.pop_front() {
+            Option::Some(x_value) => {
+                let mut ys_clone = ys.clone();
+                loop {
+                    match ys_clone.pop_front() {
+                        Option::Some(y_value) => { array.append(*x_value * *y_value); },
+                        Option::None => { break; },
+                    };
+                };
+            },
+            Option::None => { break; },
+        };
+    };
+
+    array
+}

--- a/src/linalg/src/lib.cairo
+++ b/src/linalg/src/lib.cairo
@@ -1,4 +1,6 @@
 mod dot;
+mod kron;
+mod norm;
 
 #[cfg(test)]
 mod tests;

--- a/src/linalg/src/norm.cairo
+++ b/src/linalg/src/norm.cairo
@@ -1,0 +1,40 @@
+//! Norm of an u128 array.
+
+/// Compute the norm for an u128 array.
+/// # Arguments
+/// * `array` - The inputted array.
+/// * `ord` - The order of the norm.
+/// * `iter` - The number of iterations to run the algorithm
+/// # Returns
+/// * `u128` - The norm for the array.
+use alexandria_math::fast_root::fast_nr_optimize;
+use alexandria_math::pow;
+
+use debug::PrintTrait;
+
+fn norm(mut xs: Span<u128>, ord: u128, iter: usize) -> u128 {
+    let mut norm = 0;
+    loop {
+        match xs.pop_front() {
+            Option::Some(x_value) => {
+                if ord == 0 {
+                    if *x_value != 0 {
+                        norm += 1;
+                    }
+                } else {
+                    norm += pow(*x_value, ord);
+                }
+            },
+            Option::None => { break; },
+        };
+    };
+    norm.print();
+
+    if ord == 0 {
+        return norm;
+    }
+
+    norm = fast_nr_optimize(norm, ord, iter);
+
+    norm
+}

--- a/src/linalg/src/tests.cairo
+++ b/src/linalg/src/tests.cairo
@@ -1,1 +1,3 @@
 mod dot_test;
+mod kron_test;
+mod norm_test;

--- a/src/linalg/src/tests/kron_test.cairo
+++ b/src/linalg/src/tests/kron_test.cairo
@@ -1,0 +1,27 @@
+use alexandria_linalg::kron::kron;
+
+#[test]
+#[available_gas(2000000)]
+fn kron_product_test() {
+    let mut xs: Array<u64> = array![1, 10, 100];
+    let mut ys = array![5, 6, 7];
+    let zs = kron(xs.span(), ys.span());
+    assert(*zs[0] == 5, 'wrong value at index 0');
+    assert(*zs[1] == 6, 'wrong value at index 1');
+    assert(*zs[2] == 7, 'wrong value at index 2');
+    assert(*zs[3] == 50, 'wrong value at index 3');
+    assert(*zs[4] == 60, 'wrong value at index 4');
+    assert(*zs[5] == 70, 'wrong value at index 5');
+    assert(*zs[6] == 500, 'wrong value at index 6');
+    assert(*zs[7] == 600, 'wrong value at index 7');
+    assert(*zs[8] == 700, 'wrong value at index 8');
+}
+
+#[test]
+#[should_panic(expected: ('Arrays must have the same len',))]
+#[available_gas(2000000)]
+fn kron_product_test_check_len() {
+    let mut xs: Array<u64> = array![1];
+    let mut ys = array![];
+    kron(xs.span(), ys.span());
+}

--- a/src/linalg/src/tests/norm_test.cairo
+++ b/src/linalg/src/tests/norm_test.cairo
@@ -1,0 +1,22 @@
+use alexandria_linalg::norm::norm;
+
+#[test]
+#[available_gas(2000000)]
+fn norm_test_1() {
+    let mut array: Array<u128> = array![3, 4];
+    assert(norm(array.span(), 2, 10) == 5, 'invalid l2 norm');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn norm_test_2() {
+    let mut array: Array<u128> = array![3, 4];
+    assert(norm(array.span(), 1, 10) == 7, 'invalid l1 norm');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn norm_test_3() {
+    let mut array: Array<u128> = array![3, 4];
+    assert(norm(array.span(), 0, 10) == 2, 'invalid l1 norm');
+}


### PR DESCRIPTION
This PR adds Cairo implementations of various linalg algorithms.

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- calculating Kronecker product of two lists.
- calculating N-th norm of a list.
- Corresponding tests are added for all implementations, all tests are passed.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

This PR depends on `fast_root` implemented in #250 for properly working.
