### PR TITLE
bug: array slice naming error and generic option

### DIFF
--- a/src/bytes/src/utils.cairo
+++ b/src/bytes/src/utils.cairo
@@ -103,11 +103,10 @@ fn u8_array_to_u256(arr: Span<u8>) -> u256 {
     u256 { low, high }
 }
 
-fn u64_array_slice(src: @Array<u64>, mut begin: usize, end: usize) -> Array<u64> {
+fn u64_array_slice(src: @Array<u64>, mut begin: usize, len: usize) -> Array<u64> {
     let mut slice = array![];
-    let len = begin + end;
-
-    while begin < len && begin < src.len() {
+    let end = begin + len;
+    while begin < end && begin < src.len() {
         slice.append(*src[begin]);
         begin += 1;
     };
@@ -117,13 +116,25 @@ fn u64_array_slice(src: @Array<u64>, mut begin: usize, end: usize) -> Array<u64>
 /// Returns the slice of an array.
 /// * `arr` - The array to slice.
 /// * `begin` - The index to start the slice at.
-/// * `end` - The index to end the slice at (not included).
+/// * `len` - The length of the slice.
 /// # Returns
 /// * `Array<u128>` - The slice of the array.
-fn u128_array_slice(src: @Array<u128>, mut begin: usize, end: usize) -> Array<u128> {
+fn u128_array_slice(src: @Array<u128>, mut begin: usize, len: usize) -> Array<u128> {
     let mut slice = array![];
-    let len = begin + end;
-    while begin < len && begin < src.len() {
+    let end = begin + len;
+    while begin < end && begin < src.len() {
+        slice.append(*src[begin]);
+        begin += 1;
+    };
+    slice
+}
+
+fn array_slice<T, impl TDrop: Drop<T>, impl TCopy: Copy<T>>(
+    src: @Array<T>, mut begin: usize, len: usize
+) -> Array<T> {
+    let mut slice = array![];
+    let end = begin + len;
+    while begin < end && begin < src.len() {
         slice.append(*src[begin]);
         begin += 1;
     };


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

The current implementation of array slices had a variable naming issue, where `len` and `end` seems to represent `end` and `len` respectively. Confusion leaked into the function description as well.

I also created a generic `array_slice`.

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Does this introduce a breaking change?

- [ ] Yes
- [x] No