### PR TITLE
feat(bitmap): add bitmap features

### DIFF
--- a/src/math/README.md
+++ b/src/math/README.md
@@ -29,6 +29,10 @@ The Armstrong number algorithm is used to determine if a number is an Armstrong 
 The algorithm is used for problem-solving and mathematical puzzles, and has applications in number theory, discrete mathematics, and computer science, as well as in generating strong encryption keys.
 By identifying Armstrong numbers, the algorithm provides insight into the properties of numbers and can be used in various applications in mathematics and computer science.
 
+## [Bitmap](./src/bitmap.cairo)
+
+Bitmap function to manage, search and manipulate bits efficiently.
+
 ## [Collatz sequence](./src/collatz_sequence.cairo)
 The Collatz sequence number algorithm is a mathematical algorithm used to generate the Collatz sequence of a given positive integer.
 The purpose of the Collatz sequence number algorithm is to explore the behavior of the Collatz conjecture, which is a famous unsolved problem in mathematics. The conjecture states that for any positive integer, the Collatz sequence will eventually reach the number 1. The Collatz sequence number algorithm is used to generate and study these sequences, which have applications in various areas of mathematics and computer science.

--- a/src/math/src/bitmap.cairo
+++ b/src/math/src/bitmap.cairo
@@ -1,0 +1,270 @@
+// Internam imports
+
+use alexandria_math::fast_power::fast_power as pow;
+
+/// The bit value at the provided index of a number.
+/// # Arguments
+/// * `x` - The value for which to extract the bit value.
+/// * `i` - The index.
+/// # Returns
+/// * The value at index.
+pub fn get_bit_at<
+    T,
+    +Div<T>,
+    +DivEq<T>,
+    +Rem<T>,
+    +BitAnd<T>,
+    +PartialEq<T>,
+    +Into<u8, T>,
+    +Into<T, u256>,
+    +TryInto<u256, T>,
+    +Drop<T>,
+    +Copy<T>
+>(
+    x: T, i: u8
+) -> bool {
+    let mask: T = pow(2_u8.into(), i.into());
+    x & mask == mask
+}
+
+/// Set the bit to value at the provided index of a number.
+/// # Arguments
+/// * `x` - The value for which to extract the bit value.
+/// * `i` - The index.
+/// * `value` - The value to set the bit to.
+/// # Returns
+/// * The value with the bit set to value.
+pub fn set_bit_at<
+    T,
+    +Div<T>,
+    +DivEq<T>,
+    +Rem<T>,
+    +BitAnd<T>,
+    +BitOr<T>,
+    +BitNot<T>,
+    +PartialEq<T>,
+    +Into<u8, T>,
+    +Into<T, u256>,
+    +TryInto<u256, T>,
+    +Drop<T>,
+    +Copy<T>
+>(
+    x: T, i: u8, value: bool
+) -> T {
+    let mask: T = pow(2_u8.into(), i.into());
+    if value {
+        x | mask
+    } else {
+        x & ~mask
+    }
+}
+
+/// The index of the most significant bit of the number,
+/// where the least significant bit is at index 0 and the most significant bit is at index 255
+/// # Arguments
+/// * `x` - The value for which to compute the most significant bit, must be greater than 0.
+/// # Returns
+/// * The index of the most significant bit
+pub fn most_significant_bit<T, +Into<T, u256>, +Drop<T>, +Copy<T>>(x: T) -> Option<u8> {
+    let mut x: u256 = x.into();
+    if x == 0_u8.into() {
+        return Option::None;
+    }
+    let mut r: u8 = 0;
+
+    if x >= 0x100000000000000000000000000000000 {
+        x /= 0x100000000000000000000000000000000;
+        r += 128;
+    }
+    if x >= 0x10000000000000000 {
+        x /= 0x10000000000000000;
+        r += 64;
+    }
+    if x >= 0x100000000 {
+        x /= 0x100000000;
+        r += 32;
+    }
+    if x >= 0x10000 {
+        x /= 0x10000;
+        r += 16;
+    }
+    if x >= 0x100 {
+        x /= 0x100;
+        r += 8;
+    }
+    if x >= 0x10 {
+        x /= 0x10;
+        r += 4;
+    }
+    if x >= 0x4 {
+        x /= 0x4;
+        r += 2;
+    }
+    if x >= 0x2 {
+        r += 1;
+    }
+    Option::Some(r)
+}
+
+/// The index of the least significant bit of the number,
+/// where the least significant bit is at index 0 and the most significant bit is at index 255
+/// # Arguments
+/// * `x` - The value for which to compute the least significant bit, must be greater than 0.
+/// # Returns
+/// * The index of the least significant bit
+pub fn least_significant_bit<T, +Into<T, u256>, +Drop<T>, +Copy<T>>(x: T) -> Option<u8> {
+    let mut x: u256 = x.into();
+    if x == 0 {
+        return Option::None;
+    }
+    let mut r: u8 = 255;
+
+    if (x & 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF) > 0 {
+        r -= 128;
+    } else {
+        x /= 0x100000000000000000000000000000000;
+    }
+    if (x & 0xFFFFFFFFFFFFFFFF) > 0 {
+        r -= 64;
+    } else {
+        x /= 0x10000000000000000;
+    }
+    if (x & 0xFFFFFFFF) > 0 {
+        r -= 32;
+    } else {
+        x /= 0x100000000;
+    }
+    if (x & 0xFFFF) > 0 {
+        r -= 16;
+    } else {
+        x /= 0x10000;
+    }
+    if (x & 0xFF) > 0 {
+        r -= 8;
+    } else {
+        x /= 0x100;
+    }
+    if (x & 0xF) > 0 {
+        r -= 4;
+    } else {
+        x /= 0x10;
+    }
+    if (x & 0x3) > 0 {
+        r -= 2;
+    } else {
+        x /= 0x4;
+    }
+    if (x & 0x1) > 0 {
+        r -= 1;
+    }
+    Option::Some(r)
+}
+
+/// The index of the nearest left significant bit to the index of a number.
+/// # Arguments
+/// * `x` - The value for which to compute the most significant bit.
+/// * `i` - The index for which to start the search.
+/// # Returns
+/// * The index of the nearest left significant bit, None is returned if no significant bit is found.
+pub fn nearest_left_significant_bit<
+    T,
+    +Add<T>,
+    +Sub<T>,
+    +Mul<T>,
+    +Div<T>,
+    +DivEq<T>,
+    +Rem<T>,
+    +BitAnd<T>,
+    +BitOr<T>,
+    +BitNot<T>,
+    +PartialEq<T>,
+    +PartialOrd<T>,
+    +Into<u8, T>,
+    +Into<T, u256>,
+    +TryInto<u256, T>,
+    +Drop<T>,
+    +Copy<T>
+>(
+    x: T, i: u8
+) -> Option::<u8> {
+    let mask = ~(pow(2_u8.into(), i.into()) - 1_u8.into());
+    least_significant_bit(x & mask)
+}
+
+/// The index of the nearest right significant bit to the index of a number.
+/// # Arguments
+/// * `x` - The value for which to compute the most significant bit.
+/// * `i` - The index for which to start the search.
+/// # Returns
+/// * The index of the nearest right significant bit, None is returned if no significant bit is found.
+pub fn nearest_right_significant_bit<
+    T,
+    +Add<T>,
+    +Sub<T>,
+    +Mul<T>,
+    +Div<T>,
+    +DivEq<T>,
+    +Rem<T>,
+    +BitAnd<T>,
+    +BitOr<T>,
+    +BitNot<T>,
+    +PartialEq<T>,
+    +PartialOrd<T>,
+    +Into<u8, T>,
+    +Into<T, u256>,
+    +TryInto<u256, T>,
+    +Drop<T>,
+    +Copy<T>
+>(
+    x: T, i: u8
+) -> Option::<u8> {
+    let mask = pow(2_u8.into(), (i + 1).into()) - 1_u8.into();
+    most_significant_bit(x & mask)
+}
+
+/// The index of the nearest significant bit to the index of a number,
+/// where the least significant bit is at index 0 and the most significant bit is at index 255
+/// # Arguments
+/// * `x` - The value for which to compute the most significant bit, must be greater than 0.
+/// * `i` - The index for which to start the search.
+/// * `priority` - if priority is set to true then right is prioritized over left, left over right otherwise.
+/// # Returns
+/// * The index of the nearest significant bit, None is returned if no significant bit is found.
+pub fn nearest_significant_bit<
+    T,
+    +Add<T>,
+    +Sub<T>,
+    +Mul<T>,
+    +Div<T>,
+    +DivEq<T>,
+    +Rem<T>,
+    +BitAnd<T>,
+    +BitOr<T>,
+    +BitNot<T>,
+    +PartialEq<T>,
+    +PartialOrd<T>,
+    +Into<u8, T>,
+    +Into<T, u256>,
+    +TryInto<u256, T>,
+    +Drop<T>,
+    +Copy<T>
+>(
+    x: T, i: u8, priority: bool
+) -> Option::<u8> {
+    let nlsb = nearest_left_significant_bit(x, i);
+    let nrsb = nearest_right_significant_bit(x, i);
+    match (nlsb, nrsb) {
+        (
+            Option::Some(lhs), Option::Some(rhs)
+        ) => {
+            if i - rhs < lhs - i || (priority && (i - rhs == lhs - i)) {
+                Option::Some(rhs)
+            } else {
+                Option::Some(lhs)
+            }
+        },
+        (Option::Some(lhs), Option::None) => Option::Some(lhs),
+        (Option::None, Option::Some(rhs)) => Option::Some(rhs),
+        (Option::None, Option::None) => Option::None,
+    }
+}

