### PR TITLE
Fix merkle tree hashing for poseidon

### DIFF
--- a/src/merkle_tree/src/merkle_tree.cairo
+++ b/src/merkle_tree/src/merkle_tree.cairo
@@ -41,7 +41,6 @@ struct Hasher {}
 
 mod pedersen {
     use hash::HashStateTrait;
-    use pedersen::PedersenTrait;
     use super::{Hasher, HasherTrait};
 
     impl PedersenHasherImpl of HasherTrait<Hasher> {
@@ -49,9 +48,7 @@ mod pedersen {
             Hasher {}
         }
         fn hash(ref self: Hasher, data1: felt252, data2: felt252) -> felt252 {
-            let mut state = PedersenTrait::new(data1);
-            state = state.update(data2);
-            state.finalize()
+            pedersen::pedersen(data1, data2)
         }
     }
 }

--- a/src/merkle_tree/src/merkle_tree.cairo
+++ b/src/merkle_tree/src/merkle_tree.cairo
@@ -58,7 +58,7 @@ mod pedersen {
 
 mod poseidon {
     use hash::HashStateTrait;
-    use poseidon::PoseidonTrait;
+    use poseidon::hades_permutation;
     use super::{Hasher, HasherTrait};
 
     impl PoseidonHasherImpl of HasherTrait<Hasher> {
@@ -66,10 +66,8 @@ mod poseidon {
             Hasher {}
         }
         fn hash(ref self: Hasher, data1: felt252, data2: felt252) -> felt252 {
-            let mut state = PoseidonTrait::new();
-            state = state.update(data1);
-            state = state.update(data2);
-            state.finalize()
+            let (hash, _, _) = hades_permutation(data1, data2, 2);
+            hash
         }
     }
 }

--- a/src/merkle_tree/src/tests/merkle_tree_test.cairo
+++ b/src/merkle_tree/src/tests/merkle_tree_test.cairo
@@ -102,13 +102,13 @@ fn merkle_tree_pedersen_test() {
 }
 
 #[test]
-#[available_gas(2000000)]
+#[available_gas(50000000000)]
 fn merkle_tree_poseidon_test() {
     // [Setup] Merkle tree.
     let mut merkle_tree: MerkleTree<Hasher> = MerkleTreeImpl::<_, PoseidonHasherImpl>::new();
-    let root = 0x7abc09d19c8a03abd4333a23f7823975c7bdd325170f0d32612b8baa1457d47;
+    let root = 0x48924a3b2a7a7b7cc1c9371357e95e322899880a6534bdfe24e96a828b9d780;
     let leaf = 0x1;
-    let valid_proof = array![0x2, 0x47ef3ad11ad3f8fc055281f1721acd537563ec134036bc4bd4de2af151f0832]
+    let valid_proof = array![0x2, 0x338eb608d7e48306d01f5a8d4275dd85a52ba79aaf7a1a7b35808ba573c3669]
         .span();
     let leaves = array![0x1, 0x2, 0x3];
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

The current Poseidon hashing implementation for the merkle tree is incorrect. It uses 
```
            let mut state = PoseidonTrait::new();
            state = state.update(data1);
            state = state.update(data2);
            state.finalize()

```
Under the hood this actually hashes the elements twice  (once from the state update and once from finalization, see [corelib](https://github.com/starkware-libs/cairo/blob/main/corelib/src/poseidon.cairo)), the intended behaviours is that only one round of hashing is done (when hashing two elements). This is noted in https://docs.starknet.io/documentation/architecture_and_concepts/Cryptography/hash-functions/#poseidon_hash where by the hash of two elements is simply 
<img width="417" alt="Screenshot 2024-02-19 at 11 53 04" src="https://github.com/keep-starknet-strange/alexandria/assets/106159231/b4421134-d522-4ab6-be62-e41f61e335a4">. 
Also please see POC https://github.com/Leonard-Pat/merkle-tree-failing 

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Fixes Poseidon hashing for merkle tree poseidon impl


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Updated tests to reflect this change - note the gas limit was exceeded and therefore needed to be udpated as well

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
