### PR TITLE
Fixing i257 is_zero()

### DIFF
--- a/src/math/src/i257.cairo
+++ b/src/math/src/i257.cairo
@@ -259,9 +259,11 @@ impl i257Zeroable of Zeroable<i257> {
         i257_new(0, false)
     }
     fn is_zero(self: i257) -> bool {
+        assert(!self.is_negative, 'no negative zero');
         self.abs == 0
     }
     fn is_non_zero(self: i257) -> bool {
+        assert(!self.is_negative, 'no negative zero');
         self.abs != 0
     }
 }

--- a/src/math/src/i257.cairo
+++ b/src/math/src/i257.cairo
@@ -259,10 +259,10 @@ impl i257Zeroable of Zeroable<i257> {
         i257_new(0, false)
     }
     fn is_zero(self: i257) -> bool {
-        self == Zeroable::zero()
+        self.abs == 0
     }
     fn is_non_zero(self: i257) -> bool {
-        self != Zeroable::zero()
+        self.abs != 0
     }
 }
 

--- a/src/math/src/i257.cairo
+++ b/src/math/src/i257.cairo
@@ -1,3 +1,4 @@
+use core::zeroable::Zeroable;
 // ====================== INT 257 ======================
 
 // i257 represents a 129-bit integer.
@@ -263,8 +264,7 @@ impl i257Zeroable of Zeroable<i257> {
         self.abs == 0
     }
     fn is_non_zero(self: i257) -> bool {
-        assert(!self.is_negative, 'no negative zero');
-        self.abs != 0
+        !self.is_zero()
     }
 }
 

--- a/src/math/src/tests/i257_test.cairo
+++ b/src/math/src/tests/i257_test.cairo
@@ -139,7 +139,7 @@ fn i257_test_mul() {
 
 #[test]
 fn i257_test_is_zero() {
-    let a = i257 { abs: 10, is_negative: true };
+    let a = i257 { abs: 0, is_negative: true };
     let b = i257 { abs: 0, is_negative: false };
 
     assert!(a.is_zero(), "should be true");

--- a/src/math/src/tests/i257_test.cairo
+++ b/src/math/src/tests/i257_test.cairo
@@ -136,6 +136,15 @@ fn i257_test_mul() {
     assert!(!result.is_negative, "10 * 0 -> positive");
 }
 
+
+#[test]
+fn i257_test_is_zero() {
+    let a = i257 { abs: 10, is_negative: true };
+    let b = i257 { abs: 0, is_negative: false };
+
+    assert!(a.is_zero(), "should be true");
+    assert!(b.is_zero(), "should be true");
+}
 #[test]
 fn i257_test_div_no_rem() {
     // Test division of positive integers

--- a/src/math/src/tests/i257_test.cairo
+++ b/src/math/src/tests/i257_test.cairo
@@ -145,6 +145,7 @@ fn i257_test_is_zero() {
     assert!(a.is_zero(), "should be true");
     assert!(b.is_zero(), "should be true");
 }
+
 #[test]
 fn i257_test_div_no_rem() {
     // Test division of positive integers

--- a/src/math/src/tests/i257_test.cairo
+++ b/src/math/src/tests/i257_test.cairo
@@ -136,14 +136,17 @@ fn i257_test_mul() {
     assert!(!result.is_negative, "10 * 0 -> positive");
 }
 
-
 #[test]
 fn i257_test_is_zero() {
-    let a = i257 { abs: 0, is_negative: true };
-    let b = i257 { abs: 0, is_negative: false };
-
+    let a = i257 { abs: 0, is_negative: false };
     assert!(a.is_zero(), "should be true");
-    assert!(b.is_zero(), "should be true");
+}
+
+#[test]
+#[should_panic(expected: ('no negative zero',))]
+fn i257_test_is_zero_panic() {
+    let a = i257 { abs: 0, is_negative: true };
+    let _x = a.is_zero();
 }
 
 #[test]


### PR DESCRIPTION
Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

Fixing is_zero behaviour that was causing is_zero to sometimes return false when it was indeed zero