### PR TITLE
fix: remove unnecessary `mut` in norm tests

### DIFF
--- a/src/linalg/src/tests/norm_test.cairo
+++ b/src/linalg/src/tests/norm_test.cairo
@@ -3,27 +3,27 @@ use alexandria_linalg::norm::norm;
 #[test]
 #[available_gas(2000000)]
 fn norm_test_1() {
-    let mut array: Array<u128> = array![3, 4];
+    let array: Array<u128> = array![3, 4];
     assert(norm(array.span(), 2, 10) == 5, 'invalid l2 norm');
 }
 
 #[test]
 #[available_gas(2000000)]
 fn norm_test_2() {
-    let mut array: Array<u128> = array![3, 4];
+    let array: Array<u128> = array![3, 4];
     assert(norm(array.span(), 1, 10) == 7, 'invalid l1 norm');
 }
 
 #[test]
 #[available_gas(2000000)]
 fn norm_test_3() {
-    let mut array: Array<u128> = array![3, 4];
+    let array: Array<u128> = array![3, 4];
     assert(norm(array.span(), 0, 10) == 2, 'invalid l1 norm');
 }
 
 #[test]
 #[available_gas(2000000)]
 fn norm_test_into() {
-    let mut array: Array<u32> = array![3, 4];
+    let array: Array<u32> = array![3, 4];
     assert(norm(array.span(), 2, 10) == 5, 'invalid l2 norm');
 }


### PR DESCRIPTION
This PR removes unnecessary `mut` in norm tests.

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- remove `mut` in norm tests.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
