### PR TITLE
feat: Solidity ABI encode functions and utils

### DIFF
--- a/Scarb.lock
+++ b/Scarb.lock
@@ -27,6 +27,7 @@ dependencies = [
 name = "alexandria_encoding"
 version = "0.1.0"
 dependencies = [
+ "alexandria_bytes",
  "alexandria_math",
  "alexandria_numeric",
 ]

--- a/src/bytes/src/bytes.cairo
+++ b/src/bytes/src/bytes.cairo
@@ -165,17 +165,18 @@ impl BytesImpl of BytesTrait {
     fn to_byte_array(self: Bytes) -> ByteArray {
         let mut res: ByteArray = Default::default();
         let mut offset = 0;
-        while offset < self.size() {
-            if offset + 31 <= self.size() {
-                let (new_offset, value) = self.read_bytes31(offset);
-                res.append_word(value.into(), 31);
-                offset = new_offset;
-            } else {
-                let (new_offset, value) = self.read_u8(offset);
-                res.append_byte(value);
-                offset = new_offset;
-            }
-        };
+        while offset < self
+            .size() {
+                if offset + 31 <= self.size() {
+                    let (new_offset, value) = self.read_bytes31(offset);
+                    res.append_word(value.into(), 31);
+                    offset = new_offset;
+                } else {
+                    let (new_offset, value) = self.read_u8(offset);
+                    res.append_byte(value);
+                    offset = new_offset;
+                }
+            };
         res
     }
 

--- a/src/bytes/src/bytes.cairo
+++ b/src/bytes/src/bytes.cairo
@@ -1,8 +1,8 @@
 use alexandria_bytes::utils::{
     u128_join, read_sub_u128, u128_split, u128_array_slice, keccak_u128s_be, u8_array_to_u256
 };
-use alexandria_math::{U128BitShift, U256BitShift};
 use alexandria_math::sha256::sha256;
+use alexandria_math::{U128BitShift, U256BitShift};
 use starknet::ContractAddress;
 
 /// Bytes is a dynamic array of u128, where each element contains 16 bytes.

--- a/src/bytes/src/bytes.cairo
+++ b/src/bytes/src/bytes.cairo
@@ -155,6 +155,7 @@ impl BytesImpl of BytesTrait {
         // Last elem
         if bytes.pending_word_len != 0 {
             let mut val: u256 = bytes.pending_word.into();
+            // Only append the right-aligned bytes of the last word ( using specified length )
             val = U256BitShift::shl(val, 8 * (32 - bytes.pending_word_len.into()));
             res.concat(@BytesTrait::new(bytes.pending_word_len, array![val.high, val.low]));
         }

--- a/src/bytes/src/bytes.cairo
+++ b/src/bytes/src/bytes.cairo
@@ -1,6 +1,7 @@
 use alexandria_bytes::utils::{
     u128_join, read_sub_u128, u128_split, u128_array_slice, keccak_u128s_be, u8_array_to_u256
 };
+use alexandria_math::{U128BitShift, U256BitShift};
 use alexandria_math::sha256::sha256;
 use starknet::ContractAddress;
 
@@ -42,6 +43,10 @@ trait BytesTrait {
     fn new_empty() -> Bytes;
     /// Create a Bytes with size bytes 0
     fn zero(size: usize) -> Bytes;
+    /// Create a Bytes from ByteArray ( Array<bytes31> )
+    fn from_byte_array(bytes: ByteArray) -> Bytes;
+    /// Create a ByteArray from Bytes
+    fn to_byte_array(self: Bytes) -> ByteArray;
     /// Locate offset in Bytes
     fn locate(offset: usize) -> (usize, usize);
     /// Get Bytes size
@@ -76,6 +81,8 @@ trait BytesTrait {
     fn read_bytes(self: @Bytes, offset: usize, size: usize) -> (usize, Bytes);
     /// Read felt252 from Bytes, which stored as u256
     fn read_felt252(self: @Bytes, offset: usize) -> (usize, felt252);
+    /// Read bytes31 from Bytes
+    fn read_bytes31(self: @Bytes, offset: usize) -> (usize, bytes31);
     /// Read a ContractAddress from Bytes
     fn read_address(self: @Bytes, offset: usize) -> (usize, ContractAddress);
     /// Write value with size bytes into Bytes, value is packed into u128
@@ -96,6 +103,8 @@ trait BytesTrait {
     fn append_u256(ref self: Bytes, value: u256);
     /// Write felt252 into Bytes, which stored as u256
     fn append_felt252(ref self: Bytes, value: felt252);
+    /// Write bytes31 into Bytes
+    fn append_bytes31(ref self: Bytes, value: bytes31);
     /// Write address into Bytes
     fn append_address(ref self: Bytes, value: ContractAddress);
     /// concat with other Bytes
@@ -133,6 +142,38 @@ impl BytesImpl of BytesTrait {
         };
 
         Bytes { size, data }
+    }
+
+    fn from_byte_array(mut bytes: ByteArray) -> Bytes {
+        let mut res = BytesTrait::new_empty();
+        while !bytes.data.is_empty() {
+            let value: bytes31 = bytes.data.pop_front().unwrap();
+            res.append_bytes31(value);
+        };
+        // Last elem
+        if bytes.pending_word_len != 0 {
+            let mut val: u256 = bytes.pending_word.into();
+            val = U256BitShift::shl(val, 8 * (32 - bytes.pending_word_len.into()));
+            res.concat(@BytesTrait::new(bytes.pending_word_len, array![val.high, val.low]));
+        }
+        res
+    }
+
+    fn to_byte_array(self: Bytes) -> ByteArray {
+        let mut res: ByteArray = "";
+        let mut offset = 0;
+        while offset < self.size() {
+            if offset + 31 <= self.size() {
+                let (new_offset, value) = self.read_bytes31(offset);
+                res.append_word(value.into(), 31);
+                offset = new_offset;
+            } else {
+                let (new_offset, value) = self.read_u8(offset);
+                res.append_byte(value);
+                offset = new_offset;
+            }
+        };
+        res
     }
 
     /// Locate offset in Bytes
@@ -358,6 +399,19 @@ impl BytesImpl of BytesTrait {
         (new_offset, value.try_into().expect('Couldn\'t convert to felt252'))
     }
 
+    /// read bytes31 from Bytes
+    #[inline(always)]
+    fn read_bytes31(self: @Bytes, offset: usize) -> (usize, bytes31) {
+        let (new_offset, high) = self.read_u128(0);
+        let (new_offset, low) = self.read_u128_packed(new_offset, 15);
+        let low = U128BitShift::shl(low, 8);
+        let mut value: u256 = u256 { high, low };
+        value = U256BitShift::shr(value, 8);
+        let value: felt252 = value.try_into().expect('Couldn\'t convert to felt252');
+        let value: bytes31 = value.try_into().expect('Couldn\'t convert to bytes31');
+        (new_offset, value)
+    }
+
     /// read Contract Address from Bytes
     #[inline(always)]
     fn read_address(self: @Bytes, offset: usize) -> (usize, ContractAddress) {
@@ -450,12 +504,19 @@ impl BytesImpl of BytesTrait {
         self.append_u256(value)
     }
 
+    /// Write bytes31 into Bytes
+    #[inline(always)]
+    fn append_bytes31(ref self: Bytes, value: bytes31) {
+        let mut value: u256 = value.into();
+        value = U256BitShift::shl(value, 8);
+        self.concat(@BytesTrait::new(31, array![value.high, value.low]));
+    }
+
     /// Write address into Bytes
     #[inline(always)]
     fn append_address(ref self: Bytes, value: ContractAddress) {
-        let address_felt256: felt252 = value.into();
-        let address_u256: u256 = address_felt256.into();
-        self.append_u256(address_u256)
+        let address: felt252 = value.into();
+        self.append_felt252(address)
     }
 
     /// concat with other Bytes

--- a/src/bytes/src/tests/test_bytes.cairo
+++ b/src/bytes/src/tests/test_bytes.cairo
@@ -1,3 +1,4 @@
+use alexandria_bytes::utils::{BytesDebug, BytesDisplay};
 use alexandria_bytes::{Bytes, BytesTrait};
 use starknet::ContractAddress;
 
@@ -353,6 +354,21 @@ fn test_bytes_read_u256() {
 
 #[test]
 #[available_gas(20000000)]
+fn test_bytes_read_bytes31() {
+    let bytes: Bytes = BytesTrait::new(
+        31,
+        array![
+            0x0102030405060708090a0b0c0d0e0f10,
+            0x1112131415161718191a1b1c1d1e1f00
+        ]
+    );
+    let (offset, val) = bytes.read_bytes31(0);
+    assert_eq!(offset, 31, "Offset after read_bytes31 failed");
+    assert!(val == bytes31_const::<0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f>(), "read_bytes31 test failed")
+}
+
+#[test]
+#[available_gas(20000000)]
 fn test_bytes_read_u256_array() {
     let array = array![
         0x01020304050607080910111213141516,
@@ -681,4 +697,20 @@ fn test_bytes_sha256() {
     let hash: u256 = 0xc3ab2c0ce2c246454f265f531ab14f210215ce72b91c23338405c273dc14ce1d;
     let res = bytes.sha256();
     assert_eq!(res, hash, "bytes_sha256_2");
+}
+
+#[test]
+fn test_byte_array_conversions() {
+    let bytes = BytesTrait::new(
+        52,
+        array![
+            0x01020304050607080910111213141516,
+            0x16151413121110090807060504030201,
+            0x60196ff92381eb7910f5446c2e0e04e1,
+            0x3db2194a000000000000000000000000
+        ]
+    );
+    let byte_array = bytes.clone().to_byte_array();
+    let new_bytes = BytesTrait::from_byte_array(byte_array);
+    assert_eq!(bytes, new_bytes, "byte <-> byte_array conversion failed");
 }

--- a/src/bytes/src/tests/test_bytes.cairo
+++ b/src/bytes/src/tests/test_bytes.cairo
@@ -356,15 +356,14 @@ fn test_bytes_read_u256() {
 #[available_gas(20000000)]
 fn test_bytes_read_bytes31() {
     let bytes: Bytes = BytesTrait::new(
-        31,
-        array![
-            0x0102030405060708090a0b0c0d0e0f10,
-            0x1112131415161718191a1b1c1d1e1f00
-        ]
+        31, array![0x0102030405060708090a0b0c0d0e0f10, 0x1112131415161718191a1b1c1d1e1f00]
     );
     let (offset, val) = bytes.read_bytes31(0);
     assert_eq!(offset, 31, "Offset after read_bytes31 failed");
-    assert!(val == bytes31_const::<0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f>(), "read_bytes31 test failed")
+    assert!(
+        val == bytes31_const::<0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f>(),
+        "read_bytes31 test failed"
+    )
 }
 
 #[test]

--- a/src/bytes/src/utils.cairo
+++ b/src/bytes/src/utils.cairo
@@ -10,10 +10,7 @@ fn format_byte_hex(byte: u8, ref f: Formatter) -> Result<(), Error> {
     if byte < 0x10 {
         // Add leading zero for single digit numbers
         let zero: ByteArray = "0";
-        let res = Display::fmt(@zero, ref f);
-        if res.is_err() {
-            return res;
-        }
+        Display::fmt(@zero, ref f)?;
     }
     Display::fmt(@byte.format_as_byte_array(base), ref f)
 }
@@ -22,10 +19,8 @@ impl BytesDebug of Debug<Bytes> {
     fn fmt(self: @Bytes, ref f: Formatter) -> Result<(), Error> {
         let mut i: usize = 0;
         let prefix: ByteArray = "0x";
-        let mut res = Display::fmt(@prefix, ref f);
-        if res.is_err() {
-            return res;
-        }
+        Display::fmt(@prefix, ref f)?;
+        let mut res: Result<(), Error> = Result::Ok(());
         while i < self.size() {
             let (new_i, value) = self.read_u8(i);
             res = format_byte_hex(value, ref f);
@@ -42,10 +37,8 @@ impl BytesDisplay of Display<Bytes> {
     fn fmt(self: @Bytes, ref f: Formatter) -> Result<(), Error> {
         let mut i: usize = 0;
         let prefix: ByteArray = "0x";
-        let mut res = Display::fmt(@prefix, ref f);
-        if res.is_err() {
-            return res;
-        }
+        Display::fmt(@prefix, ref f)?;
+        let mut res: Result<(), Error> = Result::Ok(());
         while i < self.size() {
             let (new_i, value) = self.read_u8(i);
             res = format_byte_hex(value, ref f);

--- a/src/bytes/src/utils.cairo
+++ b/src/bytes/src/utils.cairo
@@ -21,14 +21,15 @@ impl BytesDebug of Debug<Bytes> {
         let prefix: ByteArray = "0x";
         Display::fmt(@prefix, ref f)?;
         let mut res: Result<(), Error> = Result::Ok(());
-        while i < self.size() {
-            let (new_i, value) = self.read_u8(i);
-            res = format_byte_hex(value, ref f);
-            if res.is_err() {
-                break;
-            }
-            i = new_i;
-        };
+        while i < self
+            .size() {
+                let (new_i, value) = self.read_u8(i);
+                res = format_byte_hex(value, ref f);
+                if res.is_err() {
+                    break;
+                }
+                i = new_i;
+            };
         res
     }
 }
@@ -39,14 +40,15 @@ impl BytesDisplay of Display<Bytes> {
         let prefix: ByteArray = "0x";
         Display::fmt(@prefix, ref f)?;
         let mut res: Result<(), Error> = Result::Ok(());
-        while i < self.size() {
-            let (new_i, value) = self.read_u8(i);
-            res = format_byte_hex(value, ref f);
-            if res.is_err() {
-                break;
-            }
-            i = new_i;
-        };
+        while i < self
+            .size() {
+                let (new_i, value) = self.read_u8(i);
+                res = format_byte_hex(value, ref f);
+                if res.is_err() {
+                    break;
+                }
+                i = new_i;
+            };
         res
     }
 }

--- a/src/bytes/src/utils.cairo
+++ b/src/bytes/src/utils.cairo
@@ -1,6 +1,61 @@
+use alexandria_bytes::{Bytes, BytesTrait};
 use alexandria_data_structures::array_ext::ArrayTraitExt;
+use core::fmt::{Debug, Display, Formatter, Error};
+use core::to_byte_array::{AppendFormattedToByteArray, FormatAsByteArray};
 use integer::u128_byte_reverse;
 use keccak::{u128_to_u64, u128_split as u128_split_to_u64, cairo_keccak};
+
+fn format_byte_hex(byte: u8, ref f: Formatter) -> Result<(), Error> {
+    let base: NonZero<u8> = 16_u8.try_into().unwrap();
+    if byte < 0x10 {
+        let zero: ByteArray = "0";
+        let res = Display::fmt(@zero, ref f);
+        if res.is_err() {
+            return res;
+        }
+    }
+    Display::fmt(@byte.format_as_byte_array(base), ref f)
+}
+
+impl BytesDebug of Debug<Bytes> {
+    fn fmt(self: @Bytes, ref f: Formatter) -> Result<(), Error> {
+        let mut i: usize = 0;
+        let prefix: ByteArray = "0x";
+        let mut res = Display::fmt(@prefix, ref f);
+        if res.is_err() {
+            return res;
+        }
+        while i < self.size() {
+            let (new_i, value) = self.read_u8(i);
+            res = format_byte_hex(value, ref f);
+            if res.is_err() {
+                break;
+            }
+            i = new_i;
+        };
+        res
+    }
+}
+
+impl BytesDisplay of Display<Bytes> {
+    fn fmt(self: @Bytes, ref f: Formatter) -> Result<(), Error> {
+        let mut i: usize = 0;
+        let prefix: ByteArray = "0x";
+        let mut res = Display::fmt(@prefix, ref f);
+        if res.is_err() {
+            return res;
+        }
+        while i < self.size() {
+            let (new_i, value) = self.read_u8(i);
+            res = format_byte_hex(value, ref f);
+            if res.is_err() {
+                break;
+            }
+            i = new_i;
+        };
+        res
+    }
+}
 
 /// Computes the keccak256 of multiple uint128 values.
 /// The values are interpreted as big-endian.

--- a/src/bytes/src/utils.cairo
+++ b/src/bytes/src/utils.cairo
@@ -8,6 +8,7 @@ use keccak::{u128_to_u64, u128_split as u128_split_to_u64, cairo_keccak};
 fn format_byte_hex(byte: u8, ref f: Formatter) -> Result<(), Error> {
     let base: NonZero<u8> = 16_u8.try_into().unwrap();
     if byte < 0x10 {
+        // Add leading zero for single digit numbers
         let zero: ByteArray = "0";
         let res = Display::fmt(@zero, ref f);
         if res.is_err() {

--- a/src/encoding/README.md
+++ b/src/encoding/README.md
@@ -3,3 +3,99 @@
 ## [Base64](./src/base64.cairo)
 
 Base64 is a binary-to-text encoding scheme used for transferring binary data safely over media designed for text. It divides input data into 3-byte blocks, each converted into 4 ASCII characters using a specific index table. If input bytes aren't divisible by three, it's padded with '=' characters. The process is reversed for decoding.
+
+## [Solidity ABI](./src/sol_abi.cairo)
+
+**sol_abi** is a wrapper around `alexandria_bytes::Bytes` providing easy to use interfaces to mimic Solidity's `abi` functions.
+
+### Examples
+
+1. **Encode** and **EncodePacked**
+
+Solidity's `abi.encode` calls go from :
+
+```solidity
+uint8 v1 = 0x1a;
+uint128 v2 = 0x101112131415161718191a1b1c1d1e1f;
+bool v3 = true;
+address v4 = 0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF;
+bytes7 v5 = 0x000a0b0c0d0e0f;
+
+abi.encode(v1, v2, v3, v4, v5);
+```
+
+to the Cairo equivalent :
+
+```rust
+use alexandria_bytes::{Bytes, BytesTrait};
+use alexandria_encoding::sol_abi::{SolBytesTrait, SolAbiEncodeTrait};
+use starknet::{ContractAddress, eth_address::U256IntoEthAddress, EthAddress};
+
+fn main() {
+    let eth_address: EthAddress = 0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF_u256.into();
+    let mut encoded: Bytes = BytesTrait::new_empty();
+    encoded = encoded
+        .encode(0x1a_u8)
+        .encode(0x101112131415161718191a1b1c1d1e1f_u128)
+        .encode(true)
+        .encode(eth_address)
+        .encode(SolBytesTrait::bytes7(0xa0b0c0d0e0f));
+}
+```
+
+Which will properly pad individual types according to Solidity's spec. A similar interface is also supported for `abi.encodePacked` with the Cairo `encode_packed`.
+
+2. **Decode**
+
+Solidity's `abi.decode` calls go from :
+
+```solidity
+bytes memory encoded = ...
+(uint8 o1, uint128 o2, bool o3, address o4, bytes7 o5) = abi.decode(encoded, (uint8, uint128, bool, address, bytes7));
+```
+
+to the Cairo equivalent :
+
+```rust
+use alexandria_bytes::{Bytes, BytesTrait};
+use alexandria_encoding::sol_abi::{SolBytesTrait, SolAbiDecodeTrait};
+use starknet::{ContractAddress, eth_address::U256IntoEthAddress, EthAddress};
+
+fn main() {
+    let encoded: Bytes = ...
+    
+    let mut offset = 0;
+    let o1: u8 = encoded.decode(ref offset);
+    let o2: u128 = encoded.decode(ref offset);
+    let o3: bool = encoded.decode(ref offset);
+    let o4: EthAddress = encoded.decode(ref offset);
+    let o5: Bytes = SolBytesTrait::<Bytes>::bytes7(encoded.decode(ref offset));
+}
+```
+
+Which decodes bytes formatted like from an `encode` call.
+
+3. **BytesX**
+
+Solidity supports types `bytes1`, `bytes2`, ..., and `bytes32`, which are left-aligned/right-padded byte arrays when encoded.
+
+This module adds the `SolBytesTrait` wrapper for `alexandria_bytes::Bytes`, so declaring and using these is easier in Cairo.
+
+Solidity bytes declarations :
+
+```solidity
+bytes3 v1 = 0xabcdef;
+bytes32 v2 = 0x101112131415161718191a1b1c1d1e1f0102030405060708090a0b0c0d0e1011;
+bytes7 v3 = 0x01020304050607;
+```
+
+can be done in Cairo like :
+
+```rust
+use alexandria_bytes::{Bytes, BytesTrait};
+use alexandria_encoding::sol_abi::SolBytesTrait;
+
+let v1: Bytes = SolBytesTrait::bytes3(0xabcdef_u128);
+let v2: Bytes = SolBytesTrait::bytes32(0x101112131415161718191a1b1c1d1e1f0102030405060708090a0b0c0d0e1011_u256);
+let v3: Bytes = SolBytesTrait::bytes7(BytesTrait::new(16, array![0x01020304050607000000000000000000]));
+```

--- a/src/encoding/Scarb.toml
+++ b/src/encoding/Scarb.toml
@@ -10,3 +10,4 @@ fmt.workspace = true
 [dependencies]
 alexandria_math = { path = "../math" }
 alexandria_numeric = { path = "../numeric" }
+alexandria_bytes = { path = "../bytes" }

--- a/src/encoding/src/lib.cairo
+++ b/src/encoding/src/lib.cairo
@@ -1,6 +1,7 @@
 mod base64;
 mod reversible;
 mod rlp;
+mod sol_abi;
 
 #[cfg(test)]
 mod tests;

--- a/src/encoding/src/sol_abi.cairo
+++ b/src/encoding/src/sol_abi.cairo
@@ -1,0 +1,9 @@
+pub mod decode;
+pub mod encode;
+pub mod encode_as;
+pub mod sol_bytes;
+
+use decode::{SolAbiDecodeTrait};
+use encode::{SolAbiEncodeSelectorTrait, SolAbiEncodeTrait};
+use encode_as::{SolAbiEncodeAsTrait};
+use sol_bytes::{SolBytesTrait};

--- a/src/encoding/src/sol_abi/decode.cairo
+++ b/src/encoding/src/sol_abi/decode.cairo
@@ -2,18 +2,18 @@ use alexandria_bytes::{Bytes, BytesTrait};
 use alexandria_encoding::sol_abi::SolBytesTrait;
 use starknet::{ContractAddress, EthAddress, eth_address::U256IntoEthAddress};
 
-// Decode trait meant to provide an interface similar to Solidity's abi.decode
-// function. It is meant to be used in a chain where the passed in `offset` is
-// updated after each decode operation.
-// Values are expected to be 32 bytes long, and will be interpreted as if they
-// were encoded using the `abi.encode` function in Solidity.
+/// Decode trait meant to provide an interface similar to Solidity's abi.decode
+/// function. It is meant to be used in a chain where the passed in `offset` is
+/// updated after each decode operation.
+/// Values are expected to be 32 bytes long, and will be interpreted as if they
+/// were encoded using the `abi.encode` function in Solidity.
 pub trait SolAbiDecodeTrait<T> {
     fn decode(self: @Bytes, ref offset: usize) -> T;
 }
 
-// Decode int types
-// Integers are decoded by reading 32 bytes from the `offset`
-// `Bytes` encoding is right-aligned/left-paddded Big-endian.
+/// Decode int types
+/// Integers are decoded by reading 32 bytes from the `offset`
+/// `Bytes` encoding is right-aligned/left-paddded Big-endian.
 
 pub impl SolAbiDecodeU8 of SolAbiDecodeTrait<u8> {
     fn decode(self: @Bytes, ref offset: usize) -> u8 {
@@ -63,9 +63,9 @@ pub impl SolAbiDecodeU256 of SolAbiDecodeTrait<u256> {
     }
 }
 
-// Decode other primitives
-// Primitives are decoded by reading 32 bytes from the `offset`
-// `Bytes` encoding is right-aligned/left-paddded Big-endian.
+/// Decode other primitives
+/// Primitives are decoded by reading 32 bytes from the `offset`
+/// `Bytes` encoding is right-aligned/left-paddded Big-endian.
 
 pub impl SolAbiDecodeBool of SolAbiDecodeTrait<bool> {
     fn decode(self: @Bytes, ref offset: usize) -> bool {
@@ -94,9 +94,9 @@ pub impl SolAbiDecodeBytes31 of SolAbiDecodeTrait<bytes31> {
     }
 }
 
-// Decode byte types
-// Bytes are decoded by reading 32 bytes from the `offset`
-// `Bytes` encoding is left-aligned/right-paddded
+/// Decode byte types
+/// Bytes are decoded by reading 32 bytes from the `offset`
+/// `Bytes` encoding is left-aligned/right-paddded
 
 pub impl SolAbiDecodeBytes of SolAbiDecodeTrait<Bytes> {
     fn decode(self: @Bytes, ref offset: usize) -> Bytes {
@@ -114,9 +114,9 @@ pub impl SolAbiDecodeByteArray of SolAbiDecodeTrait<ByteArray> {
     }
 }
 
-// Decode address types
-// Addresses are decoded by reading 32 bytes from the `offset`
-// `Bytes` encoding is right-aligned/left-paddded Big-endian.
+/// Decode address types
+/// Addresses are decoded by reading 32 bytes from the `offset`
+/// `Bytes` encoding is right-aligned/left-paddded Big-endian.
 
 pub impl SolAbiDecodeStarknetAddress of SolAbiDecodeTrait<ContractAddress> {
     fn decode(self: @Bytes, ref offset: usize) -> ContractAddress {

--- a/src/encoding/src/sol_abi/decode.cairo
+++ b/src/encoding/src/sol_abi/decode.cairo
@@ -1,0 +1,138 @@
+use alexandria_bytes::{Bytes, BytesTrait};
+use alexandria_encoding::sol_abi::SolBytesTrait;
+use starknet::{ContractAddress, EthAddress, eth_address::U256IntoEthAddress};
+
+// Decode trait meant to provide an interface similar to Solidity's abi.decode
+// function. It is meant to be used in a chain where the passed in `offset` is
+// updated after each decode operation.
+// Values are expected to be 32 bytes long, and will be interpreted as if they
+// were encoded using the `abi.encode` function in Solidity.
+pub trait SolAbiDecodeTrait<T> {
+    fn decode(self: @Bytes, ref offset: usize) -> T;
+}
+
+// Decode int types
+// Integers are decoded by reading 32 bytes from the `offset`
+// `Bytes` encoding is right-aligned/left-paddded Big-endian.
+
+pub impl SolAbiDecodeU8 of SolAbiDecodeTrait<u8> {
+    fn decode(self: @Bytes, ref offset: usize) -> u8 {
+        let (new_offset, decodedU8) = self.read_u256(offset);
+        offset = new_offset;
+        decodedU8.try_into().expect('Couldn\'t convert to u8')
+    }
+}
+
+pub impl SolAbiDecodeU16 of SolAbiDecodeTrait<u16> {
+    fn decode(self: @Bytes, ref offset: usize) -> u16 {
+        let (new_offset, decodedU16) = self.read_u256(offset);
+        offset = new_offset;
+        decodedU16.try_into().expect('Couldn\'t convert to u16')
+    }
+}
+
+pub impl SolAbiDecodeU32 of SolAbiDecodeTrait<u32> {
+    fn decode(self: @Bytes, ref offset: usize) -> u32 {
+        let (new_offset, decodedU32) = self.read_u256(offset);
+        offset = new_offset;
+        decodedU32.try_into().expect('Couldn\'t convert to u32')
+    }
+}
+
+pub impl SolAbiDecodeU64 of SolAbiDecodeTrait<u64> {
+    fn decode(self: @Bytes, ref offset: usize) -> u64 {
+        let (new_offset, decodedU64) = self.read_u256(offset);
+        offset = new_offset;
+        decodedU64.try_into().expect('Couldn\'t convert to u64')
+    }
+}
+
+pub impl SolAbiDecodeU128 of SolAbiDecodeTrait<u128> {
+    fn decode(self: @Bytes, ref offset: usize) -> u128 {
+        let (new_offset, decodedU128) = self.read_u256(offset);
+        offset = new_offset;
+        decodedU128.try_into().expect('Couldn\'t convert to u128')
+    }
+}
+
+pub impl SolAbiDecodeU256 of SolAbiDecodeTrait<u256> {
+    fn decode(self: @Bytes, ref offset: usize) -> u256 {
+        let (new_offset, decodedU256) = self.read_u256(offset);
+        offset = new_offset;
+        decodedU256
+    }
+}
+
+// Decode other primitives
+// Primitives are decoded by reading 32 bytes from the `offset`
+// `Bytes` encoding is right-aligned/left-paddded Big-endian.
+
+pub impl SolAbiDecodeBool of SolAbiDecodeTrait<bool> {
+    fn decode(self: @Bytes, ref offset: usize) -> bool {
+        let (new_offset, decodedBool) = self.read_u256(offset);
+        offset = new_offset;
+        decodedBool != 0
+    }
+}
+
+pub impl SolAbiDecodeFelt252 of SolAbiDecodeTrait<felt252> {
+    fn decode(self: @Bytes, ref offset: usize) -> felt252 {
+        let (new_offset, decodedFelt252) = self.read_u256(offset);
+        offset = new_offset;
+        decodedFelt252.try_into().expect('Couldn\'t convert to felt252')
+    }
+}
+
+pub impl SolAbiDecodeBytes31 of SolAbiDecodeTrait<bytes31> {
+    fn decode(self: @Bytes, ref offset: usize) -> bytes31 {
+        let (new_offset, decodedBytes31) = self.read_u256(offset);
+        offset = new_offset;
+        let decodedBytes31: felt252 = decodedBytes31
+            .try_into()
+            .expect('Couldn\'t convert to felt252');
+        decodedBytes31.try_into().expect('Couldn\'t convert to bytes31')
+    }
+}
+
+// Decode byte types
+// Bytes are decoded by reading 32 bytes from the `offset`
+// `Bytes` encoding is left-aligned/right-paddded
+
+pub impl SolAbiDecodeBytes of SolAbiDecodeTrait<Bytes> {
+    fn decode(self: @Bytes, ref offset: usize) -> Bytes {
+        let (new_offset, decodedBytes) = self.read_u256(offset);
+        offset = new_offset;
+        SolBytesTrait::bytes32(decodedBytes)
+    }
+}
+
+pub impl SolAbiDecodeByteArray of SolAbiDecodeTrait<ByteArray> {
+    fn decode(self: @Bytes, ref offset: usize) -> ByteArray {
+        let (new_offset, decodedBytes) = self.read_u256(offset);
+        offset = new_offset;
+        SolBytesTrait::bytes32(decodedBytes).to_byte_array()
+    }
+}
+
+// Decode address types
+// Addresses are decoded by reading 32 bytes from the `offset`
+// `Bytes` encoding is right-aligned/left-paddded Big-endian.
+
+pub impl SolAbiDecodeStarknetAddress of SolAbiDecodeTrait<ContractAddress> {
+    fn decode(self: @Bytes, ref offset: usize) -> ContractAddress {
+        let (new_offset, decodedAddress) = self.read_u256(offset);
+        offset = new_offset;
+        let decodedAddress: felt252 = decodedAddress
+            .try_into()
+            .expect('Couldn\'t convert to felt252');
+        decodedAddress.try_into().expect('Couldn\'t convert to address')
+    }
+}
+
+pub impl SolAbiDecodeEthAddress of SolAbiDecodeTrait<EthAddress> {
+    fn decode(self: @Bytes, ref offset: usize) -> EthAddress {
+        let (new_offset, decodedAddress) = self.read_u256(offset);
+        offset = new_offset;
+        decodedAddress.try_into().expect('Couldn\'t convert to address')
+    }
+}

--- a/src/encoding/src/sol_abi/encode.cairo
+++ b/src/encoding/src/sol_abi/encode.cairo
@@ -1,0 +1,217 @@
+use alexandria_bytes::{Bytes, BytesTrait};
+use alexandria_math::U256BitShift;
+use starknet::{ContractAddress, EthAddress};
+
+// Encode selector trait meant to provide an interface similar to Solidity's abi.encodeWithSelector
+// function. It is meant to be the first call in an encode chain, adding the function selector to
+// the encoded data. Value encoded is only 4 bytes long representing the function selector.
+// Use like this: BytesTrait::new_empty().encode_selector(selector).encode(arg1).encode(arg2)...
+pub trait SolAbiEncodeSelectorTrait {
+    fn encode_selector(self: Bytes, selector: u32) -> Bytes;
+}
+
+pub impl SolAbiEncodeSelector of SolAbiEncodeSelectorTrait {
+    fn encode_selector(mut self: Bytes, selector: u32) -> Bytes {
+        self.append_u32(selector);
+        self
+    }
+}
+
+// Encode trait meant to provide an interface similar to Solidity's abi.encode
+// function. It is meant to allow chaining of encode calls to build up a `Bytes`
+// object. Values are encoded in 32 bytes chunks, and padding is added as necessary.
+// Also provides a packed version of the encoding similar to Solidity's
+// abi.encodePacked, which does not add padding.
+// Use like this: BytesTrait::new_empty().encode(arg1).encode(arg2)...
+// Or like this: BytesTrait::new_empty().encode_packed(arg1).encode_packed(arg2)...
+pub trait SolAbiEncodeTrait<T> {
+    fn encode(self: Bytes, x: T) -> Bytes;
+    fn encode_packed(self: Bytes, x: T) -> Bytes;
+}
+
+// Encode int types
+// Integers are encoded as 32 bytes long, which are right-aligned/left-padded Big-endian.
+// Packed encodings are not padded and only append the bytes of the value based on type.
+
+pub impl SolAbiEncodeU8 of SolAbiEncodeTrait<u8> {
+    fn encode(mut self: Bytes, x: u8) -> Bytes {
+        self.append_u256(x.into());
+        self
+    }
+
+    fn encode_packed(mut self: Bytes, x: u8) -> Bytes {
+        self.append_u8(x);
+        self
+    }
+}
+
+pub impl SolAbiEncodeU16 of SolAbiEncodeTrait<u16> {
+    fn encode(mut self: Bytes, x: u16) -> Bytes {
+        self.append_u256(x.into());
+        self
+    }
+
+    fn encode_packed(mut self: Bytes, x: u16) -> Bytes {
+        self.append_u16(x);
+        self
+    }
+}
+
+pub impl SolAbiEncodeU32 of SolAbiEncodeTrait<u32> {
+    fn encode(mut self: Bytes, x: u32) -> Bytes {
+        self.append_u256(x.into());
+        self
+    }
+
+    fn encode_packed(mut self: Bytes, x: u32) -> Bytes {
+        self.append_u32(x);
+        self
+    }
+}
+
+pub impl SolAbiEncodeU64 of SolAbiEncodeTrait<u64> {
+    fn encode(mut self: Bytes, x: u64) -> Bytes {
+        self.append_u256(x.into());
+        self
+    }
+
+    fn encode_packed(mut self: Bytes, x: u64) -> Bytes {
+        self.append_u64(x);
+        self
+    }
+}
+
+pub impl SolAbiEncodeU128 of SolAbiEncodeTrait<u128> {
+    fn encode(mut self: Bytes, x: u128) -> Bytes {
+        self.append_u256(x.into());
+        self
+    }
+
+    fn encode_packed(mut self: Bytes, x: u128) -> Bytes {
+        self.append_u128(x);
+        self
+    }
+}
+
+pub impl SolAbiEncodeU256 of SolAbiEncodeTrait<u256> {
+    fn encode(mut self: Bytes, x: u256) -> Bytes {
+        self.append_u256(x);
+        self
+    }
+
+    fn encode_packed(mut self: Bytes, x: u256) -> Bytes {
+        self.append_u256(x);
+        self
+    }
+}
+
+// Encode other primitives
+// Primitives are encoded as 32 bytes long, which are right-aligned/left-padded Big-endian.
+// Packed encodings are not padded and only append the bytes of the value based on type.
+
+pub impl SolAbiEncodeBool of SolAbiEncodeTrait<bool> {
+    fn encode(mut self: Bytes, x: bool) -> Bytes {
+        if x {
+            self.append_u256(1);
+        } else {
+            self.append_u256(0);
+        }
+        self
+    }
+
+    fn encode_packed(mut self: Bytes, x: bool) -> Bytes {
+        if x {
+            self.append_u8(1);
+        } else {
+            self.append_u8(0);
+        }
+        self
+    }
+}
+
+pub impl SolAbiEncodeFelt252 of SolAbiEncodeTrait<felt252> {
+    fn encode(mut self: Bytes, x: felt252) -> Bytes {
+        self.append_u256(x.into());
+        self
+    }
+
+    fn encode_packed(mut self: Bytes, x: felt252) -> Bytes {
+        self.append_felt252(x);
+        self
+    }
+}
+
+pub impl SolAbiEncodeBytes31 of SolAbiEncodeTrait<bytes31> {
+    fn encode(mut self: Bytes, x: bytes31) -> Bytes {
+        self.append_u256(x.into());
+        self
+    }
+
+    fn encode_packed(mut self: Bytes, x: bytes31) -> Bytes {
+        self.append_bytes31(x);
+        self
+    }
+}
+
+// Encode byte types
+// Bytes are encoded as 32 bytes long, which are left-aligned/right-padded.
+// Packed encodings are not padded and only append the bytes up to the length of the value.
+
+pub impl SolAbiEncodeBytes of SolAbiEncodeTrait<Bytes> {
+    fn encode(mut self: Bytes, mut x: Bytes) -> Bytes {
+        self.concat(@x);
+        self.concat(@BytesTrait::zero(32 - (x.size() % 32)));
+        self
+    }
+
+    fn encode_packed(mut self: Bytes, x: Bytes) -> Bytes {
+        self.concat(@x);
+        self
+    }
+}
+
+pub impl SolAbiEncodeByteArray of SolAbiEncodeTrait<ByteArray> {
+    fn encode(mut self: Bytes, x: ByteArray) -> Bytes {
+        let x_len: usize = x.len();
+        self.concat(@BytesTrait::from_byte_array(x));
+        self.concat(@BytesTrait::zero(32 - (x_len % 32)));
+        self
+    }
+
+    fn encode_packed(mut self: Bytes, x: ByteArray) -> Bytes {
+        self.concat(@BytesTrait::from_byte_array(x));
+        self
+    }
+}
+
+// Encode address types
+// Addresses are encoded as 32 bytes long, which are right-aligned/left-padded Big-endian.
+// Packed encodings are not padded and only append the bytes of the value based on type.
+
+pub impl SolAbiEncodeStarknetAddress of SolAbiEncodeTrait<ContractAddress> {
+    fn encode(mut self: Bytes, x: ContractAddress) -> Bytes {
+        let address_felt252: felt252 = x.into();
+        let address_u256: u256 = address_felt252.into();
+        self.append_u256(address_u256);
+        self
+    }
+
+    fn encode_packed(mut self: Bytes, x: ContractAddress) -> Bytes {
+        self.append_address(x);
+        self
+    }
+}
+
+pub impl SolAbiEncodeEthAddress of SolAbiEncodeTrait<EthAddress> {
+    fn encode(mut self: Bytes, x: EthAddress) -> Bytes {
+        self.append_u256(x.address.into());
+        self
+    }
+
+    fn encode_packed(mut self: Bytes, x: EthAddress) -> Bytes {
+        let mut address256: u256 = x.address.into();
+        address256 = U256BitShift::shl(address256, 96); // 12 * 8
+        self.concat(@BytesTrait::new(20, array![address256.high, address256.low]));
+        self
+    }
+}

--- a/src/encoding/src/sol_abi/encode.cairo
+++ b/src/encoding/src/sol_abi/encode.cairo
@@ -2,10 +2,12 @@ use alexandria_bytes::{Bytes, BytesTrait};
 use alexandria_math::U256BitShift;
 use starknet::{ContractAddress, EthAddress};
 
-// Encode selector trait meant to provide an interface similar to Solidity's abi.encodeWithSelector
-// function. It is meant to be the first call in an encode chain, adding the function selector to
-// the encoded data. Value encoded is only 4 bytes long representing the function selector.
-// Use like this: BytesTrait::new_empty().encode_selector(selector).encode(arg1).encode(arg2)...
+/// Encode selector trait meant to provide an interface similar to Solidity's
+/// abi.encodeWithSelector function. It is meant to be the first call in an
+/// encode chain, adding the function selector to the encoded data. Value encoded
+/// is only 4 bytes long representing the function selector.
+/// Use like this:
+/// BytesTrait::new_empty().encode_selector(selector).encode(arg1).encode(arg2)...
 pub trait SolAbiEncodeSelectorTrait {
     fn encode_selector(self: Bytes, selector: u32) -> Bytes;
 }
@@ -17,21 +19,21 @@ pub impl SolAbiEncodeSelector of SolAbiEncodeSelectorTrait {
     }
 }
 
-// Encode trait meant to provide an interface similar to Solidity's abi.encode
-// function. It is meant to allow chaining of encode calls to build up a `Bytes`
-// object. Values are encoded in 32 bytes chunks, and padding is added as necessary.
-// Also provides a packed version of the encoding similar to Solidity's
-// abi.encodePacked, which does not add padding.
-// Use like this: BytesTrait::new_empty().encode(arg1).encode(arg2)...
-// Or like this: BytesTrait::new_empty().encode_packed(arg1).encode_packed(arg2)...
+/// Encode trait meant to provide an interface similar to Solidity's abi.encode
+/// function. It is meant to allow chaining of encode calls to build up a `Bytes`
+/// object. Values are encoded in 32 bytes chunks, and padding is added as necessary.
+/// Also provides a packed version of the encoding similar to Solidity's
+/// abi.encodePacked, which does not add padding.
+/// Use like this: BytesTrait::new_empty().encode(arg1).encode(arg2)...
+/// Or like this: BytesTrait::new_empty().encode_packed(arg1).encode_packed(arg2)...
 pub trait SolAbiEncodeTrait<T> {
     fn encode(self: Bytes, x: T) -> Bytes;
     fn encode_packed(self: Bytes, x: T) -> Bytes;
 }
 
-// Encode int types
-// Integers are encoded as 32 bytes long, which are right-aligned/left-padded Big-endian.
-// Packed encodings are not padded and only append the bytes of the value based on type.
+/// Encode int types
+/// Integers are encoded as 32 bytes long, which are right-aligned/left-padded Big-endian.
+/// Packed encodings are not padded and only append the bytes of the value based on type.
 
 pub impl SolAbiEncodeU8 of SolAbiEncodeTrait<u8> {
     fn encode(mut self: Bytes, x: u8) -> Bytes {
@@ -105,9 +107,9 @@ pub impl SolAbiEncodeU256 of SolAbiEncodeTrait<u256> {
     }
 }
 
-// Encode other primitives
-// Primitives are encoded as 32 bytes long, which are right-aligned/left-padded Big-endian.
-// Packed encodings are not padded and only append the bytes of the value based on type.
+/// Encode other primitives
+/// Primitives are encoded as 32 bytes long, which are right-aligned/left-padded Big-endian.
+/// Packed encodings are not padded and only append the bytes of the value based on type.
 
 pub impl SolAbiEncodeBool of SolAbiEncodeTrait<bool> {
     fn encode(mut self: Bytes, x: bool) -> Bytes {
@@ -153,9 +155,9 @@ pub impl SolAbiEncodeBytes31 of SolAbiEncodeTrait<bytes31> {
     }
 }
 
-// Encode byte types
-// Bytes are encoded as 32 bytes long, which are left-aligned/right-padded.
-// Packed encodings are not padded and only append the bytes up to the length of the value.
+/// Encode byte types
+/// Bytes are encoded as 32 bytes long, which are left-aligned/right-padded.
+/// Packed encodings are not padded and only append the bytes up to the length of the value.
 
 pub impl SolAbiEncodeBytes of SolAbiEncodeTrait<Bytes> {
     fn encode(mut self: Bytes, mut x: Bytes) -> Bytes {
@@ -184,9 +186,9 @@ pub impl SolAbiEncodeByteArray of SolAbiEncodeTrait<ByteArray> {
     }
 }
 
-// Encode address types
-// Addresses are encoded as 32 bytes long, which are right-aligned/left-padded Big-endian.
-// Packed encodings are not padded and only append the bytes of the value based on type.
+/// Encode address types
+/// Addresses are encoded as 32 bytes long, which are right-aligned/left-padded Big-endian.
+/// Packed encodings are not padded and only append the bytes of the value based on type.
 
 pub impl SolAbiEncodeStarknetAddress of SolAbiEncodeTrait<ContractAddress> {
     fn encode(mut self: Bytes, x: ContractAddress) -> Bytes {

--- a/src/encoding/src/sol_abi/encode_as.cairo
+++ b/src/encoding/src/sol_abi/encode_as.cairo
@@ -1,0 +1,76 @@
+use alexandria_bytes::{Bytes, BytesTrait};
+use alexandria_math::{U128BitShift, U256BitShift};
+
+// Encode trait for arbitrarily sized encodings, meant to allow easy bytesX type encodings.
+// Encode the value `x` as `Bytes` with a specific `byteSize`. Allows chaining of encode/encode_as
+// calls to build up a `Bytes` object.
+// Use like : `let encoded: Bytes = Bytes::new_empty().encode_as(32, x).encode_as(13, y)...`
+pub trait SolAbiEncodeAsTrait<T> {
+    fn encode_as(self: Bytes, byteSize: usize, x: T) -> Bytes;
+}
+
+// Encode as from int types
+// Integers are encoded as `byteSize` bytes, which are right-aligned/left-padded Big-endian.
+
+pub impl SolAbiEncodeAsU256 of SolAbiEncodeAsTrait<u256> {
+    fn encode_as(mut self: Bytes, byteSize: usize, mut x: u256) -> Bytes {
+        assert!(byteSize <= 32, "byteSize must be <= 32");
+        x = U256BitShift::shl(x, 8 * (32 - byteSize.into()));
+        let bytesRes: Bytes = BytesTrait::new(byteSize, array![x.high, x.low]);
+        self.concat(@bytesRes);
+        self
+    }
+}
+
+pub impl SolAbiEncodeAsU128 of SolAbiEncodeAsTrait<u128> {
+    fn encode_as(mut self: Bytes, byteSize: usize, mut x: u128) -> Bytes {
+        if byteSize > 16 {
+            self = self.encode_as(byteSize, Into::<u128, u256>::into(x));
+        } else {
+            x = U128BitShift::shl(x, 8 * (16 - byteSize.into()));
+            let bytesRes: Bytes = BytesTrait::new(byteSize, array![x]);
+            self.concat(@bytesRes);
+        }
+        self
+    }
+}
+
+pub impl SolAbiEncodeAsFelt252 of SolAbiEncodeAsTrait<felt252> {
+    fn encode_as(mut self: Bytes, byteSize: usize, x: felt252) -> Bytes {
+        assert!(byteSize <= 32, "byteSize must be <= 32");
+        let mut x: u256 = x.into();
+        x = U256BitShift::shl(x, 8 * (32 - byteSize.into()));
+        let bytesRes: Bytes = BytesTrait::new(byteSize, array![x.high, x.low]);
+        self.concat(@bytesRes);
+        self
+    }
+}
+
+pub impl SolAbiEncodeAsBytes31 of SolAbiEncodeAsTrait<bytes31> {
+    fn encode_as(mut self: Bytes, byteSize: usize, x: bytes31) -> Bytes {
+        assert!(byteSize <= 32, "byteSize must be <= 32");
+        let mut x: u256 = x.into();
+        x = U256BitShift::shl(x, 8 * (32 - byteSize.into()));
+        let bytesRes: Bytes = BytesTrait::new(byteSize, array![x.high, x.low]);
+        self.concat(@bytesRes);
+        self
+    }
+}
+
+// Encode as from bytes types
+// Bytes are encoded as `byteSize` bytes, which are left-aligned/right-padded.
+
+pub impl SolAbiEncodeAsBytes of SolAbiEncodeAsTrait<Bytes> {
+    fn encode_as(mut self: Bytes, byteSize: usize, x: Bytes) -> Bytes {
+        self.concat(@BytesTrait::new(byteSize, x.data));
+        self
+    }
+}
+
+pub impl SolAbiEncodeAsByteArray of SolAbiEncodeAsTrait<ByteArray> {
+    fn encode_as(mut self: Bytes, byteSize: usize, x: ByteArray) -> Bytes {
+        let x: Bytes = BytesTrait::from_byte_array(x);
+        self.concat(@BytesTrait::new(byteSize, x.data));
+        self
+    }
+}

--- a/src/encoding/src/sol_abi/encode_as.cairo
+++ b/src/encoding/src/sol_abi/encode_as.cairo
@@ -1,16 +1,17 @@
 use alexandria_bytes::{Bytes, BytesTrait};
 use alexandria_math::{U128BitShift, U256BitShift};
 
-// Encode trait for arbitrarily sized encodings, meant to allow easy bytesX type encodings.
-// Encode the value `x` as `Bytes` with a specific `byteSize`. Allows chaining of encode/encode_as
-// calls to build up a `Bytes` object.
-// Use like : `let encoded: Bytes = Bytes::new_empty().encode_as(32, x).encode_as(13, y)...`
+/// Encode trait for arbitrarily sized encodings, meant to allow easy bytesX
+/// type encodings. Encode the value `x` as `Bytes` with a specific `byteSize`.
+/// Allows chaining of encode/encode_as calls to build up a `Bytes` object.
+/// Use like :
+/// `let encoded: Bytes = Bytes::new_empty().encode_as(32, x).encode_as(13, y)...`
 pub trait SolAbiEncodeAsTrait<T> {
     fn encode_as(self: Bytes, byteSize: usize, x: T) -> Bytes;
 }
 
-// Encode as from int types
-// Integers are encoded as `byteSize` bytes, which are right-aligned/left-padded Big-endian.
+/// Encode as from int types
+/// Integers are encoded as `byteSize` bytes, which are right-aligned/left-padded Big-endian.
 
 pub impl SolAbiEncodeAsU256 of SolAbiEncodeAsTrait<u256> {
     fn encode_as(mut self: Bytes, byteSize: usize, mut x: u256) -> Bytes {
@@ -57,8 +58,8 @@ pub impl SolAbiEncodeAsBytes31 of SolAbiEncodeAsTrait<bytes31> {
     }
 }
 
-// Encode as from bytes types
-// Bytes are encoded as `byteSize` bytes, which are left-aligned/right-padded.
+/// Encode as from bytes types
+/// Bytes are encoded as `byteSize` bytes, which are left-aligned/right-padded.
 
 pub impl SolAbiEncodeAsBytes of SolAbiEncodeAsTrait<Bytes> {
     fn encode_as(mut self: Bytes, byteSize: usize, x: Bytes) -> Bytes {

--- a/src/encoding/src/sol_abi/sol_bytes.cairo
+++ b/src/encoding/src/sol_abi/sol_bytes.cairo
@@ -1,10 +1,11 @@
 use alexandria_bytes::{Bytes, BytesTrait};
 use alexandria_encoding::sol_abi::SolAbiEncodeAsTrait;
 
-// Solidity Bytes Trait meant to provide an interface similar to Solidity's bytesX types.
-// Like `bytes1`, `bytes2`, `bytes3`, ..., `bytes32`. Acts as a wrapper around the `encode_as`
-// to make it easier to understand and use.
-// Use like this: `let bytes7Val: Bytes = SolBytesTrait::bytes7(0x01020304050607_u128);`
+/// Solidity Bytes Trait meant to provide an interface similar to Solidity's
+/// bytesX types, like `bytes1`, `bytes2`, `bytes3`, ..., `bytes32`. Acts as
+/// a wrapper around the `encode_as` to make it easier to understand and use.
+/// Use like this:
+/// `let bytes7Val: Bytes = SolBytesTrait::bytes7(0x01020304050607_u128);`
 pub trait SolBytesTrait<T> {
     fn bytes1(val: T) -> Bytes;
     fn bytes2(val: T) -> Bytes;

--- a/src/encoding/src/sol_abi/sol_bytes.cairo
+++ b/src/encoding/src/sol_abi/sol_bytes.cairo
@@ -1,0 +1,146 @@
+use alexandria_bytes::{Bytes, BytesTrait};
+use alexandria_encoding::sol_abi::SolAbiEncodeAsTrait;
+
+// Solidity Bytes Trait meant to provide an interface similar to Solidity's bytesX types.
+// Like `bytes1`, `bytes2`, `bytes3`, ..., `bytes32`. Acts as a wrapper around the `encode_as`
+// to make it easier to understand and use.
+// Use like this: `let bytes7Val: Bytes = SolBytesTrait::bytes7(0x01020304050607_u128);`
+pub trait SolBytesTrait<T> {
+    fn bytes1(val: T) -> Bytes;
+    fn bytes2(val: T) -> Bytes;
+    fn bytes3(val: T) -> Bytes;
+    fn bytes4(val: T) -> Bytes;
+    fn bytes5(val: T) -> Bytes;
+    fn bytes6(val: T) -> Bytes;
+    fn bytes7(val: T) -> Bytes;
+    fn bytes8(val: T) -> Bytes;
+    fn bytes9(val: T) -> Bytes;
+    fn bytes10(val: T) -> Bytes;
+    fn bytes11(val: T) -> Bytes;
+    fn bytes12(val: T) -> Bytes;
+    fn bytes13(val: T) -> Bytes;
+    fn bytes14(val: T) -> Bytes;
+    fn bytes15(val: T) -> Bytes;
+    fn bytes16(val: T) -> Bytes;
+    fn bytes17(val: T) -> Bytes;
+    fn bytes18(val: T) -> Bytes;
+    fn bytes19(val: T) -> Bytes;
+    fn bytes20(val: T) -> Bytes;
+    fn bytes21(val: T) -> Bytes;
+    fn bytes22(val: T) -> Bytes;
+    fn bytes23(val: T) -> Bytes;
+    fn bytes24(val: T) -> Bytes;
+    fn bytes25(val: T) -> Bytes;
+    fn bytes26(val: T) -> Bytes;
+    fn bytes27(val: T) -> Bytes;
+    fn bytes28(val: T) -> Bytes;
+    fn bytes29(val: T) -> Bytes;
+    fn bytes30(val: T) -> Bytes;
+    fn bytes31(val: T) -> Bytes;
+    fn bytes32(val: T) -> Bytes;
+
+    fn bytes(len: usize, val: T) -> Bytes;
+}
+
+pub impl SolBytesImpl<T, +Drop<T>, +SolAbiEncodeAsTrait<T>> of SolBytesTrait<T> {
+    fn bytes1(val: T) -> Bytes {
+        BytesTrait::new_empty().encode_as(1, val)
+    }
+    fn bytes2(val: T) -> Bytes {
+        BytesTrait::new_empty().encode_as(2, val)
+    }
+    fn bytes3(val: T) -> Bytes {
+        BytesTrait::new_empty().encode_as(3, val)
+    }
+    fn bytes4(val: T) -> Bytes {
+        BytesTrait::new_empty().encode_as(4, val)
+    }
+    fn bytes5(val: T) -> Bytes {
+        BytesTrait::new_empty().encode_as(5, val)
+    }
+    fn bytes6(val: T) -> Bytes {
+        BytesTrait::new_empty().encode_as(6, val)
+    }
+    fn bytes7(val: T) -> Bytes {
+        BytesTrait::new_empty().encode_as(7, val)
+    }
+    fn bytes8(val: T) -> Bytes {
+        BytesTrait::new_empty().encode_as(8, val)
+    }
+    fn bytes9(val: T) -> Bytes {
+        BytesTrait::new_empty().encode_as(9, val)
+    }
+    fn bytes10(val: T) -> Bytes {
+        BytesTrait::new_empty().encode_as(10, val)
+    }
+    fn bytes11(val: T) -> Bytes {
+        BytesTrait::new_empty().encode_as(11, val)
+    }
+    fn bytes12(val: T) -> Bytes {
+        BytesTrait::new_empty().encode_as(12, val)
+    }
+    fn bytes13(val: T) -> Bytes {
+        BytesTrait::new_empty().encode_as(13, val)
+    }
+    fn bytes14(val: T) -> Bytes {
+        BytesTrait::new_empty().encode_as(14, val)
+    }
+    fn bytes15(val: T) -> Bytes {
+        BytesTrait::new_empty().encode_as(15, val)
+    }
+    fn bytes16(val: T) -> Bytes {
+        BytesTrait::new_empty().encode_as(16, val)
+    }
+    fn bytes17(val: T) -> Bytes {
+        BytesTrait::new_empty().encode_as(17, val)
+    }
+    fn bytes18(val: T) -> Bytes {
+        BytesTrait::new_empty().encode_as(18, val)
+    }
+    fn bytes19(val: T) -> Bytes {
+        BytesTrait::new_empty().encode_as(19, val)
+    }
+    fn bytes20(val: T) -> Bytes {
+        BytesTrait::new_empty().encode_as(20, val)
+    }
+    fn bytes21(val: T) -> Bytes {
+        BytesTrait::new_empty().encode_as(21, val)
+    }
+    fn bytes22(val: T) -> Bytes {
+        BytesTrait::new_empty().encode_as(22, val)
+    }
+    fn bytes23(val: T) -> Bytes {
+        BytesTrait::new_empty().encode_as(23, val)
+    }
+    fn bytes24(val: T) -> Bytes {
+        BytesTrait::new_empty().encode_as(24, val)
+    }
+    fn bytes25(val: T) -> Bytes {
+        BytesTrait::new_empty().encode_as(25, val)
+    }
+    fn bytes26(val: T) -> Bytes {
+        BytesTrait::new_empty().encode_as(26, val)
+    }
+    fn bytes27(val: T) -> Bytes {
+        BytesTrait::new_empty().encode_as(27, val)
+    }
+    fn bytes28(val: T) -> Bytes {
+        BytesTrait::new_empty().encode_as(28, val)
+    }
+    fn bytes29(val: T) -> Bytes {
+        BytesTrait::new_empty().encode_as(29, val)
+    }
+    fn bytes30(val: T) -> Bytes {
+        BytesTrait::new_empty().encode_as(30, val)
+    }
+    fn bytes31(val: T) -> Bytes {
+        BytesTrait::new_empty().encode_as(31, val)
+    }
+    fn bytes32(val: T) -> Bytes {
+        BytesTrait::new_empty().encode_as(32, val)
+    }
+
+    fn bytes(len: usize, val: T) -> Bytes {
+        BytesTrait::new_empty().encode_as(len, val)
+    }
+}

--- a/src/encoding/src/tests.cairo
+++ b/src/encoding/src/tests.cairo
@@ -2,3 +2,4 @@ mod base64_felt_test;
 mod base64_test;
 mod reversible_test;
 mod rlp_test;
+mod sol_abi;

--- a/src/encoding/src/tests/sol_abi.cairo
+++ b/src/encoding/src/tests/sol_abi.cairo
@@ -1,0 +1,320 @@
+use alexandria_bytes::utils::{BytesDebug, BytesDisplay};
+use alexandria_bytes::{Bytes, BytesTrait};
+use alexandria_encoding::sol_abi::{
+    SolAbiEncodeTrait, SolAbiEncodeAsTrait, SolAbiEncodeSelectorTrait, SolAbiDecodeTrait,
+    SolBytesTrait
+};
+use core::to_byte_array::FormatAsByteArray;
+use starknet::{ContractAddress, eth_address::U256IntoEthAddress, EthAddress};
+
+// Compare Bytes types up to the size of the data ( incase different values outside size range )
+fn compare_bytes(actual: @Bytes, expected: @Bytes) -> bool {
+    if actual.size() != expected.size() {
+        return false;
+    }
+    if actual.data.len() != expected.data.len() {
+        return false;
+    }
+    let mut i: usize = 0;
+    while i < actual.size() {
+        let (_, actual_val) = actual.read_u8(i);
+        let (_, expected_val) = expected.read_u8(i);
+        if actual_val != expected_val {
+            break;
+        }
+        i += 1;
+    };
+    if i < actual.size() {
+        return false;
+    }
+    true
+}
+
+#[test]
+fn encode_test() {
+    let expected: Bytes = BytesTrait::new(
+        480,
+        array![
+            0x00000000000000000000000000000000,
+            0x0000000000000000000000000000001a,
+            0x00000000000000000000000000000000,
+            0x101112131415161718191a1b1c1d1e1f,
+            0x00000000000000000000000000000000,
+            0x000000000000000000000000ddccbbaa,
+            0x00000000000000000000000000000000,
+            0x00000000000000000000000000001112,
+            0x00000000000000000000000000000000,
+            0x0000000000000000090a0b0c0d0e0f10,
+            0x00000000000000000000000000000000,
+            0x00000000000000000000000000000001,
+            0x0102030405060708090a0b0c0d0e1011,
+            0x12131415161718191a1b1c1d1e1f2021,
+            0x00000000000000000000000000000000,
+            0x00000000000000000000000000000000,
+            0x00000000000000000000000000000000,
+            0x00000000000000000000000000000001,
+            0x00000000000000000000000000000000,
+            1234567890,
+            0x0000000000000000000000000000abcd,
+            0xefabcdefabcdefabcdefabcdefabcdef,
+            0x000a0b0c0d0e0f000000000000000000,
+            0x00000000000000000000000000000000,
+            0x0000abcdef0000000000000000000000,
+            0x00000000000000000000000000000000,
+            0x049d36570d4e46f48e99674bd3fcc846,
+            0x44ddd6b96f7c741b1562b82f9e004dc7,
+            0x000000000000000000000000DeaDbeef,
+            0xdEAdbeefdEadbEEFdeadbeEFdEaDbeeF
+        ]
+    );
+    let mut encoded: Bytes = BytesTrait::new_empty();
+    let address: ContractAddress =
+        0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7_felt252
+        .try_into()
+        .expect('Couldn\'t convert to address');
+    let eth_address: EthAddress = 0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF_u256.into();
+    encoded = encoded
+        .encode(0x1a_u8)
+        .encode(0x101112131415161718191a1b1c1d1e1f_u128)
+        .encode(0xddccbbaa_u32)
+        .encode(0x1112_u16)
+        .encode(0x090a0b0c0d0e0f10_u64)
+        .encode(0x1_u8)
+        .encode(0x0102030405060708090a0b0c0d0e101112131415161718191a1b1c1d1e1f2021_u256)
+        .encode(false)
+        .encode(true)
+        .encode(1234567890_felt252)
+        .encode(bytes31_const::<0xabcdefabcdefabcdefabcdefabcdefabcdef>())
+        .encode(SolBytesTrait::bytes7(0xa0b0c0d0e0f))
+        .encode(SolBytesTrait::bytes5(0x0000abcdef).to_byte_array())
+        .encode(address)
+        .encode(eth_address);
+    assert_eq!(encoded, expected, "Encode uints failed");
+}
+
+#[test]
+fn encode_packed_test() {
+    let expected: Bytes = BytesTrait::new(
+        195,
+        array![
+            0x0800000000000000a7a8a9aaabacadae,
+            0xaf000abcde002a00000000101112130f,
+            0xa0a1a2a3a4a5a6a7a8a9aaabacadaeaf,
+            0xb0b1b2b3b4b5b6b7b8b9babbbcbdbe00,
+            0x01000000000000000000000000000000,
+            0x00000000000000000000000000001234,
+            0x0102030405060708090a000000000000,
+            0x00000000000000000000000000000000,
+            0x00000000001234567890049d36570d4e,
+            0x46f48e99674bd3fcc84644ddd6b96f7c,
+            0x741b1562b82f9e004dc7DeaDbeefdEAd,
+            0xbeefdEadbEEFdeadbeEFdEaDbeeFa0aa,
+            0xabacad00000000000000000000000000
+        ]
+    );
+    let mut encoded: Bytes = BytesTrait::new_empty();
+    let address: ContractAddress =
+        0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7_felt252
+        .try_into()
+        .expect('Couldn\'t convert to address');
+    let eth_address: EthAddress = 0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF_u256.into();
+    let bytesArray: ByteArray = SolBytesTrait::bytes5(0xa0aaabacad_u128).to_byte_array();
+    encoded = encoded
+        .encode_packed(0x8_u8)
+        .encode_packed(0xa7a8a9aaabacadaeaf_u128)
+        .encode_packed(0xabcde_u32)
+        .encode_packed(0x2a_u16)
+        .encode_packed(0x10111213_u64)
+        .encode_packed(0x0fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbe_u256)
+        .encode_packed(false)
+        .encode_packed(true)
+        .encode_packed(bytes31_const::<0x1234>())
+        .encode_packed(SolBytesTrait::bytes10(0x0102030405060708090a_u128))
+        .encode_packed(0x1234567890_felt252)
+        .encode_packed(address)
+        .encode_packed(eth_address)
+        .encode_packed(bytesArray);
+    assert_eq!(encoded, expected, "Encode packed uints failed");
+}
+
+#[test]
+fn encoded_as_test() {
+    let expected: Bytes = BytesTrait::new(
+        29, array![0x10111200000000000000000000000000, 0x0000000000aabbcc0000a0b1c2000000]
+    );
+    let mut encoded: Bytes = BytesTrait::new_empty();
+    encoded = encoded
+        .encode_as(3, 0x101112_u128)
+        .encode_as(21, 0xaabbcc_felt252)
+        .encode_as(5, 0xa0b1c2_u256);
+    assert_eq!(encoded, expected, "Encode as failed");
+
+    let mut encoded: Bytes = BytesTrait::new_empty();
+    encoded = encoded
+        .encode_as(3, SolBytesTrait::bytes10(0x10111213141516171910))
+        .encode_as(21, bytes31_const::<0xaabbcc>())
+        .encode_as(5, SolBytesTrait::bytes10(0x0000a0b1c2c3c4c5c6c8).to_byte_array());
+    assert_eq!(encoded, expected, "Encode as from bytes failed");
+}
+
+#[test]
+fn selector_test() {
+    // selector for : transfer(address,uint256) 
+    let expected: Bytes = BytesTrait::new(4, array![0xa9059cbb000000000000000000000000]);
+    let mut encoded: Bytes = BytesTrait::new_empty();
+    encoded = encoded.encode_selector(0xa9059cbb_u32);
+    assert_eq!(encoded, expected, "Encode selector failed");
+
+    // encode call : transfer(0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF, 10000)
+    let expected: Bytes = BytesTrait::new(
+        68,
+        array![
+            0xa9059cbb000000000000000000000000,
+            0xDeaDbeefdEAdbeefdEadbEEFdeadbeEF,
+            0xdEaDbeeF000000000000000000000000,
+            0x00000000000000000000000000000000,
+            0x00002710000000000000000000000000
+        ]
+    );
+    let mut encoded: Bytes = BytesTrait::new_empty();
+    let eth_address: EthAddress = 0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF_u256.into();
+    encoded = encoded.encode_selector(0xa9059cbb_u32).encode(eth_address).encode(10000_u256);
+    assert_eq!(encoded, expected, "Encode selector full failed");
+}
+
+#[test]
+fn decode_test() {
+    let encoded: Bytes = BytesTrait::new(
+        384,
+        array![
+            0x00000000000000000000000000000000,
+            0x0000000000000000000000000000a0a1,
+            0x00000000000000000000000000000000,
+            0x000000000000000000000000a2a3a4a5,
+            0x00000000000000000000000000000000,
+            0x000000000000000000000000000000a6,
+            0x00000000000000000000000000000000,
+            0xa7a8a9aaabacadaeafb0b1b2b3b4b5b6,
+            0xabcdefabcdefabcdefabcdefabcdefab,
+            0xcdefabcdefabcdefabcdefabcdefabcd,
+            0x00000000000000000000000000000000,
+            0x0000000000000000b7b8b9babbbcbdbe,
+            0x00a0a1a2a30000000000000000000000,
+            0x00000000000000000000000000000000,
+            0xa0a1a2a3a4a5a6a7a8a9aaabacadaeaf,
+            0xb0b1b2b3000000000000000000000000,
+            0x000000000000000000000000000000a0,
+            0xaaab00000000000000000000000000ac,
+            0x00000000000000000000000000000000,
+            0x00000000000000000000000000001234,
+            0x00a0a1a2a30000000000000000000000,
+            0x00000000000000000000000000001234,
+            0x000000000000000000000000Deadbeef,
+            0xDeaDbeefdEAdbeefdEadbEEFdeadbeEF
+        ]
+    );
+
+    let mut offset = 0;
+    let decoded: u16 = encoded.decode(ref offset);
+    assert_eq!(decoded, 0xa0a1, "Decode uint16 failed");
+    assert_eq!(offset, 32, "Offset after decode uint16 failed");
+
+    let decoded: u32 = encoded.decode(ref offset);
+    assert_eq!(decoded, 0xa2a3a4a5, "Decode uint32 failed");
+    assert_eq!(offset, 64, "Offset after decode uint32 failed");
+
+    let decoded: u8 = encoded.decode(ref offset);
+    assert_eq!(decoded, 0xa6, "Decode uint8 failed");
+    assert_eq!(offset, 96, "Offset after decode uint8 failed");
+
+    let decoded: u128 = encoded.decode(ref offset);
+    assert_eq!(decoded, 0xa7a8a9aaabacadaeafb0b1b2b3b4b5b6, "Decode uint128 failed");
+    assert_eq!(offset, 128, "Offset after decode uint128 failed");
+
+    let decoded: u256 = encoded.decode(ref offset);
+    assert_eq!(
+        decoded,
+        0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd_u256,
+        "Decode uint256 failed"
+    );
+    assert_eq!(offset, 160, "Offset after decode uint256 failed");
+
+    let decoded: u64 = encoded.decode(ref offset);
+    assert_eq!(decoded, 0xb7b8b9babbbcbdbe, "Decode uint64 failed");
+    assert_eq!(offset, 192, "Offset after decode uint64 failed");
+
+    let decoded: Bytes = SolBytesTrait::<Bytes>::bytes5(encoded.decode(ref offset));
+    assert_eq!(decoded, SolBytesTrait::bytes5(0xa0a1a2a3), "Decode Bytes failed");
+    assert_eq!(offset, 224, "Offset after decode Bytes failed");
+
+    let decoded: ByteArray = encoded.decode(ref offset);
+    let expected: ByteArray = SolBytesTrait::bytes32(
+        0xa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3000000000000000000000000_u256
+    )
+        .to_byte_array();
+    assert_eq!(decoded, expected, "Decode ByteArray failed");
+    assert_eq!(offset, 256, "Offset after decode ByteArray failed");
+
+    let decoded: bytes31 = encoded.decode(ref offset);
+    assert!(
+        decoded == bytes31_const::<0xa0aaab00000000000000000000000000ac>(), "Decode byte31 failed"
+    );
+    assert_eq!(offset, 288, "Offset after decode byte31 failed");
+
+    let decoded: felt252 = encoded.decode(ref offset);
+    assert_eq!(decoded, 0x1234_felt252, "Decode felt252 failed");
+    assert_eq!(offset, 320, "Offset after decode felt252 failed");
+
+    let expected: ContractAddress =
+        0xa0a1a2a3000000000000000000000000000000000000000000000000001234_felt252
+        .try_into()
+        .expect('Couldn\'t convert to address');
+    let decoded: ContractAddress = encoded.decode(ref offset);
+    assert_eq!(decoded, expected, "Decode ContractAddress failed");
+    assert_eq!(offset, 352, "Offset after decode ContractAddress failed");
+
+    let expected: EthAddress = 0xDeadbeefDeaDbeefdEAdbeefdEadbEEFdeadbeEF_u256.into();
+    let decoded: EthAddress = encoded.decode(ref offset);
+    assert_eq!(decoded, expected, "Decode EthAddress failed");
+    assert_eq!(offset, 384, "Offset after decode EthAddress failed");
+}
+
+#[test]
+fn sol_bytes_test() {
+    // Test bytesX with integer types
+    let expectedVal14: Bytes = SolBytesTrait::bytes14(0x1234567890abcdef1234567890ab_u128);
+    let bytesVal5: Bytes = SolBytesTrait::bytes5(0x1234567890_u256);
+    let bytesVal9: Bytes = SolBytesTrait::bytes9(0xabcdef1234567890ab_felt252);
+    let mut bytesValAcc: Bytes = BytesTrait::new_empty();
+    bytesValAcc.concat(@bytesVal5);
+    bytesValAcc.concat(@bytesVal9);
+    assert_eq!(expectedVal14, bytesValAcc, "Concat bytes ints failed");
+
+    // Test bytesX with integer types needing `into` calls
+    let expectedVal21: Bytes = SolBytesTrait::bytes21(
+        0x0000a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2_u256
+    );
+    let bytesVal18: Bytes = SolBytesTrait::bytes18(0xa0a1a2a3a4a5a6a7a8a9aaabacadaeaf_u128);
+    let bytesVal3: Bytes = SolBytesTrait::bytes3(bytes31_const::<0xb0b1b2>());
+    let mut bytesValAcc: Bytes = BytesTrait::new_empty();
+    bytesValAcc.concat(@bytesVal18);
+    bytesValAcc.concat(@bytesVal3);
+    assert_eq!(expectedVal21, bytesValAcc, "Concat bytes ints into failed");
+
+    // Test bytesX with Bytes types
+    let expectedVal25: Bytes = SolBytesTrait::bytes25(
+        0xa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8_u256
+    );
+    let bytesVal6: Bytes = SolBytesTrait::bytes6(
+        BytesTrait::new(16, array![0xa0a1a2a3a4a500000000000000000000])
+    );
+    let bytesArray: ByteArray = SolBytesTrait::bytes32(
+        0xa6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b800000000000000000000000000_u256
+    )
+        .to_byte_array();
+    let bytesVal19: Bytes = SolBytesTrait::bytes19(bytesArray);
+    let mut bytesValAcc: Bytes = BytesTrait::new_empty();
+    bytesValAcc.concat(@bytesVal6);
+    bytesValAcc.concat(@bytesVal19);
+    assert_eq!(expectedVal25, bytesValAcc, "Concat bytes failed");
+}

--- a/src/encoding/src/tests/sol_abi.cairo
+++ b/src/encoding/src/tests/sol_abi.cairo
@@ -16,14 +16,15 @@ fn compare_bytes(actual: @Bytes, expected: @Bytes) -> bool {
         return false;
     }
     let mut i: usize = 0;
-    while i < actual.size() {
-        let (_, actual_val) = actual.read_u8(i);
-        let (_, expected_val) = expected.read_u8(i);
-        if actual_val != expected_val {
-            break;
-        }
-        i += 1;
-    };
+    while i < actual
+        .size() {
+            let (_, actual_val) = actual.read_u8(i);
+            let (_, expected_val) = expected.read_u8(i);
+            if actual_val != expected_val {
+                break;
+            }
+            i += 1;
+        };
     if i < actual.size() {
         return false;
     }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Added various traits/utils for supporting Solidity-like ABI encode functions. This includes the traits :
- `SolAbiEncodeTrait` : providing equivalents for Solidity `abi.encode` and `abi.encodePacked`
- `SolAbiEncodeSelectorTrait` : for Solidity `abi.encodeWithSelector`
- `SolAbiDecodeTrait` : for Solidity `abi.decode`
- `SolBytesTrait` : Providing utilities for easy conversion of types into Solidity-like `bytes1`, `bytes2`, ..., `bytes32` types

Also added some helpers for `alexandria_bytes::Bytes`, such as : 
- `Bytes` <-> Cairo's `ByteArray` & `bytes31` function options
- Debug & Display traits for `Bytes`, to allow printing `Bytes` as a hex string

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

Issue Number: #274 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->