--- a/src/math/src/bitmap.cairo
+++ b/src/math/src/bitmap.cairo
@@ -2,171 +2,8 @@
 
 use alexandria_math::fast_power::fast_power as pow;
 
-/// The bit value at the provided index of a number.
-/// # Arguments
-/// * `x` - The value for which to extract the bit value.
-/// * `i` - The index.
-/// # Returns
-/// * The value at index.
-pub fn get_bit_at<
-    T,
-    +Div<T>,
-    +DivEq<T>,
-    +Rem<T>,
-    +BitAnd<T>,
-    +PartialEq<T>,
-    +Into<u8, T>,
-    +Into<T, u256>,
-    +TryInto<u256, T>,
-    +Drop<T>,
-    +Copy<T>
->(
-    x: T, i: u8
-) -> bool {
-    let mask: T = pow(2_u8.into(), i.into());
-    x & mask == mask
-}
-
-/// Set the bit to value at the provided index of a number.
-/// # Arguments
-/// * `x` - The value for which to extract the bit value.
-/// * `i` - The index.
-/// * `value` - The value to set the bit to.
-/// # Returns
-/// * The value with the bit set to value.
-pub fn set_bit_at<
-    T,
-    +Div<T>,
-    +DivEq<T>,
-    +Rem<T>,
-    +BitAnd<T>,
-    +BitOr<T>,
-    +BitNot<T>,
-    +PartialEq<T>,
-    +Into<u8, T>,
-    +Into<T, u256>,
-    +TryInto<u256, T>,
-    +Drop<T>,
-    +Copy<T>
->(
-    x: T, i: u8, value: bool
-) -> T {
-    let mask: T = pow(2_u8.into(), i.into());
-    if value {
-        x | mask
-    } else {
-        x & ~mask
-    }
-}
-
-/// The index of the most significant bit of the number,
-/// where the least significant bit is at index 0 and the most significant bit is at index 255
-/// # Arguments
-/// * `x` - The value for which to compute the most significant bit, must be greater than 0.
-/// # Returns
-/// * The index of the most significant bit
-pub fn most_significant_bit<T, +Into<T, u256>, +Drop<T>, +Copy<T>>(x: T) -> Option<u8> {
-    let mut x: u256 = x.into();
-    if x == 0_u8.into() {
-        return Option::None;
-    }
-    let mut r: u8 = 0;
-
-    if x >= 0x100000000000000000000000000000000 {
-        x /= 0x100000000000000000000000000000000;
-        r += 128;
-    }
-    if x >= 0x10000000000000000 {
-        x /= 0x10000000000000000;
-        r += 64;
-    }
-    if x >= 0x100000000 {
-        x /= 0x100000000;
-        r += 32;
-    }
-    if x >= 0x10000 {
-        x /= 0x10000;
-        r += 16;
-    }
-    if x >= 0x100 {
-        x /= 0x100;
-        r += 8;
-    }
-    if x >= 0x10 {
-        x /= 0x10;
-        r += 4;
-    }
-    if x >= 0x4 {
-        x /= 0x4;
-        r += 2;
-    }
-    if x >= 0x2 {
-        r += 1;
-    }
-    Option::Some(r)
-}
-
-/// The index of the least significant bit of the number,
-/// where the least significant bit is at index 0 and the most significant bit is at index 255
-/// # Arguments
-/// * `x` - The value for which to compute the least significant bit, must be greater than 0.
-/// # Returns
-/// * The index of the least significant bit
-pub fn least_significant_bit<T, +Into<T, u256>, +Drop<T>, +Copy<T>>(x: T) -> Option<u8> {
-    let mut x: u256 = x.into();
-    if x == 0 {
-        return Option::None;
-    }
-    let mut r: u8 = 255;
-
-    if (x & 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF) > 0 {
-        r -= 128;
-    } else {
-        x /= 0x100000000000000000000000000000000;
-    }
-    if (x & 0xFFFFFFFFFFFFFFFF) > 0 {
-        r -= 64;
-    } else {
-        x /= 0x10000000000000000;
-    }
-    if (x & 0xFFFFFFFF) > 0 {
-        r -= 32;
-    } else {
-        x /= 0x100000000;
-    }
-    if (x & 0xFFFF) > 0 {
-        r -= 16;
-    } else {
-        x /= 0x10000;
-    }
-    if (x & 0xFF) > 0 {
-        r -= 8;
-    } else {
-        x /= 0x100;
-    }
-    if (x & 0xF) > 0 {
-        r -= 4;
-    } else {
-        x /= 0x10;
-    }
-    if (x & 0x3) > 0 {
-        r -= 2;
-    } else {
-        x /= 0x4;
-    }
-    if (x & 0x1) > 0 {
-        r -= 1;
-    }
-    Option::Some(r)
-}
-
-/// The index of the nearest left significant bit to the index of a number.
-/// # Arguments
-/// * `x` - The value for which to compute the most significant bit.
-/// * `i` - The index for which to start the search.
-/// # Returns
-/// * The index of the nearest left significant bit, None is returned if no significant bit is found.
-pub fn nearest_left_significant_bit<
+#[generate_trait]
+pub impl Bitmap<
     T,
     +Add<T>,
     +Sub<T>,
