### PR TITLE
Feat: fast interpolation bin search closest+bug fix

### DIFF
--- a/Scarb.lock
+++ b/Scarb.lock
@@ -55,6 +55,7 @@ name = "alexandria_numeric"
 version = "0.1.0"
 dependencies = [
  "alexandria_math",
+ "alexandria_searching",
 ]
 
 [[package]]

--- a/src/numeric/Scarb.toml
+++ b/src/numeric/Scarb.toml
@@ -9,3 +9,4 @@ fmt.workspace = true
 
 [dependencies]
 alexandria_math = { path = "../math" }
+alexandria_searching = { path = "../searching" }

--- a/src/numeric/src/interpolate.cairo
+++ b/src/numeric/src/interpolate.cairo
@@ -1,17 +1,18 @@
+use alexandria_searching::binary_search::binary_search_closest as search;
 //! One-dimensional linear interpolation for monotonically increasing sample points.
 
 #[derive(Serde, Copy, Drop, PartialEq)]
 enum Interpolation {
-    Linear: (),
-    Nearest: (),
-    ConstantLeft: (),
-    ConstantRight: (),
+    Linear,
+    Nearest,
+    ConstantLeft,
+    ConstantRight,
 }
 
 #[derive(Serde, Copy, Drop, PartialEq)]
 enum Extrapolation {
-    Null: (),
-    Constant: (),
+    Null,
+    Constant,
 }
 
 /// Interpolate y(x) at x.
@@ -38,8 +39,8 @@ fn interpolate<
     x: T, xs: Span<T>, ys: Span<T>, interpolation: Interpolation, extrapolation: Extrapolation
 ) -> T {
     // [Check] Inputs
-    assert(xs.len() == ys.len(), 'Arrays must have the same len');
-    assert(xs.len() >= 2, 'Array must have at least 2 elts');
+    assert_eq!(xs.len(), ys.len());
+    assert!(xs.len() >= 2, "Array must have at least 2 elts");
 
     // [Check] Extrapolation
     if x <= *xs[0] {
@@ -58,7 +59,7 @@ fn interpolate<
     // [Compute] Interpolation, could be optimized with binary search
     let mut index = 0;
     loop {
-        assert(*xs[index + 1] > *xs[index], 'Abscissa must be sorted');
+        assert!(*xs[index + 1] > *xs[index], "Abscissa must be sorted");
 
         if x < *xs[index + 1] {
             break match interpolation {
@@ -96,8 +97,6 @@ fn interpolate<
     }
 }
 
-use alexandria_searching::binary_search::binary_search_closest as search;
-
 fn interpolate_fast<
     T,
     impl TPartialOrd: PartialOrd<T>,
@@ -113,8 +112,8 @@ fn interpolate_fast<
     x: T, xs: Span<T>, ys: Span<T>, interpolation: Interpolation, extrapolation: Extrapolation
 ) -> T {
     // [Check] Inputs
-    assert(xs.len() == ys.len(), 'Arrays must have the same len');
-    assert(xs.len() >= 2, 'Array must have at least 2 elts');
+    assert_eq!(xs.len(), ys.len());
+    assert!(xs.len() >= 2, "Array must have at least 2 elts");
 
     // [Check] Extrapolation
     if x <= *xs[0] {
@@ -135,8 +134,8 @@ fn interpolate_fast<
     // [Compute] Interpolation with binary search
     let index: u32 = search(xs, x).expect('search error');
 
-    assert(*xs[index + 1] > *xs[index], 'Abscissa must be sorted');
-    assert(x < *xs[index + 1], 'search error');
+    assert!(*xs[index + 1] > *xs[index], "Abscissa must be sorted");
+    assert!(x < *xs[index + 1], "search error");
 
     match interpolation {
         Interpolation::Linear => {

--- a/src/numeric/src/interpolate.cairo
+++ b/src/numeric/src/interpolate.cairo
@@ -44,14 +44,14 @@ fn interpolate<
     // [Check] Extrapolation
     if x <= *xs[0] {
         return match extrapolation {
-            Extrapolation::Null(()) => Zeroable::zero(),
-            Extrapolation::Constant(()) => *ys[0],
+            Extrapolation::Null => Zeroable::zero(),
+            Extrapolation::Constant => *ys[0],
         };
     }
     if x >= *xs[xs.len() - 1] {
         return match extrapolation {
-            Extrapolation::Null(()) => Zeroable::zero(),
-            Extrapolation::Constant(()) => *ys[xs.len() - 1],
+            Extrapolation::Null => Zeroable::zero(),
+            Extrapolation::Constant => *ys[xs.len() - 1],
         };
     }
 
@@ -62,7 +62,7 @@ fn interpolate<
 
         if x < *xs[index + 1] {
             break match interpolation {
-                Interpolation::Linear(()) => {
+                Interpolation::Linear => {
                     // y = [(xb - x) * ya + (x - xa) * yb] / (xb - xa)
                     // y = [alpha * ya + beta * yb] / den
                     let den = *xs[index + 1] - *xs[index];
@@ -70,7 +70,7 @@ fn interpolate<
                     let beta = x - *xs[index];
                     (alpha * *ys[index] + beta * *ys[index + 1]) / den
                 },
-                Interpolation::Nearest(()) => {
+                Interpolation::Nearest => {
                     // y = ya or yb
                     let alpha = *xs[index + 1] - x;
                     let beta = x - *xs[index];
@@ -80,11 +80,91 @@ fn interpolate<
                         *ys[index + 1]
                     }
                 },
-                Interpolation::ConstantLeft(()) => *ys[index + 1],
-                Interpolation::ConstantRight(()) => *ys[index],
+                Interpolation::ConstantLeft => {
+                    // Handle equality case: x == *xs[index]
+                    if x <= *xs[index] {
+                        *ys[index]
+                    } else {
+                        *ys[index + 1]
+                    }
+                },
+                Interpolation::ConstantRight => *ys[index],
             };
         }
 
         index += 1;
+    }
+}
+
+use alexandria_searching::binary_search::binary_search_closest as search;
+
+fn interpolate_fast<
+    T,
+    impl TPartialOrd: PartialOrd<T>,
+    impl TNumericLiteral: NumericLiteral<T>,
+    impl TAdd: Add<T>,
+    impl TSub: Sub<T>,
+    impl TMul: Mul<T>,
+    impl TDiv: Div<T>,
+    impl TZeroable: Zeroable<T>,
+    impl TCopy: Copy<T>,
+    impl TDrop: Drop<T>,
+>(
+    x: T, xs: Span<T>, ys: Span<T>, interpolation: Interpolation, extrapolation: Extrapolation
+) -> T {
+    // [Check] Inputs
+    assert(xs.len() == ys.len(), 'Arrays must have the same len');
+    assert(xs.len() >= 2, 'Array must have at least 2 elts');
+
+    // [Check] Extrapolation
+    if x <= *xs[0] {
+        let y = match extrapolation {
+            Extrapolation::Null => Zeroable::zero(),
+            Extrapolation::Constant => *ys[0],
+        };
+        return y;
+    }
+    if x >= *xs[xs.len() - 1] {
+        let y = match extrapolation {
+            Extrapolation::Null => Zeroable::zero(),
+            Extrapolation::Constant => *ys[xs.len() - 1],
+        };
+        return y;
+    }
+
+    // [Compute] Interpolation with binary search
+    let index: u32 = search(xs, x).expect('search error');
+
+    assert(*xs[index + 1] > *xs[index], 'Abscissa must be sorted');
+    assert(x < *xs[index + 1], 'search error');
+
+    match interpolation {
+        Interpolation::Linear => {
+            // y = [(xb - x) * ya + (x - xa) * yb] / (xb - xa)
+            // y = [alpha * ya + beta * yb] / den
+            let den = *xs[index + 1] - *xs[index];
+            let alpha = *xs[index + 1] - x;
+            let beta = x - *xs[index];
+            (alpha * *ys[index] + beta * *ys[index + 1]) / den
+        },
+        Interpolation::Nearest => {
+            // y = ya or yb
+            let alpha = *xs[index + 1] - x;
+            let beta = x - *xs[index];
+            if alpha >= beta {
+                *ys[index]
+            } else {
+                *ys[index + 1]
+            }
+        },
+        Interpolation::ConstantLeft => {
+            // Handle equality case: x == *xs[index]
+            if x <= *xs[index] {
+                *ys[index]
+            } else {
+                *ys[index + 1]
+            }
+        },
+        Interpolation::ConstantRight => *ys[index],
     }
 }

--- a/src/numeric/src/interpolate.cairo
+++ b/src/numeric/src/interpolate.cairo
@@ -39,7 +39,7 @@ fn interpolate<
     x: T, xs: Span<T>, ys: Span<T>, interpolation: Interpolation, extrapolation: Extrapolation
 ) -> T {
     // [Check] Inputs
-    assert_eq!(xs.len(), ys.len());
+    assert!(xs.len() == ys.len(), "Arrays must have the same len");
     assert!(xs.len() >= 2, "Array must have at least 2 elts");
 
     // [Check] Extrapolation
@@ -112,7 +112,7 @@ fn interpolate_fast<
     x: T, xs: Span<T>, ys: Span<T>, interpolation: Interpolation, extrapolation: Extrapolation
 ) -> T {
     // [Check] Inputs
-    assert_eq!(xs.len(), ys.len());
+    assert!(xs.len() == ys.len(), "Arrays must have the same len");
     assert!(xs.len() >= 2, "Array must have at least 2 elts");
 
     // [Check] Extrapolation

--- a/src/numeric/src/tests.cairo
+++ b/src/numeric/src/tests.cairo
@@ -2,6 +2,6 @@ mod cumprod_test;
 mod cumsum_test;
 mod diff_test;
 mod integers_test;
-mod interpolate_test;
 mod interpolate_fast_test;
+mod interpolate_test;
 mod trapezoidal_rule_test;

--- a/src/numeric/src/tests.cairo
+++ b/src/numeric/src/tests.cairo
@@ -3,4 +3,5 @@ mod cumsum_test;
 mod diff_test;
 mod integers_test;
 mod interpolate_test;
+mod interpolate_fast_test;
 mod trapezoidal_rule_test;

--- a/src/numeric/src/tests/interpolate_fast_test.cairo
+++ b/src/numeric/src/tests/interpolate_fast_test.cairo
@@ -1,0 +1,149 @@
+use alexandria_numeric::interpolate::{
+    interpolate_fast as interpolate, Interpolation, Extrapolation
+};
+
+#[test]
+#[available_gas(2000000)]
+fn interp_extrapolation_test() {
+    let xs: Array::<u64> = array![3, 5, 7];
+    let ys = array![11, 13, 17];
+    assert(
+        interpolate(0, xs.span(), ys.span(), Interpolation::Linear, Extrapolation::Constant) == 11,
+        'invalid extrapolation'
+    );
+    assert(
+        interpolate(9, xs.span(), ys.span(), Interpolation::Linear, Extrapolation::Constant) == 17,
+        'invalid extrapolation'
+    );
+    assert(
+        interpolate(0, xs.span(), ys.span(), Interpolation::Linear, Extrapolation::Null) == 0,
+        'invalid extrapolation'
+    );
+    assert(
+        interpolate(9, xs.span(), ys.span(), Interpolation::Linear, Extrapolation::Null) == 0,
+        'invalid extrapolation'
+    );
+}
+
+#[test]
+#[available_gas(2000000)]
+fn interp_linear_test() {
+    let xs: Array::<u64> = array![3, 5, 7];
+    let ys = array![11, 13, 17];
+    assert(
+        interpolate(4, xs.span(), ys.span(), Interpolation::Linear, Extrapolation::Constant) == 12,
+        'invalid interpolation'
+    );
+    assert(
+        interpolate(4, xs.span(), ys.span(), Interpolation::Linear, Extrapolation::Constant) == 12,
+        'invalid interpolation'
+    );
+}
+
+#[test]
+#[available_gas(2000000)]
+fn interp_nearest_test() {
+    let xs: Array::<u64> = array![3, 5, 7];
+    let ys = array![11, 13, 17];
+    assert(
+        interpolate(4, xs.span(), ys.span(), Interpolation::Nearest, Extrapolation::Constant) == 11,
+        'invalid interpolation'
+    );
+    assert(
+        interpolate(6, xs.span(), ys.span(), Interpolation::Nearest, Extrapolation::Constant) == 13,
+        'invalid interpolation'
+    );
+    assert(
+        interpolate(7, xs.span(), ys.span(), Interpolation::Nearest, Extrapolation::Constant) == 17,
+        'invalid interpolation'
+    );
+}
+
+#[test]
+#[available_gas(2000000)]
+fn interp_constant_left_test() {
+    let xs: Array::<u64> = array![3, 5, 7];
+    let ys = array![11, 13, 17];
+    assert(
+        interpolate(
+            4, xs.span(), ys.span(), Interpolation::ConstantLeft, Extrapolation::Constant
+        ) == 13,
+        'invalid interpolation'
+    );
+    assert(
+        interpolate(
+            6, xs.span(), ys.span(), Interpolation::ConstantLeft, Extrapolation::Constant
+        ) == 17,
+        'invalid interpolation'
+    );
+    assert(
+        interpolate(
+            7, xs.span(), ys.span(), Interpolation::ConstantLeft, Extrapolation::Constant
+        ) == 17,
+        'invalid interpolation'
+    );
+}
+
+use debug::PrintTrait;
+
+#[test]
+#[available_gas(2000000)]
+fn interp_constant_left_diff() {
+    let xs: Span<u64> = array![0, 2, 4, 6, 8].span();
+    let ys: Span<u64> = array![0, 2, 4, 6, 8].span();
+    let inter = Interpolation::ConstantLeft;
+    let extra = Extrapolation::Constant;
+    assert_eq!(@interpolate(0, xs, ys, inter, extra), @0);
+    assert_eq!(@interpolate(1, xs, ys, inter, extra), @2);
+    assert_eq!(@interpolate(2, xs, ys, inter, extra), @2);
+    assert_eq!(@interpolate(3, xs, ys, inter, extra), @4);
+    assert_eq!(@interpolate(4, xs, ys, inter, extra), @4);
+    assert_eq!(@interpolate(5, xs, ys, inter, extra), @6);
+    assert_eq!(@interpolate(6, xs, ys, inter, extra), @6);
+    assert_eq!(@interpolate(7, xs, ys, inter, extra), @8);
+    assert_eq!(@interpolate(8, xs, ys, inter, extra), @8);
+    assert_eq!(@interpolate(9, xs, ys, inter, extra), @8);
+}
+
+#[test]
+#[available_gas(2000000)]
+fn interp_constant_right_test() {
+    let xs: Array::<u64> = array![3, 5, 8];
+    let ys = array![11, 13, 17];
+    assert(
+        interpolate(
+            4, xs.span(), ys.span(), Interpolation::ConstantRight, Extrapolation::Constant
+        ) == 11,
+        'invalid interpolation'
+    );
+    assert(
+        interpolate(
+            6, xs.span(), ys.span(), Interpolation::ConstantRight, Extrapolation::Constant
+        ) == 13,
+        'invalid interpolation'
+    );
+    assert(
+        interpolate(
+            7, xs.span(), ys.span(), Interpolation::ConstantRight, Extrapolation::Constant
+        ) == 13,
+        'invalid interpolation'
+    );
+}
+
+#[test]
+#[should_panic(expected: ('Arrays must have the same len',))]
+#[available_gas(2000000)]
+fn interp_revert_len_mismatch() {
+    let xs: Array::<u64> = array![3, 5];
+    let ys = array![11];
+    interpolate(4, xs.span(), ys.span(), Interpolation::Linear, Extrapolation::Constant);
+}
+
+#[test]
+#[should_panic(expected: ('Array must have at least 2 elts',))]
+#[available_gas(2000000)]
+fn interp_revert_len_too_short() {
+    let xs: Array::<u64> = array![3];
+    let ys = array![11];
+    interpolate(4, xs.span(), ys.span(), Interpolation::Linear, Extrapolation::Constant);
+}

--- a/src/numeric/src/tests/interpolate_fast_test.cairo
+++ b/src/numeric/src/tests/interpolate_fast_test.cairo
@@ -104,7 +104,7 @@ fn interp_constant_right_test() {
 }
 
 #[test]
-#[should_panic()]
+#[should_panic(expected: ("Arrays must have the same len",))]
 #[available_gas(2000000)]
 fn interp_revert_len_mismatch() {
     let xs: Array::<u64> = array![3, 5];
@@ -113,7 +113,7 @@ fn interp_revert_len_mismatch() {
 }
 
 #[test]
-#[should_panic()]
+#[should_panic(expected: ("Array must have at least 2 elts",))]
 #[available_gas(2000000)]
 fn interp_revert_len_too_short() {
     let xs: Array::<u64> = array![3];

--- a/src/numeric/src/tests/interpolate_fast_test.cairo
+++ b/src/numeric/src/tests/interpolate_fast_test.cairo
@@ -7,22 +7,14 @@ use alexandria_numeric::interpolate::{
 fn interp_extrapolation_test() {
     let xs: Array::<u64> = array![3, 5, 7];
     let ys = array![11, 13, 17];
-    assert(
-        interpolate(0, xs.span(), ys.span(), Interpolation::Linear, Extrapolation::Constant) == 11,
-        'invalid extrapolation'
+    assert_eq!(
+        interpolate(0, xs.span(), ys.span(), Interpolation::Linear, Extrapolation::Constant), 11
     );
-    assert(
-        interpolate(9, xs.span(), ys.span(), Interpolation::Linear, Extrapolation::Constant) == 17,
-        'invalid extrapolation'
+    assert_eq!(
+        interpolate(9, xs.span(), ys.span(), Interpolation::Linear, Extrapolation::Constant), 17
     );
-    assert(
-        interpolate(0, xs.span(), ys.span(), Interpolation::Linear, Extrapolation::Null) == 0,
-        'invalid extrapolation'
-    );
-    assert(
-        interpolate(9, xs.span(), ys.span(), Interpolation::Linear, Extrapolation::Null) == 0,
-        'invalid extrapolation'
-    );
+    assert_eq!(interpolate(0, xs.span(), ys.span(), Interpolation::Linear, Extrapolation::Null), 0);
+    assert_eq!(interpolate(9, xs.span(), ys.span(), Interpolation::Linear, Extrapolation::Null), 0);
 }
 
 #[test]
@@ -30,13 +22,11 @@ fn interp_extrapolation_test() {
 fn interp_linear_test() {
     let xs: Array::<u64> = array![3, 5, 7];
     let ys = array![11, 13, 17];
-    assert(
-        interpolate(4, xs.span(), ys.span(), Interpolation::Linear, Extrapolation::Constant) == 12,
-        'invalid interpolation'
+    assert_eq!(
+        interpolate(4, xs.span(), ys.span(), Interpolation::Linear, Extrapolation::Constant), 12
     );
-    assert(
-        interpolate(4, xs.span(), ys.span(), Interpolation::Linear, Extrapolation::Constant) == 12,
-        'invalid interpolation'
+    assert_eq!(
+        interpolate(4, xs.span(), ys.span(), Interpolation::Linear, Extrapolation::Constant), 12
     );
 }
 
@@ -45,17 +35,14 @@ fn interp_linear_test() {
 fn interp_nearest_test() {
     let xs: Array::<u64> = array![3, 5, 7];
     let ys = array![11, 13, 17];
-    assert(
-        interpolate(4, xs.span(), ys.span(), Interpolation::Nearest, Extrapolation::Constant) == 11,
-        'invalid interpolation'
+    assert_eq!(
+        interpolate(4, xs.span(), ys.span(), Interpolation::Nearest, Extrapolation::Constant), 11
     );
-    assert(
-        interpolate(6, xs.span(), ys.span(), Interpolation::Nearest, Extrapolation::Constant) == 13,
-        'invalid interpolation'
+    assert_eq!(
+        interpolate(6, xs.span(), ys.span(), Interpolation::Nearest, Extrapolation::Constant), 13
     );
-    assert(
-        interpolate(7, xs.span(), ys.span(), Interpolation::Nearest, Extrapolation::Constant) == 17,
-        'invalid interpolation'
+    assert_eq!(
+        interpolate(7, xs.span(), ys.span(), Interpolation::Nearest, Extrapolation::Constant), 17
     );
 }
 
@@ -64,27 +51,19 @@ fn interp_nearest_test() {
 fn interp_constant_left_test() {
     let xs: Array::<u64> = array![3, 5, 7];
     let ys = array![11, 13, 17];
-    assert(
-        interpolate(
-            4, xs.span(), ys.span(), Interpolation::ConstantLeft, Extrapolation::Constant
-        ) == 13,
-        'invalid interpolation'
+    assert_eq!(
+        interpolate(4, xs.span(), ys.span(), Interpolation::ConstantLeft, Extrapolation::Constant),
+        13
     );
-    assert(
-        interpolate(
-            6, xs.span(), ys.span(), Interpolation::ConstantLeft, Extrapolation::Constant
-        ) == 17,
-        'invalid interpolation'
+    assert_eq!(
+        interpolate(6, xs.span(), ys.span(), Interpolation::ConstantLeft, Extrapolation::Constant),
+        17
     );
-    assert(
-        interpolate(
-            7, xs.span(), ys.span(), Interpolation::ConstantLeft, Extrapolation::Constant
-        ) == 17,
-        'invalid interpolation'
+    assert_eq!(
+        interpolate(7, xs.span(), ys.span(), Interpolation::ConstantLeft, Extrapolation::Constant),
+        17
     );
 }
-
-use debug::PrintTrait;
 
 #[test]
 #[available_gas(2000000)]
@@ -110,28 +89,22 @@ fn interp_constant_left_diff() {
 fn interp_constant_right_test() {
     let xs: Array::<u64> = array![3, 5, 8];
     let ys = array![11, 13, 17];
-    assert(
-        interpolate(
-            4, xs.span(), ys.span(), Interpolation::ConstantRight, Extrapolation::Constant
-        ) == 11,
-        'invalid interpolation'
+    assert_eq!(
+        interpolate(4, xs.span(), ys.span(), Interpolation::ConstantRight, Extrapolation::Constant),
+        11
     );
-    assert(
-        interpolate(
-            6, xs.span(), ys.span(), Interpolation::ConstantRight, Extrapolation::Constant
-        ) == 13,
-        'invalid interpolation'
+    assert_eq!(
+        interpolate(6, xs.span(), ys.span(), Interpolation::ConstantRight, Extrapolation::Constant),
+        13
     );
-    assert(
-        interpolate(
-            7, xs.span(), ys.span(), Interpolation::ConstantRight, Extrapolation::Constant
-        ) == 13,
-        'invalid interpolation'
+    assert_eq!(
+        interpolate(7, xs.span(), ys.span(), Interpolation::ConstantRight, Extrapolation::Constant),
+        13
     );
 }
 
 #[test]
-#[should_panic(expected: ('Arrays must have the same len',))]
+#[should_panic()]
 #[available_gas(2000000)]
 fn interp_revert_len_mismatch() {
     let xs: Array::<u64> = array![3, 5];
@@ -140,7 +113,7 @@ fn interp_revert_len_mismatch() {
 }
 
 #[test]
-#[should_panic(expected: ('Array must have at least 2 elts',))]
+#[should_panic()]
 #[available_gas(2000000)]
 fn interp_revert_len_too_short() {
     let xs: Array::<u64> = array![3];

--- a/src/numeric/src/tests/interpolate_test.cairo
+++ b/src/numeric/src/tests/interpolate_test.cairo
@@ -5,30 +5,14 @@ use alexandria_numeric::interpolate::{interpolate, Interpolation, Extrapolation}
 fn interp_extrapolation_test() {
     let xs: Array::<u64> = array![3, 5, 7];
     let ys = array![11, 13, 17];
-    assert(
-        interpolate(
-            0, xs.span(), ys.span(), Interpolation::Linear(()), Extrapolation::Constant(())
-        ) == 11,
-        'invalid extrapolation'
+    assert_eq!(
+        interpolate(0, xs.span(), ys.span(), Interpolation::Linear, Extrapolation::Constant), 11
     );
-    assert(
-        interpolate(
-            9, xs.span(), ys.span(), Interpolation::Linear(()), Extrapolation::Constant(())
-        ) == 17,
-        'invalid extrapolation'
+    assert_eq!(
+        interpolate(9, xs.span(), ys.span(), Interpolation::Linear, Extrapolation::Constant), 17
     );
-    assert(
-        interpolate(
-            0, xs.span(), ys.span(), Interpolation::Linear(()), Extrapolation::Null(())
-        ) == 0,
-        'invalid extrapolation'
-    );
-    assert(
-        interpolate(
-            9, xs.span(), ys.span(), Interpolation::Linear(()), Extrapolation::Null(())
-        ) == 0,
-        'invalid extrapolation'
-    );
+    assert_eq!(interpolate(0, xs.span(), ys.span(), Interpolation::Linear, Extrapolation::Null), 0);
+    assert_eq!(interpolate(9, xs.span(), ys.span(), Interpolation::Linear, Extrapolation::Null), 0);
 }
 
 #[test]
@@ -36,17 +20,11 @@ fn interp_extrapolation_test() {
 fn interp_linear_test() {
     let xs: Array::<u64> = array![3, 5, 7];
     let ys = array![11, 13, 17];
-    assert(
-        interpolate(
-            4, xs.span(), ys.span(), Interpolation::Linear(()), Extrapolation::Constant(())
-        ) == 12,
-        'invalid interpolation'
+    assert_eq!(
+        interpolate(4, xs.span(), ys.span(), Interpolation::Linear, Extrapolation::Constant), 12
     );
-    assert(
-        interpolate(
-            4, xs.span(), ys.span(), Interpolation::Linear(()), Extrapolation::Constant(())
-        ) == 12,
-        'invalid interpolation'
+    assert_eq!(
+        interpolate(4, xs.span(), ys.span(), Interpolation::Linear, Extrapolation::Constant), 12
     );
 }
 
@@ -55,23 +33,14 @@ fn interp_linear_test() {
 fn interp_nearest_test() {
     let xs: Array::<u64> = array![3, 5, 7];
     let ys = array![11, 13, 17];
-    assert(
-        interpolate(
-            4, xs.span(), ys.span(), Interpolation::Nearest(()), Extrapolation::Constant(())
-        ) == 11,
-        'invalid interpolation'
+    assert_eq!(
+        interpolate(4, xs.span(), ys.span(), Interpolation::Nearest, Extrapolation::Constant), 11
     );
-    assert(
-        interpolate(
-            6, xs.span(), ys.span(), Interpolation::Nearest(()), Extrapolation::Constant(())
-        ) == 13,
-        'invalid interpolation'
+    assert_eq!(
+        interpolate(6, xs.span(), ys.span(), Interpolation::Nearest, Extrapolation::Constant), 13
     );
-    assert(
-        interpolate(
-            7, xs.span(), ys.span(), Interpolation::Nearest(()), Extrapolation::Constant(())
-        ) == 17,
-        'invalid interpolation'
+    assert_eq!(
+        interpolate(7, xs.span(), ys.span(), Interpolation::Nearest, Extrapolation::Constant), 17
     );
 }
 
@@ -80,23 +49,17 @@ fn interp_nearest_test() {
 fn interp_constant_left_test() {
     let xs: Array::<u64> = array![3, 5, 7];
     let ys = array![11, 13, 17];
-    assert(
-        interpolate(
-            4, xs.span(), ys.span(), Interpolation::ConstantLeft(()), Extrapolation::Constant(())
-        ) == 13,
-        'invalid interpolation'
+    assert_eq!(
+        interpolate(4, xs.span(), ys.span(), Interpolation::ConstantLeft, Extrapolation::Constant),
+        13
     );
-    assert(
-        interpolate(
-            6, xs.span(), ys.span(), Interpolation::ConstantLeft(()), Extrapolation::Constant(())
-        ) == 17,
-        'invalid interpolation'
+    assert_eq!(
+        interpolate(6, xs.span(), ys.span(), Interpolation::ConstantLeft, Extrapolation::Constant),
+        17
     );
-    assert(
-        interpolate(
-            7, xs.span(), ys.span(), Interpolation::ConstantLeft(()), Extrapolation::Constant(())
-        ) == 17,
-        'invalid interpolation'
+    assert_eq!(
+        interpolate(7, xs.span(), ys.span(), Interpolation::ConstantLeft, Extrapolation::Constant),
+        17
     );
 }
 
@@ -105,40 +68,34 @@ fn interp_constant_left_test() {
 fn interp_constant_right_test() {
     let xs: Array::<u64> = array![3, 5, 8];
     let ys = array![11, 13, 17];
-    assert(
-        interpolate(
-            4, xs.span(), ys.span(), Interpolation::ConstantRight(()), Extrapolation::Constant(())
-        ) == 11,
-        'invalid interpolation'
+    assert_eq!(
+        interpolate(4, xs.span(), ys.span(), Interpolation::ConstantRight, Extrapolation::Constant),
+        11
     );
-    assert(
-        interpolate(
-            6, xs.span(), ys.span(), Interpolation::ConstantRight(()), Extrapolation::Constant(())
-        ) == 13,
-        'invalid interpolation'
+    assert_eq!(
+        interpolate(6, xs.span(), ys.span(), Interpolation::ConstantRight, Extrapolation::Constant),
+        13
     );
-    assert(
-        interpolate(
-            7, xs.span(), ys.span(), Interpolation::ConstantRight(()), Extrapolation::Constant(())
-        ) == 13,
-        'invalid interpolation'
+    assert_eq!(
+        interpolate(7, xs.span(), ys.span(), Interpolation::ConstantRight, Extrapolation::Constant),
+        13
     );
 }
 
 #[test]
-#[should_panic(expected: ('Arrays must have the same len',))]
+#[should_panic()]
 #[available_gas(2000000)]
 fn interp_revert_len_mismatch() {
     let xs: Array::<u64> = array![3, 5];
     let ys = array![11];
-    interpolate(4, xs.span(), ys.span(), Interpolation::Linear(()), Extrapolation::Constant(()));
+    interpolate(4, xs.span(), ys.span(), Interpolation::Linear, Extrapolation::Constant);
 }
 
 #[test]
-#[should_panic(expected: ('Array must have at least 2 elts',))]
+#[should_panic()]
 #[available_gas(2000000)]
 fn interp_revert_len_too_short() {
     let xs: Array::<u64> = array![3];
     let ys = array![11];
-    interpolate(4, xs.span(), ys.span(), Interpolation::Linear(()), Extrapolation::Constant(()));
+    interpolate(4, xs.span(), ys.span(), Interpolation::Linear, Extrapolation::Constant);
 }

--- a/src/numeric/src/tests/interpolate_test.cairo
+++ b/src/numeric/src/tests/interpolate_test.cairo
@@ -83,7 +83,7 @@ fn interp_constant_right_test() {
 }
 
 #[test]
-#[should_panic()]
+#[should_panic(expected: ("Arrays must have the same len",))]
 #[available_gas(2000000)]
 fn interp_revert_len_mismatch() {
     let xs: Array::<u64> = array![3, 5];
@@ -92,7 +92,7 @@ fn interp_revert_len_mismatch() {
 }
 
 #[test]
-#[should_panic()]
+#[should_panic(expected: ("Array must have at least 2 elts",))]
 #[available_gas(2000000)]
 fn interp_revert_len_too_short() {
     let xs: Array::<u64> = array![3];

--- a/src/searching/src/binary_search.cairo
+++ b/src/searching/src/binary_search.cairo
@@ -26,3 +26,44 @@ fn binary_search<T, +Copy<T>, +Drop<T>, +PartialEq<T>, +PartialOrd<T>>(
         Option::None => Option::None
     }
 }
+
+fn binary_search_closest<T, impl TCopy: Copy<T>, impl TDrop: Drop<T>, impl TOr: PartialOrd<T>>(
+    span: Span<T>, val: T
+) -> Option<u32> {
+    // Initial check
+    if (span.len() == 0) {
+        return Option::None;
+    }
+    let middle = span.len() / 2;
+    if (*span[middle] <= val && val <= *span[middle]) {
+        return Option::Some(middle);
+    }
+    if (span.len() == 1) {
+        return Option::None;
+    }
+    if (span.len() == 2) {
+        if (*span[0] <= val && val < *span[1]) {
+            return Option::Some(0);
+        } else {
+            return Option::None;
+        }
+    }
+
+    let mut len = middle;
+    if (middle * 2 < span.len()) {
+        len += 1;
+    }
+    if (*span[middle] > val) {
+        let index = binary_search_closest(span.slice(0, middle + 1), val);
+        match index {
+            Option::Some(v) => Option::Some(v),
+            Option::None => Option::None
+        }
+    } else {
+        let index = binary_search_closest(span.slice(middle, len), val);
+        match index {
+            Option::Some(v) => Option::Some(v + middle),
+            Option::None => Option::None
+        }
+    }
+}

--- a/src/searching/src/tests.cairo
+++ b/src/searching/src/tests.cairo
@@ -1,4 +1,5 @@
 mod binary_search_test;
+mod binary_search_closest_test;
 mod bm_search_test;
 mod dijkstra_test;
 mod levenshtein_distance_test;

--- a/src/searching/src/tests.cairo
+++ b/src/searching/src/tests.cairo
@@ -1,5 +1,5 @@
-mod binary_search_test;
 mod binary_search_closest_test;
+mod binary_search_test;
 mod bm_search_test;
 mod dijkstra_test;
 mod levenshtein_distance_test;

--- a/src/searching/src/tests/binary_search_closest_test.cairo
+++ b/src/searching/src/tests/binary_search_closest_test.cairo
@@ -8,23 +8,23 @@ fn value_found() {
     let mut span = arr.span();
 
     // Test with an even length
-    assert(search(span, 100).unwrap() == 0, 'Should be index 0');
-    assert(search(span, 200).unwrap() == 1, 'Should be index 1');
-    assert(search(span, 300).unwrap() == 2, 'Should be index 2');
-    assert(search(span, 400).unwrap() == 3, 'Should be index 3');
-    assert(search(span, 500).unwrap() == 4, 'Should be index 4');
-    assert(search(span, 600).unwrap() == 5, 'Should be index 5');
+    assert_eq!(search(span, 100).unwrap(), 0);
+    assert_eq!(search(span, 200).unwrap(), 1);
+    assert_eq!(search(span, 300).unwrap(), 2);
+    assert_eq!(search(span, 400).unwrap(), 3);
+    assert_eq!(search(span, 500).unwrap(), 4);
+    assert_eq!(search(span, 600).unwrap(), 5);
 
     // Odd length
     arr.append(700);
     span = arr.span();
-    assert(search(span, 100).unwrap() == 0, 'Should be index 0');
-    assert(search(span, 200).unwrap() == 1, 'Should be index 1');
-    assert(search(span, 300).unwrap() == 2, 'Should be index 2');
-    assert(search(span, 400).unwrap() == 3, 'Should be index 3');
-    assert(search(span, 500).unwrap() == 4, 'Should be index 4');
-    assert(search(span, 600).unwrap() == 5, 'Should be index 5');
-    assert(search(span, 700).unwrap() == 6, 'Should be index 6');
+    assert_eq!(search(span, 100).unwrap(), 0);
+    assert_eq!(search(span, 200).unwrap(), 1);
+    assert_eq!(search(span, 300).unwrap(), 2);
+    assert_eq!(search(span, 400).unwrap(), 3);
+    assert_eq!(search(span, 500).unwrap(), 4);
+    assert_eq!(search(span, 600).unwrap(), 5);
+    assert_eq!(search(span, 700).unwrap(), 6);
 }
 
 #[test]
@@ -34,16 +34,16 @@ fn value_not_found() {
 
     // Test with an even length
     let mut span = arr.span();
-    assert(search(span, 20).is_none(), 'value was found');
-    assert(search(span, 42000).is_none(), 'value was found');
-    assert(search(span, 760).is_none(), 'value was found');
+    assert!(search(span, 20).is_none(), "value was found");
+    assert!(search(span, 42000).is_none(), "value was found");
+    assert!(search(span, 760).is_none(), "value was found");
 
     // Odd length
-    arr.append(700); // 6
+    arr.append(700);
     span = arr.span();
-    assert(search(span, 20).is_none(), 'value was found');
-    assert(search(span, 42000).is_none(), 'value was found');
-    assert(search(span, 760).is_none(), 'value was found');
+    assert!(search(span, 20).is_none(), "value was found");
+    assert!(search(span, 42000).is_none(), "value was found");
+    assert!(search(span, 760).is_none(), "value was found");
 }
 
 #[test]
@@ -51,23 +51,21 @@ fn value_not_found() {
 fn value_found_length_one() {
     let span: Span<u128> = array![100].span();
 
-    assert(search(span, 100).unwrap() == 0, 'value was not found')
+    assert_eq!(search(span, 100).unwrap(), 0);
 }
 
 #[test]
 #[available_gas(2000000)]
 fn value_not_found_length_one() {
     let span: Span<u128> = array![100].span();
-
-    assert(search(span, 50).is_none(), 'value was found')
+    assert!(search(span, 50).is_none(), "value was found")
 }
 
 #[test]
 #[available_gas(2000000)]
 fn zero_length_span() {
     let span: Span<u128> = array![].span();
-
-    assert(search(span, 100).is_none(), 'value was found')
+    assert!(search(span, 100).is_none(), "value was found")
 }
 
 // Closest specific tests
@@ -76,24 +74,24 @@ fn zero_length_span() {
 #[available_gas(1_000_000)]
 fn length_two_span() {
     let span: Span<u128> = array![100, 200].span();
-    assert(search(span, 50).is_none(), 'value was found');
-    assert(search(span, 100).unwrap() == 0, 'value was not found');
-    assert(search(span, 150).unwrap() == 0, 'value was not found');
-    assert(search(span, 200).unwrap() == 1, 'value was not found');
-    assert(search(span, 250).is_none(), 'value was found');
+    assert!(search(span, 50).is_none(), "value was found");
+    assert_eq!(search(span, 100).unwrap(), 0);
+    assert_eq!(search(span, 150).unwrap(), 0);
+    assert_eq!(search(span, 200).unwrap(), 1);
+    assert!(search(span, 250).is_none(), "value was found");
 }
 
 #[test]
 #[available_gas(1_000_000)]
 fn length_three_span() {
     let span: Span<u128> = array![100, 200, 300].span();
-    assert(search(span, 50).is_none(), 'value was found');
-    assert(search(span, 100).unwrap() == 0, 'value was not found');
-    assert(search(span, 150).unwrap() == 0, 'value was not found');
-    assert(search(span, 200).unwrap() == 1, 'value was not found');
-    assert(search(span, 250).unwrap() == 1, 'value was not found');
-    assert(search(span, 300).unwrap() == 2, 'value was not found');
-    assert(search(span, 350).is_none(), 'value was found');
+    assert!(search(span, 50).is_none(), "value was found");
+    assert_eq!(search(span, 100).unwrap(), 0);
+    assert_eq!(search(span, 150).unwrap(), 0);
+    assert_eq!(search(span, 200).unwrap(), 1);
+    assert_eq!(search(span, 250).unwrap(), 1);
+    assert_eq!(search(span, 300).unwrap(), 2);
+    assert!(search(span, 350).is_none(), "value was found");
 }
 
 #[test]
@@ -104,21 +102,21 @@ fn closest_value_found() {
     let mut span = arr.span();
 
     // Test with an even length
-    assert(search(span, 150).unwrap() == 0, 'Should be index 0');
-    assert(search(span, 250).unwrap() == 1, 'Should be index 1');
-    assert(search(span, 350).unwrap() == 2, 'Should be index 2');
-    assert(search(span, 450).unwrap() == 3, 'Should be index 3');
-    assert(search(span, 550).unwrap() == 4, 'Should be index 4');
+    assert_eq!(search(span, 150).unwrap(), 0);
+    assert_eq!(search(span, 250).unwrap(), 1);
+    assert_eq!(search(span, 350).unwrap(), 2);
+    assert_eq!(search(span, 450).unwrap(), 3);
+    assert_eq!(search(span, 550).unwrap(), 4);
 
     // Odd length
     arr.append(700);
     span = arr.span();
-    assert(search(span, 150).unwrap() == 0, 'Should be index 0');
-    assert(search(span, 250).unwrap() == 1, 'Should be index 1');
-    assert(search(span, 350).unwrap() == 2, 'Should be index 2');
-    assert(search(span, 450).unwrap() == 3, 'Should be index 3');
-    assert(search(span, 550).unwrap() == 4, 'Should be index 4');
-    assert(search(span, 650).unwrap() == 5, 'Should be index 5');
+    assert_eq!(search(span, 150).unwrap(), 0);
+    assert_eq!(search(span, 250).unwrap(), 1);
+    assert_eq!(search(span, 350).unwrap(), 2);
+    assert_eq!(search(span, 450).unwrap(), 3);
+    assert_eq!(search(span, 550).unwrap(), 4);
+    assert_eq!(search(span, 650).unwrap(), 5);
 }
 
 #[test]
@@ -129,36 +127,36 @@ fn all_values() {
     let mut span = arr.span();
 
     // Test with an even length
-    assert(search(span, 50).is_none(), 'value was found');
-    assert(search(span, 100).unwrap() == 0, 'Should be index 0');
-    assert(search(span, 150).unwrap() == 0, 'Should be index 0');
-    assert(search(span, 200).unwrap() == 1, 'Should be index 1');
-    assert(search(span, 250).unwrap() == 1, 'Should be index 1');
-    assert(search(span, 300).unwrap() == 2, 'Should be index 2');
-    assert(search(span, 350).unwrap() == 2, 'Should be index 2');
-    assert(search(span, 400).unwrap() == 3, 'Should be index 3');
-    assert(search(span, 450).unwrap() == 3, 'Should be index 3');
-    assert(search(span, 500).unwrap() == 4, 'Should be index 4');
-    assert(search(span, 550).unwrap() == 4, 'Should be index 4');
-    assert(search(span, 600).unwrap() == 5, 'Should be index 5');
-    assert(search(span, 650).is_none(), 'value was found');
+    assert!(search(span, 50).is_none(), "value was found");
+    assert_eq!(search(span, 100).unwrap(), 0);
+    assert_eq!(search(span, 150).unwrap(), 0);
+    assert_eq!(search(span, 200).unwrap(), 1);
+    assert_eq!(search(span, 250).unwrap(), 1);
+    assert_eq!(search(span, 300).unwrap(), 2);
+    assert_eq!(search(span, 350).unwrap(), 2);
+    assert_eq!(search(span, 400).unwrap(), 3);
+    assert_eq!(search(span, 450).unwrap(), 3);
+    assert_eq!(search(span, 500).unwrap(), 4);
+    assert_eq!(search(span, 550).unwrap(), 4);
+    assert_eq!(search(span, 600).unwrap(), 5);
+    assert!(search(span, 650).is_none(), "value was found");
 
     // Odd length
     arr.append(700);
     span = arr.span();
-    assert(search(span, 50).is_none(), 'value was found');
-    assert(search(span, 100).unwrap() == 0, 'Should be index 0');
-    assert(search(span, 150).unwrap() == 0, 'Should be index 0');
-    assert(search(span, 200).unwrap() == 1, 'Should be index 1');
-    assert(search(span, 250).unwrap() == 1, 'Should be index 1');
-    assert(search(span, 300).unwrap() == 2, 'Should be index 2');
-    assert(search(span, 350).unwrap() == 2, 'Should be index 2');
-    assert(search(span, 400).unwrap() == 3, 'Should be index 3');
-    assert(search(span, 450).unwrap() == 3, 'Should be index 3');
-    assert(search(span, 500).unwrap() == 4, 'Should be index 4');
-    assert(search(span, 550).unwrap() == 4, 'Should be index 4');
-    assert(search(span, 600).unwrap() == 5, 'Should be index 5');
-    assert(search(span, 650).unwrap() == 5, 'Should be index 5');
-    assert(search(span, 700).unwrap() == 6, 'Should be index 6');
-    assert(search(span, 750).is_none(), 'value was found');
+    assert!(search(span, 50).is_none(), "value was found");
+    assert_eq!(search(span, 100).unwrap(), 0);
+    assert_eq!(search(span, 150).unwrap(), 0);
+    assert_eq!(search(span, 200).unwrap(), 1);
+    assert_eq!(search(span, 250).unwrap(), 1);
+    assert_eq!(search(span, 300).unwrap(), 2);
+    assert_eq!(search(span, 350).unwrap(), 2);
+    assert_eq!(search(span, 400).unwrap(), 3);
+    assert_eq!(search(span, 450).unwrap(), 3);
+    assert_eq!(search(span, 500).unwrap(), 4);
+    assert_eq!(search(span, 550).unwrap(), 4);
+    assert_eq!(search(span, 600).unwrap(), 5);
+    assert_eq!(search(span, 650).unwrap(), 5);
+    assert_eq!(search(span, 700).unwrap(), 6);
+    assert!(search(span, 750).is_none(), "value was found");
 }

--- a/src/searching/src/tests/binary_search_closest_test.cairo
+++ b/src/searching/src/tests/binary_search_closest_test.cairo
@@ -1,0 +1,164 @@
+use alexandria_searching::binary_search::binary_search_closest as search;
+
+#[test]
+#[available_gas(2000000)]
+fn value_found() {
+    let mut arr: Array<u128> = array![100, 200, 300, 400, 500, 600];
+
+    let mut span = arr.span();
+
+    // Test with an even length
+    assert(search(span, 100).unwrap() == 0, 'Should be index 0');
+    assert(search(span, 200).unwrap() == 1, 'Should be index 1');
+    assert(search(span, 300).unwrap() == 2, 'Should be index 2');
+    assert(search(span, 400).unwrap() == 3, 'Should be index 3');
+    assert(search(span, 500).unwrap() == 4, 'Should be index 4');
+    assert(search(span, 600).unwrap() == 5, 'Should be index 5');
+
+    // Odd length
+    arr.append(700);
+    span = arr.span();
+    assert(search(span, 100).unwrap() == 0, 'Should be index 0');
+    assert(search(span, 200).unwrap() == 1, 'Should be index 1');
+    assert(search(span, 300).unwrap() == 2, 'Should be index 2');
+    assert(search(span, 400).unwrap() == 3, 'Should be index 3');
+    assert(search(span, 500).unwrap() == 4, 'Should be index 4');
+    assert(search(span, 600).unwrap() == 5, 'Should be index 5');
+    assert(search(span, 700).unwrap() == 6, 'Should be index 6');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn value_not_found() {
+    let mut arr: Array<u128> = array![100, 200, 300, 400, 500, 600];
+
+    // Test with an even length
+    let mut span = arr.span();
+    assert(search(span, 20).is_none(), 'value was found');
+    assert(search(span, 42000).is_none(), 'value was found');
+    assert(search(span, 760).is_none(), 'value was found');
+
+    // Odd length
+    arr.append(700); // 6
+    span = arr.span();
+    assert(search(span, 20).is_none(), 'value was found');
+    assert(search(span, 42000).is_none(), 'value was found');
+    assert(search(span, 760).is_none(), 'value was found');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn value_found_length_one() {
+    let span: Span<u128> = array![100].span();
+
+    assert(search(span, 100).unwrap() == 0, 'value was not found')
+}
+
+#[test]
+#[available_gas(2000000)]
+fn value_not_found_length_one() {
+    let span: Span<u128> = array![100].span();
+
+    assert(search(span, 50).is_none(), 'value was found')
+}
+
+#[test]
+#[available_gas(2000000)]
+fn zero_length_span() {
+    let span: Span<u128> = array![].span();
+
+    assert(search(span, 100).is_none(), 'value was found')
+}
+
+// Closest specific tests
+
+#[test]
+#[available_gas(1_000_000)]
+fn length_two_span() {
+    let span: Span<u128> = array![100, 200].span();
+    assert(search(span, 50).is_none(), 'value was found');
+    assert(search(span, 100).unwrap() == 0, 'value was not found');
+    assert(search(span, 150).unwrap() == 0, 'value was not found');
+    assert(search(span, 200).unwrap() == 1, 'value was not found');
+    assert(search(span, 250).is_none(), 'value was found');
+}
+
+#[test]
+#[available_gas(1_000_000)]
+fn length_three_span() {
+    let span: Span<u128> = array![100, 200, 300].span();
+    assert(search(span, 50).is_none(), 'value was found');
+    assert(search(span, 100).unwrap() == 0, 'value was not found');
+    assert(search(span, 150).unwrap() == 0, 'value was not found');
+    assert(search(span, 200).unwrap() == 1, 'value was not found');
+    assert(search(span, 250).unwrap() == 1, 'value was not found');
+    assert(search(span, 300).unwrap() == 2, 'value was not found');
+    assert(search(span, 350).is_none(), 'value was found');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn closest_value_found() {
+    let mut arr: Array<u128> = array![100, 200, 300, 400, 500, 600];
+
+    let mut span = arr.span();
+
+    // Test with an even length
+    assert(search(span, 150).unwrap() == 0, 'Should be index 0');
+    assert(search(span, 250).unwrap() == 1, 'Should be index 1');
+    assert(search(span, 350).unwrap() == 2, 'Should be index 2');
+    assert(search(span, 450).unwrap() == 3, 'Should be index 3');
+    assert(search(span, 550).unwrap() == 4, 'Should be index 4');
+
+    // Odd length
+    arr.append(700);
+    span = arr.span();
+    assert(search(span, 150).unwrap() == 0, 'Should be index 0');
+    assert(search(span, 250).unwrap() == 1, 'Should be index 1');
+    assert(search(span, 350).unwrap() == 2, 'Should be index 2');
+    assert(search(span, 450).unwrap() == 3, 'Should be index 3');
+    assert(search(span, 550).unwrap() == 4, 'Should be index 4');
+    assert(search(span, 650).unwrap() == 5, 'Should be index 5');
+}
+
+#[test]
+#[available_gas(5_000_000)]
+fn all_values() {
+    let mut arr: Array<u128> = array![100, 200, 300, 400, 500, 600];
+
+    let mut span = arr.span();
+
+    // Test with an even length
+    assert(search(span, 50).is_none(), 'value was found');
+    assert(search(span, 100).unwrap() == 0, 'Should be index 0');
+    assert(search(span, 150).unwrap() == 0, 'Should be index 0');
+    assert(search(span, 200).unwrap() == 1, 'Should be index 1');
+    assert(search(span, 250).unwrap() == 1, 'Should be index 1');
+    assert(search(span, 300).unwrap() == 2, 'Should be index 2');
+    assert(search(span, 350).unwrap() == 2, 'Should be index 2');
+    assert(search(span, 400).unwrap() == 3, 'Should be index 3');
+    assert(search(span, 450).unwrap() == 3, 'Should be index 3');
+    assert(search(span, 500).unwrap() == 4, 'Should be index 4');
+    assert(search(span, 550).unwrap() == 4, 'Should be index 4');
+    assert(search(span, 600).unwrap() == 5, 'Should be index 5');
+    assert(search(span, 650).is_none(), 'value was found');
+
+    // Odd length
+    arr.append(700);
+    span = arr.span();
+    assert(search(span, 50).is_none(), 'value was found');
+    assert(search(span, 100).unwrap() == 0, 'Should be index 0');
+    assert(search(span, 150).unwrap() == 0, 'Should be index 0');
+    assert(search(span, 200).unwrap() == 1, 'Should be index 1');
+    assert(search(span, 250).unwrap() == 1, 'Should be index 1');
+    assert(search(span, 300).unwrap() == 2, 'Should be index 2');
+    assert(search(span, 350).unwrap() == 2, 'Should be index 2');
+    assert(search(span, 400).unwrap() == 3, 'Should be index 3');
+    assert(search(span, 450).unwrap() == 3, 'Should be index 3');
+    assert(search(span, 500).unwrap() == 4, 'Should be index 4');
+    assert(search(span, 550).unwrap() == 4, 'Should be index 4');
+    assert(search(span, 600).unwrap() == 5, 'Should be index 5');
+    assert(search(span, 650).unwrap() == 5, 'Should be index 5');
+    assert(search(span, 700).unwrap() == 6, 'Should be index 6');
+    assert(search(span, 750).is_none(), 'value was found');
+}

--- a/src/searching/src/tests/binary_search_test.cairo
+++ b/src/searching/src/tests/binary_search_test.cairo
@@ -50,22 +50,19 @@ fn value_not_found() {
 #[available_gas(2000000)]
 fn value_found_length_one() {
     let span: Span<u128> = array![100].span();
-
-    assert(binary_search(span, 100).unwrap() == 0, 'value was not found')
+    assert_eq!(binary_search(span, 100).unwrap(), 0, "value was not found")
 }
 
 #[test]
 #[available_gas(2000000)]
 fn value_not_found_length_one() {
     let span: Span<u128> = array![100].span();
-
-    assert(binary_search(span, 50).is_none(), 'value was found')
+    assert!(binary_search(span, 50).is_none(), "value was found")
 }
 
 #[test]
 #[available_gas(2000000)]
 fn zero_length_span() {
     let span: Span<u128> = array![].span();
-
-    assert(binary_search(span, 100).is_none(), 'value was found')
+    assert!(binary_search(span, 100).is_none(), "value was found")
 }


### PR DESCRIPTION
- implement a gas efficient implementation of interpolation
- implement binary search for closest element in sorted array
- fix interpolation error in the case of `Interpolation::ConstantLeft`
- additional tests are provided

## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Interpolation is gas inefficient with large arrays

closes #285

## What is the new behavior?

Fast interpolation complexity is now logarithmic (vs linear) in the number of array elements.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Bug fix in the original interpolation is corrected and more tests cases are provided.