@@ -184,87 +21,188 @@ pub fn nearest_left_significant_bit<
     +TryInto<u256, T>,
     +Drop<T>,
     +Copy<T>
->(
-    x: T, i: u8
-) -> Option::<u8> {
-    let mask = ~(pow(2_u8.into(), i.into()) - 1_u8.into());
-    least_significant_bit(x & mask)
-}
+> of BitmapTrait<T> {
+    /// The bit value at the provided index of a number.
+    /// # Arguments
+    /// * `x` - The value for which to extract the bit value.
+    /// * `i` - The index.
+    /// # Returns
+    /// * The value at index.
+    #[inline(always)]
+    fn get_bit_at(x: T, i: u8) -> bool {
+        let mask: T = pow(2_u8.into(), i.into());
+        x & mask == mask
+    }
 
-/// The index of the nearest right significant bit to the index of a number.
-/// # Arguments
-/// * `x` - The value for which to compute the most significant bit.
-/// * `i` - The index for which to start the search.
-/// # Returns
-/// * The index of the nearest right significant bit, None is returned if no significant bit is found.
-pub fn nearest_right_significant_bit<
-    T,
-    +Add<T>,
-    +Sub<T>,
-    +Mul<T>,
-    +Div<T>,
-    +DivEq<T>,
-    +Rem<T>,
-    +BitAnd<T>,
-    +BitOr<T>,
-    +BitNot<T>,
-    +PartialEq<T>,
-    +PartialOrd<T>,
-    +Into<u8, T>,
-    +Into<T, u256>,
-    +TryInto<u256, T>,
-    +Drop<T>,
-    +Copy<T>
->(
-    x: T, i: u8
-) -> Option::<u8> {
-    let mask = pow(2_u8.into(), (i + 1).into()) - 1_u8.into();
-    most_significant_bit(x & mask)
-}
+    /// Set the bit to value at the provided index of a number.
+    /// # Arguments
+    /// * `x` - The value for which to extract the bit value.
+    /// * `i` - The index.
+    /// * `value` - The value to set the bit to.
+    /// # Returns
+    /// * The value with the bit set to value.
+    #[inline(always)]
+    fn set_bit_at(x: T, i: u8, value: bool) -> T {
+        let mask: T = pow(2_u8.into(), i.into());
+        if value {
+            x | mask
+        } else {
+            x & ~mask
+        }
+    }
 
-/// The index of the nearest significant bit to the index of a number,
-/// where the least significant bit is at index 0 and the most significant bit is at index 255
-/// # Arguments
-/// * `x` - The value for which to compute the most significant bit, must be greater than 0.
-/// * `i` - The index for which to start the search.
-/// * `priority` - if priority is set to true then right is prioritized over left, left over right otherwise.
-/// # Returns
-/// * The index of the nearest significant bit, None is returned if no significant bit is found.
-pub fn nearest_significant_bit<
-    T,
-    +Add<T>,
-    +Sub<T>,
-    +Mul<T>,
-    +Div<T>,
-    +DivEq<T>,
-    +Rem<T>,
-    +BitAnd<T>,
-    +BitOr<T>,
-    +BitNot<T>,
-    +PartialEq<T>,
-    +PartialOrd<T>,
-    +Into<u8, T>,
-    +Into<T, u256>,
-    +TryInto<u256, T>,
-    +Drop<T>,
-    +Copy<T>
->(
-    x: T, i: u8, priority: bool
-) -> Option::<u8> {
-    let nlsb = nearest_left_significant_bit(x, i);
-    let nrsb = nearest_right_significant_bit(x, i);
-    match (nlsb, nrsb) {
-        (
-            Option::Some(lhs), Option::Some(rhs)
-        ) => {
-            if i - rhs < lhs - i || (priority && (i - rhs == lhs - i)) {
-                Option::Some(rhs)
-            } else {
-                Option::Some(lhs)
-            }
-        },
-        (Option::Some(lhs), Option::None) => Option::Some(lhs),
-        (Option::None, Option::Some(rhs)) => Option::Some(rhs),
-        (Option::None, Option::None) => Option::None,
+    /// The index of the most significant bit of the number,
+    /// where the least significant bit is at index 0 and the most significant bit is at index 255
+    /// # Arguments
+    /// * `x` - The value for which to compute the most significant bit, must be greater than 0.
+    /// # Returns
+    /// * The index of the most significant bit
+    #[inline(always)]
+    fn most_significant_bit(x: T) -> Option<u8> {
+        let mut x: u256 = x.into();
+        if x == 0_u8.into() {
+            return Option::None;
+        }
+        let mut r: u8 = 0;
+
+        if x >= 0x100000000000000000000000000000000 {
+            x /= 0x100000000000000000000000000000000;
+            r += 128;
+        }
+        if x >= 0x10000000000000000 {
+            x /= 0x10000000000000000;
+            r += 64;
+        }
+        if x >= 0x100000000 {
+            x /= 0x100000000;
+            r += 32;
+        }
+        if x >= 0x10000 {
+            x /= 0x10000;
+            r += 16;
+        }
+        if x >= 0x100 {
+            x /= 0x100;
+            r += 8;
+        }
+        if x >= 0x10 {
+            x /= 0x10;
+            r += 4;
+        }
+        if x >= 0x4 {
+            x /= 0x4;
+            r += 2;
+        }
+        if x >= 0x2 {
+            r += 1;
+        }
+        Option::Some(r)
+    }
+
+    /// The index of the least significant bit of the number,
+    /// where the least significant bit is at index 0 and the most significant bit is at index 255
+    /// # Arguments
+    /// * `x` - The value for which to compute the least significant bit, must be greater than 0.
+    /// # Returns
+    /// * The index of the least significant bit
+    #[inline(always)]
+    fn least_significant_bit(x: T) -> Option<u8> {
+        let mut x: u256 = x.into();
+        if x == 0 {
+            return Option::None;
+        }
+        let mut r: u8 = 255;
+
+        if (x & 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF) > 0 {
+            r -= 128;
+        } else {
+            x /= 0x100000000000000000000000000000000;
+        }
+        if (x & 0xFFFFFFFFFFFFFFFF) > 0 {
+            r -= 64;
+        } else {
+            x /= 0x10000000000000000;
+        }
+        if (x & 0xFFFFFFFF) > 0 {
+            r -= 32;
+        } else {
+            x /= 0x100000000;
+        }
+        if (x & 0xFFFF) > 0 {
+            r -= 16;
+        } else {
+            x /= 0x10000;
+        }
+        if (x & 0xFF) > 0 {
+            r -= 8;
+        } else {
+            x /= 0x100;
+        }
+        if (x & 0xF) > 0 {
+            r -= 4;
+        } else {
+            x /= 0x10;
+        }
+        if (x & 0x3) > 0 {
+            r -= 2;
+        } else {
+            x /= 0x4;
+        }
+        if (x & 0x1) > 0 {
+            r -= 1;
+        }
+        Option::Some(r)
+    }
+
+    /// The index of the nearest left significant bit to the index of a number.
+    /// # Arguments
+    /// * `x` - The value for which to compute the most significant bit.
+    /// * `i` - The index for which to start the search.
+    /// # Returns
+    /// * The index of the nearest left significant bit, None is returned if no significant bit is found.
+    #[inline(always)]
+    fn nearest_left_significant_bit(x: T, i: u8) -> Option::<u8> {
+        let mask = ~(pow(2_u8.into(), i.into()) - 1_u8.into());
+        Bitmap::least_significant_bit(x & mask)
+    }
+
+    /// The index of the nearest right significant bit to the index of a number.
+    /// # Arguments
+    /// * `x` - The value for which to compute the most significant bit.
+    /// * `i` - The index for which to start the search.
+    /// # Returns
+    /// * The index of the nearest right significant bit, None is returned if no significant bit is found.
+    #[inline(always)]
+    fn nearest_right_significant_bit(x: T, i: u8) -> Option::<u8> {
+        let mask = pow(2_u8.into(), (i + 1).into()) - 1_u8.into();
+        Bitmap::most_significant_bit(x & mask)
+    }
+
+    /// The index of the nearest significant bit to the index of a number,
+    /// where the least significant bit is at index 0 and the most significant bit is at index 255
+    /// # Arguments
+    /// * `x` - The value for which to compute the most significant bit, must be greater than 0.
+    /// * `i` - The index for which to start the search.
+    /// * `priority` - if priority is set to true then right is prioritized over left, left over right otherwise.
+    /// # Returns
+    /// * The index of the nearest significant bit, None is returned if no significant bit is found.
+    #[inline(always)]
+    fn nearest_significant_bit(x: T, i: u8, priority: bool) -> Option::<u8> {
+        let nlsb = Bitmap::nearest_left_significant_bit(x, i);
+        let nrsb = Bitmap::nearest_right_significant_bit(x, i);
+        match (nlsb, nrsb) {
+            (
+                Option::Some(lhs), Option::Some(rhs)
+            ) => {
+                if i - rhs < lhs - i || (priority && (i - rhs == lhs - i)) {
+                    Option::Some(rhs)
+                } else {
+                    Option::Some(lhs)
+                }
+            },
+            (Option::Some(lhs), Option::None) => Option::Some(lhs),
+            (Option::None, Option::Some(rhs)) => Option::Some(rhs),
+            (Option::None, Option::None) => Option::None,
+        }
     }
 }

--- a/src/math/src/fast_power.cairo
+++ b/src/math/src/fast_power.cairo
@@ -1,30 +1,87 @@
 //! # Fast power algorithm
 
-// Calculate the ( base ^ power ) mod modulus
-// using the fast powering algorithm # Arguments
+// Calculate the base ^ power 
+// using the fast powering algorithm
+// # Arguments
 // * ` base ` - The base of the exponentiation 
 // * ` power ` - The power of the exponentiation 
-// * ` modulus ` - The modulus used in the calculation # Returns
+// * ` modulus ` - The modulus used in the calculation
+// # Returns
+// * ` T ` - The result of ( base ^ power ) mod modulus
+pub fn fast_power<
+    T,
+    +Div<T>,
+    +DivEq<T>,
+    +Rem<T>,
+    +Into<u8, T>,
+    +Into<T, u256>,
+    +TryInto<u256, T>,
+    +PartialEq<T>,
+    +Copy<T>,
+    +Drop<T>
+>(
+    base: T, mut power: T
+) -> T {
+    assert!(base != 0_u8.into(), "fast_power: invalid input");
+
+    let mut base: u256 = base.into();
+    let mut result: u256 = 1;
+
+    loop {
+        if power % 2_u8.into() != 0_u8.into() {
+            result *= base;
+        }
+        power /= 2_u8.into();
+        if (power == 0_u8.into()) {
+            break;
+        }
+        base *= base;
+    };
+
+    result.try_into().expect('value cant be larger than u128')
+}
+
+// Calculate the ( base ^ power ) mod modulus
+// using the fast powering algorithm
+// # Arguments
+// * ` base ` - The base of the exponentiation 
+// * ` power ` - The power of the exponentiation 
+// * ` modulus ` - The modulus used in the calculation
+// # Returns
 // * ` u128 ` - The result of ( base ^ power ) mod modulus
+pub fn fast_power_mod<
+    T,
+    +Div<T>,
+    +DivEq<T>,
+    +Rem<T>,
+    +Into<u8, T>,
+    +Into<T, u256>,
+    +TryInto<u256, T>,
+    +PartialEq<T>,
+    +Copy<T>,
+    +Drop<T>
+>(
+    base: T, mut power: T, modulus: T
+) -> T {
+    assert!(base != 0_u8.into(), "fast_power: invalid input");
 
-pub fn fast_power(base: u128, mut power: u128, modulus: u128) -> u128 {
-    assert!(base != 0, "fast_power: invalid input");
-
-    if modulus == 1 {
-        return 0;
+    if modulus == 1_u8.into() {
+        return 0_u8.into();
     }
 
     let mut base: u256 = base.into();
     let modulus: u256 = modulus.into();
     let mut result: u256 = 1;
 
-    while (power != 0) {
-        if power % 2 != 0 {
+    loop {
+        if power % 2_u8.into() != 0_u8.into() {
             result = (result * base) % modulus;
         }
-
+        power /= 2_u8.into();
+        if (power == 0_u8.into()) {
+            break;
+        }
         base = (base * base) % modulus;
-        power = power / 2;
     };
 
     result.try_into().expect('value cant be larger than u128')

--- a/src/math/src/fast_power.cairo
+++ b/src/math/src/fast_power.cairo
@@ -1,13 +1,14 @@
 //! # Fast power algorithm
 
-// Calculate the base ^ power 
-// using the fast powering algorithm
-// # Arguments
-// * ` base ` - The base of the exponentiation 
-// * ` power ` - The power of the exponentiation 
-// * ` modulus ` - The modulus used in the calculation
-// # Returns
-// * ` T ` - The result of ( base ^ power ) mod modulus
+/// Calculate the base ^ power 
+/// using the fast powering algorithm
+/// # Arguments
+/// * ` base ` - The base of the exponentiation 
+/// * ` power ` - The power of the exponentiation 
+/// # Returns
+/// * ` T ` - The result of base ^ power
+/// # Panics
+/// * ` base ` is 0
 pub fn fast_power<
     T,
     +Div<T>,
@@ -38,17 +39,19 @@ pub fn fast_power<
         base *= base;
     };
 
-    result.try_into().expect('value cant be larger than u128')
+    result.try_into().expect('too large to fit output type')
 }
 
-// Calculate the ( base ^ power ) mod modulus
-// using the fast powering algorithm
-// # Arguments
-// * ` base ` - The base of the exponentiation 
-// * ` power ` - The power of the exponentiation 
-// * ` modulus ` - The modulus used in the calculation
-// # Returns
-// * ` u128 ` - The result of ( base ^ power ) mod modulus
+/// Calculate the ( base ^ power ) mod modulus
+/// using the fast powering algorithm
+/// # Arguments
+/// * ` base ` - The base of the exponentiation 
+/// * ` power ` - The power of the exponentiation 
+/// * ` modulus ` - The modulus used in the calculation
+/// # Returns
+/// * ` T ` - The result of ( base ^ power ) mod modulus
+/// # Panics
+/// * ` base ` is 0
 pub fn fast_power_mod<
     T,
     +Div<T>,
@@ -84,5 +87,5 @@ pub fn fast_power_mod<
         base = (base * base) % modulus;
     };
 
-    result.try_into().expect('value cant be larger than u128')
+    result.try_into().expect('too large to fit output type')
 }

--- a/src/math/src/lib.cairo
+++ b/src/math/src/lib.cairo
@@ -1,5 +1,6 @@
 pub mod aliquot_sum;
 pub mod armstrong_number;
+pub mod bitmap;
 pub mod collatz_sequence;
 pub mod ed25519;
 pub mod extended_euclidean_algorithm;

--- a/src/math/src/tests.cairo
+++ b/src/math/src/tests.cairo
@@ -1,5 +1,6 @@
 mod aliquot_sum_test;
 mod armstrong_number_test;
+mod bitmap_test;
 mod collatz_sequence_test;
 mod ed25519_test;
 mod extended_euclidean_algorithm_test;

--- a/src/math/src/tests/bitmap_test.cairo
+++ b/src/math/src/tests/bitmap_test.cairo
@@ -1,0 +1,111 @@
+use alexandria_math::bitmap;
+
+#[test]
+fn test_bitmap_get_bit_at_0() {
+    let bitmap: u256 = 0;
+    let result = bitmap::get_bit_at(bitmap, 0);
+    assert(!result, 'Bitmap: get bit');
+}
+
+#[test]
+fn test_bitmap_get_bit_at_1() {
+    let bitmap: u256 = 255;
+    let result = bitmap::get_bit_at(bitmap, 1);
+    assert(result, 'Bitmap: get bit');
+}
+
+#[test]
+fn test_bitmap_get_bit_at_10() {
+    let bitmap: u256 = 3071;
+    let result = bitmap::get_bit_at(bitmap, 10);
+    assert(!result, 'Bitmap: get bit');
+}
+
+#[test]
+fn test_bitmap_set_bit_at_0() {
+    let bitmap: u256 = 0;
+    let result = bitmap::set_bit_at(bitmap, 0, true);
+    assert(result == 1, 'Bitmap: set bit at');
+    let result = bitmap::set_bit_at(bitmap, 0, false);
+    assert(result == bitmap, 'Bitmap: unset bit at');
+}
+
+#[test]
+fn test_bitmap_set_bit_at_1() {
+    let bitmap: u256 = 1;
+    let result = bitmap::set_bit_at(bitmap, 1, true);
+    assert(result == 3, 'Bitmap: set bit at');
+    let result = bitmap::set_bit_at(bitmap, 1, false);
+    assert(result == bitmap, 'Bitmap: unset bit at');
+}
+
+#[test]
+fn test_bitmap_set_bit_at_10() {
+    let bitmap: u256 = 3;
+    let result = bitmap::set_bit_at(bitmap, 10, true);
+    assert(result == 1027, 'Bitmap: set bit at');
+    let result = bitmap::set_bit_at(bitmap, 10, false);
+    assert(result == bitmap, 'Bitmap: unset bit at');
+}
+
+#[test]
+fn test_bitmap_most_significant_bit() {
+    let bitmap: u32 = 1234; // 10011010010
+    let msb = bitmap::most_significant_bit(bitmap);
+    assert(msb.unwrap() == 10, 'Bitmap: most significant bit');
+}
+
+#[test]
+fn test_bitmap_least_significant_bit() {
+    let bitmap: u32 = 1234; // 10011010010
+    let msb = bitmap::least_significant_bit(bitmap);
+    assert(msb.unwrap() == 1, 'Bitmap: least significant bit');
+}
+
+#[test]
+fn test_bitmap_nearest_left_significant_bit() {
+    let bitmap: u32 = 1234; // 10011010010
+    let index = 5;
+    let nlsb = bitmap::nearest_left_significant_bit(bitmap, index);
+    assert(nlsb.unwrap() == 6, 'Bitmap: nearest significant bit');
+}
+
+#[test]
+fn test_bitmap_nearest_right_significant_bit() {
+    let bitmap: u32 = 1234; // 10011010010
+    let index = 5;
+    let nrsb = bitmap::nearest_right_significant_bit(bitmap, index);
+    assert(nrsb.unwrap() == 4, 'Bitmap: nearest significant bit');
+}
+
+#[test]
+fn test_bitmap_nearest_significant_bit_left_priority() {
+    let bitmap: u32 = 1234; // 10011010010
+    let index = 5;
+    let nsb = bitmap::nearest_significant_bit(bitmap, index, false);
+    assert(nsb.unwrap() == 6, 'Bitmap: nearest significant bit');
+}
+
+#[test]
+fn test_bitmap_nearest_significant_bit_right_priority() {
+    let bitmap: u32 = 1234; // 10011010010
+    let index = 5;
+    let nsb = bitmap::nearest_significant_bit(bitmap, index, true);
+    assert(nsb.unwrap() == 4, 'Bitmap: nearest significant bit');
+}
+
+#[test]
+fn test_bitmap_nearest_significant_bit_left_priority_at_index() {
+    let bitmap: u32 = 1234; // 10011010010
+    let index = 6;
+    let nsb = bitmap::nearest_significant_bit(bitmap, index, false);
+    assert(nsb.unwrap() == 6, 'Bitmap: nearest significant bit');
+}
+
+#[test]
+fn test_bitmap_nearest_significant_bit_right_priority_at_index() {
+    let bitmap: u32 = 1234; // 10011010010
+    let index = 6;
+    let nsb = bitmap::nearest_significant_bit(bitmap, index, true);
+    assert(nsb.unwrap() == 6, 'Bitmap: nearest significant bit');
+}

--- a/src/math/src/tests/bitmap_test.cairo
+++ b/src/math/src/tests/bitmap_test.cairo
@@ -1,64 +1,64 @@
-use alexandria_math::bitmap;
+use alexandria_math::bitmap::Bitmap;
 
 #[test]
 fn test_bitmap_get_bit_at_0() {
     let bitmap: u256 = 0;
-    let result = bitmap::get_bit_at(bitmap, 0);
+    let result = Bitmap::get_bit_at(bitmap, 0);
     assert!(!result, "Bitmap: get bit");
 }
 
 #[test]
 fn test_bitmap_get_bit_at_1() {
     let bitmap: u256 = 255;
-    let result = bitmap::get_bit_at(bitmap, 1);
+    let result = Bitmap::get_bit_at(bitmap, 1);
     assert!(result, "Bitmap: get bit");
 }
 
 #[test]
 fn test_bitmap_get_bit_at_10() {
     let bitmap: u256 = 3071;
-    let result = bitmap::get_bit_at(bitmap, 10);
+    let result = Bitmap::get_bit_at(bitmap, 10);
     assert!(!result, "Bitmap: get bit");
 }
 
 #[test]
 fn test_bitmap_set_bit_at_0() {
     let bitmap: u256 = 0;
-    let result = bitmap::set_bit_at(bitmap, 0, true);
+    let result = Bitmap::set_bit_at(bitmap, 0, true);
     assert!(result == 1, "Bitmap: set bit at");
-    let result = bitmap::set_bit_at(bitmap, 0, false);
+    let result = Bitmap::set_bit_at(bitmap, 0, false);
     assert!(result == bitmap, "Bitmap: unset bit at");
 }
 
 #[test]
 fn test_bitmap_set_bit_at_1() {
     let bitmap: u256 = 1;
-    let result = bitmap::set_bit_at(bitmap, 1, true);
+    let result = Bitmap::set_bit_at(bitmap, 1, true);
     assert!(result == 3, "Bitmap: set bit at");
-    let result = bitmap::set_bit_at(bitmap, 1, false);
+    let result = Bitmap::set_bit_at(bitmap, 1, false);
     assert!(result == bitmap, "Bitmap: unset bit at");
 }
 
 #[test]
 fn test_bitmap_set_bit_at_10() {
     let bitmap: u256 = 3;
-    let result = bitmap::set_bit_at(bitmap, 10, true);
+    let result = Bitmap::set_bit_at(bitmap, 10, true);
     assert!(result == 1027, "Bitmap: set bit at");
-    let result = bitmap::set_bit_at(bitmap, 10, false);
+    let result = Bitmap::set_bit_at(bitmap, 10, false);
     assert!(result == bitmap, "Bitmap: unset bit at");
 }
 
 #[test]
 fn test_bitmap_most_significant_bit() {
     let bitmap: u32 = 1234; // 10011010010
-    let msb = bitmap::most_significant_bit(bitmap);
+    let msb = Bitmap::most_significant_bit(bitmap);
     assert!(msb.unwrap() == 10, "Bitmap: most significant bit");
 }
 
 #[test]
 fn test_bitmap_least_significant_bit() {
     let bitmap: u32 = 1234; // 10011010010
-    let msb = bitmap::least_significant_bit(bitmap);
+    let msb = Bitmap::least_significant_bit(bitmap);
     assert!(msb.unwrap() == 1, "Bitmap: least significant bit");
 }
 
@@ -66,7 +66,7 @@ fn test_bitmap_least_significant_bit() {
 fn test_bitmap_nearest_left_significant_bit() {
     let bitmap: u32 = 1234; // 10011010010
     let index = 5;
-    let nlsb = bitmap::nearest_left_significant_bit(bitmap, index);
+    let nlsb = Bitmap::nearest_left_significant_bit(bitmap, index);
     assert!(nlsb.unwrap() == 6, "Bitmap: nearest significant bit");
 }
 
@@ -74,7 +74,7 @@ fn test_bitmap_nearest_left_significant_bit() {
 fn test_bitmap_nearest_right_significant_bit() {
     let bitmap: u32 = 1234; // 10011010010
     let index = 5;
-    let nrsb = bitmap::nearest_right_significant_bit(bitmap, index);
+    let nrsb = Bitmap::nearest_right_significant_bit(bitmap, index);
     assert!(nrsb.unwrap() == 4, "Bitmap: nearest significant bit");
 }
 
@@ -82,7 +82,7 @@ fn test_bitmap_nearest_right_significant_bit() {
 fn test_bitmap_nearest_significant_bit_left_priority() {
     let bitmap: u32 = 1234; // 10011010010
     let index = 5;
-    let nsb = bitmap::nearest_significant_bit(bitmap, index, false);
+    let nsb = Bitmap::nearest_significant_bit(bitmap, index, false);
     assert!(nsb.unwrap() == 6, "Bitmap: nearest significant bit");
 }
 
@@ -90,7 +90,7 @@ fn test_bitmap_nearest_significant_bit_left_priority() {
 fn test_bitmap_nearest_significant_bit_right_priority() {
     let bitmap: u32 = 1234; // 10011010010
     let index = 5;
-    let nsb = bitmap::nearest_significant_bit(bitmap, index, true);
+    let nsb = Bitmap::nearest_significant_bit(bitmap, index, true);
     assert!(nsb.unwrap() == 4, "Bitmap: nearest significant bit");
 }
 
@@ -98,7 +98,7 @@ fn test_bitmap_nearest_significant_bit_right_priority() {
 fn test_bitmap_nearest_significant_bit_left_priority_at_index() {
     let bitmap: u32 = 1234; // 10011010010
     let index = 6;
-    let nsb = bitmap::nearest_significant_bit(bitmap, index, false);
+    let nsb = Bitmap::nearest_significant_bit(bitmap, index, false);
     assert!(nsb.unwrap() == 6, "Bitmap: nearest significant bit");
 }
 
@@ -106,6 +106,6 @@ fn test_bitmap_nearest_significant_bit_left_priority_at_index() {
 fn test_bitmap_nearest_significant_bit_right_priority_at_index() {
     let bitmap: u32 = 1234; // 10011010010
     let index = 6;
-    let nsb = bitmap::nearest_significant_bit(bitmap, index, true);
+    let nsb = Bitmap::nearest_significant_bit(bitmap, index, true);
     assert!(nsb.unwrap() == 6, "Bitmap: nearest significant bit");
 }

--- a/src/math/src/tests/bitmap_test.cairo
+++ b/src/math/src/tests/bitmap_test.cairo
@@ -4,62 +4,62 @@ use alexandria_math::bitmap;
 fn test_bitmap_get_bit_at_0() {
     let bitmap: u256 = 0;
     let result = bitmap::get_bit_at(bitmap, 0);
-    assert(!result, 'Bitmap: get bit');
+    assert!(!result, "Bitmap: get bit");
 }
 
 #[test]
 fn test_bitmap_get_bit_at_1() {
     let bitmap: u256 = 255;
     let result = bitmap::get_bit_at(bitmap, 1);
-    assert(result, 'Bitmap: get bit');
+    assert!(result, "Bitmap: get bit");
 }
 
 #[test]
 fn test_bitmap_get_bit_at_10() {
     let bitmap: u256 = 3071;
     let result = bitmap::get_bit_at(bitmap, 10);
-    assert(!result, 'Bitmap: get bit');
+    assert!(!result, "Bitmap: get bit");
 }
 
 #[test]
 fn test_bitmap_set_bit_at_0() {
     let bitmap: u256 = 0;
     let result = bitmap::set_bit_at(bitmap, 0, true);
-    assert(result == 1, 'Bitmap: set bit at');
+    assert!(result == 1, "Bitmap: set bit at");
     let result = bitmap::set_bit_at(bitmap, 0, false);
-    assert(result == bitmap, 'Bitmap: unset bit at');
+    assert!(result == bitmap, "Bitmap: unset bit at");
 }
 
 #[test]
 fn test_bitmap_set_bit_at_1() {
     let bitmap: u256 = 1;
     let result = bitmap::set_bit_at(bitmap, 1, true);
-    assert(result == 3, 'Bitmap: set bit at');
+    assert!(result == 3, "Bitmap: set bit at");
     let result = bitmap::set_bit_at(bitmap, 1, false);
-    assert(result == bitmap, 'Bitmap: unset bit at');
+    assert!(result == bitmap, "Bitmap: unset bit at");
 }
 
 #[test]
 fn test_bitmap_set_bit_at_10() {
     let bitmap: u256 = 3;
     let result = bitmap::set_bit_at(bitmap, 10, true);
-    assert(result == 1027, 'Bitmap: set bit at');
+    assert!(result == 1027, "Bitmap: set bit at");
     let result = bitmap::set_bit_at(bitmap, 10, false);
-    assert(result == bitmap, 'Bitmap: unset bit at');
+    assert!(result == bitmap, "Bitmap: unset bit at");
 }
 
 #[test]
 fn test_bitmap_most_significant_bit() {
     let bitmap: u32 = 1234; // 10011010010
     let msb = bitmap::most_significant_bit(bitmap);
-    assert(msb.unwrap() == 10, 'Bitmap: most significant bit');
+    assert!(msb.unwrap() == 10, "Bitmap: most significant bit");
 }
 
 #[test]
 fn test_bitmap_least_significant_bit() {
     let bitmap: u32 = 1234; // 10011010010
     let msb = bitmap::least_significant_bit(bitmap);
-    assert(msb.unwrap() == 1, 'Bitmap: least significant bit');
+    assert!(msb.unwrap() == 1, "Bitmap: least significant bit");
 }
 
 #[test]
@@ -67,7 +67,7 @@ fn test_bitmap_nearest_left_significant_bit() {
     let bitmap: u32 = 1234; // 10011010010
     let index = 5;
     let nlsb = bitmap::nearest_left_significant_bit(bitmap, index);
-    assert(nlsb.unwrap() == 6, 'Bitmap: nearest significant bit');
+    assert!(nlsb.unwrap() == 6, "Bitmap: nearest significant bit");
 }
 
 #[test]
@@ -75,7 +75,7 @@ fn test_bitmap_nearest_right_significant_bit() {
     let bitmap: u32 = 1234; // 10011010010
     let index = 5;
     let nrsb = bitmap::nearest_right_significant_bit(bitmap, index);
-    assert(nrsb.unwrap() == 4, 'Bitmap: nearest significant bit');
+    assert!(nrsb.unwrap() == 4, "Bitmap: nearest significant bit");
 }
 
 #[test]
@@ -83,7 +83,7 @@ fn test_bitmap_nearest_significant_bit_left_priority() {
     let bitmap: u32 = 1234; // 10011010010
     let index = 5;
     let nsb = bitmap::nearest_significant_bit(bitmap, index, false);
-    assert(nsb.unwrap() == 6, 'Bitmap: nearest significant bit');
+    assert!(nsb.unwrap() == 6, "Bitmap: nearest significant bit");
 }
 
 #[test]
@@ -91,7 +91,7 @@ fn test_bitmap_nearest_significant_bit_right_priority() {
     let bitmap: u32 = 1234; // 10011010010
     let index = 5;
     let nsb = bitmap::nearest_significant_bit(bitmap, index, true);
-    assert(nsb.unwrap() == 4, 'Bitmap: nearest significant bit');
+    assert!(nsb.unwrap() == 4, "Bitmap: nearest significant bit");
 }
 
 #[test]
@@ -99,7 +99,7 @@ fn test_bitmap_nearest_significant_bit_left_priority_at_index() {
     let bitmap: u32 = 1234; // 10011010010
     let index = 6;
     let nsb = bitmap::nearest_significant_bit(bitmap, index, false);
-    assert(nsb.unwrap() == 6, 'Bitmap: nearest significant bit');
+    assert!(nsb.unwrap() == 6, "Bitmap: nearest significant bit");
 }
 
 #[test]
@@ -107,5 +107,5 @@ fn test_bitmap_nearest_significant_bit_right_priority_at_index() {
     let bitmap: u32 = 1234; // 10011010010
     let index = 6;
     let nsb = bitmap::nearest_significant_bit(bitmap, index, true);
-    assert(nsb.unwrap() == 6, 'Bitmap: nearest significant bit');
+    assert!(nsb.unwrap() == 6, "Bitmap: nearest significant bit");
 }

--- a/src/math/src/tests/fast_power_test.cairo
+++ b/src/math/src/tests/fast_power_test.cairo
@@ -1,25 +1,50 @@
-use alexandria_math::fast_power::fast_power;
+use alexandria_math::fast_power::{fast_power, fast_power_mod};
 
 #[test]
 #[available_gas(1000000000)]
 fn fast_power_test() {
-    assert_eq!(fast_power(2, 1, 17), 2, "invalid result");
-    assert_eq!(fast_power(2, 2, 17), 4, "invalid result");
-    assert_eq!(fast_power(2, 3, 17), 8, "invalid result");
-    assert_eq!(fast_power(3, 4, 17), 13, "invalid result");
-    assert_eq!(fast_power(2, 100, 1000000007), 976371285, "invalid result");
+    assert_eq!(fast_power(2_u128, 1_u128), 2, "invalid result");
+    assert_eq!(fast_power(2_u128, 2_u128), 4, "invalid result");
+    assert_eq!(fast_power(2_u128, 3_u128), 8, "invalid result");
+    assert_eq!(fast_power(3_u128, 4_u128), 81, "invalid result");
+    assert_eq!(fast_power(2_u128, 100_u128), 0x10000000000000000000000000, "invalid result");
+    assert_eq!(fast_power(2_u128, 127_u128), 0x80000000000000000000000000000000, "invalid result");
+
+    assert_eq!(fast_power(2_u256, 128_u256), 0x100000000000000000000000000000000, "invalid result");
+
+    assert_eq!(
+        fast_power(2_u256, 255_u256),
+        0x8000000000000000000000000000000000000000000000000000000000000000,
+        "invalid result"
+    );
+}
+
+#[test]
+#[available_gas(1000000000)]
+fn fast_power_mod_test() {
+    assert_eq!(fast_power_mod(2_u128, 1_u128, 17_u128), 2, "invalid result");
+    assert_eq!(fast_power_mod(2_u128, 2_u128, 17_u128), 4, "invalid result");
+    assert_eq!(fast_power_mod(2_u128, 3_u128, 17_u128), 8, "invalid result");
+    assert_eq!(fast_power_mod(3_u128, 4_u128, 17_u128), 13, "invalid result");
+    assert_eq!(fast_power_mod(2_u128, 100_u128, 1000000007_u128), 976371285, "invalid result");
     assert(
-        fast_power(
-            2, 127, 340282366920938463463374607431768211454
+        fast_power_mod(
+            2_u128, 127_u128, 340282366920938463463374607431768211454_u128
         ) == 170141183460469231731687303715884105728,
         'invalid result'
     );
-    assert_eq!(fast_power(2, 127, 34028236692093846346337460743176821144), 8, "invalid result");
+    assert_eq!(
+        fast_power_mod(2_u128, 127_u128, 34028236692093846346337460743176821144_u128),
+        8,
+        "invalid result"
+    );
 
-    assert_eq!(fast_power(2, 128, 9299), 1412, "invalid result");
+    assert_eq!(fast_power_mod(2_u128, 128_u128, 9299_u128), 1412, "invalid result");
 
     assert(
-        fast_power(2, 88329, 34028236692093846346337460743176821144) == 2199023255552,
+        fast_power_mod(
+            2_u128, 88329_u128, 34028236692093846346337460743176821144_u128
+        ) == 2199023255552,
         'invalid result'
     );
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

No bitmap management

Issue Number: #295

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- `bitmap::get_bit_at`
- `bitmap::set_bit_at`
- `bitmap::most_significant_bit`
- `bitmap::least_significant_bit`
- `bitmap::nearest_left_significant_bit`
- `bitmap::nearest_right_significant_bit`
- `bitmap::nearest_significant_bit`

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

`fast_power` has been renamed to `fast_power_mod` and a new `fast_power` derived from the previous one (without the mod operation) has been introduced.

## Other information

`fast_power` has been made generic, revert from `while` to `loop` pattern to save gas (~10% for large power) and also to prevent overflow (an extra mul operation was done even if the remaining power was 0 due to while pattern).