### PR TITLE
u256 sqr mod

### DIFF
--- a/src/math/src/mod_arithmetics.cairo
+++ b/src/math/src/mod_arithmetics.cairo
@@ -112,9 +112,8 @@ pub fn u256_wide_sqr(a: u256) -> u512 nopanic {
 /// # Returns
 /// * `u256` - result of modular multiplication
 #[inline(always)]
-pub fn sqr_mod(a: u256, modulo: u256) -> u256 {
+pub fn sqr_mod(a: u256, mod_non_zero: NonZero<u256>) -> u256 {
     let mult: u512 = u256_wide_sqr(a);
-    let mod_non_zero: NonZero<u256> = modulo.try_into().unwrap();
     let (_, rem_u256) = u512_safe_div_rem_by_u256(mult, mod_non_zero);
     rem_u256
 }

--- a/src/math/src/tests/mod_arithmetics_test.cairo
+++ b/src/math/src/tests/mod_arithmetics_test.cairo
@@ -120,12 +120,12 @@ fn mult_mod_2_test() {
 fn sqr_mod_test() {
     assert_eq!(sqr_mod(p, 2), 1, "Incorrect result");
     assert_eq!(
-        sqr_mod(p, pow_256_minus_1),
+        sqr_mod(p, pow_256_minus_1.try_into().unwrap()),
         mult_mod(p, p, pow_256_minus_1.try_into().unwrap()),
         "Incorrect result"
     );
     assert_eq!(
-        sqr_mod(pow_256_minus_1, p),
+        sqr_mod(pow_256_minus_1, p.try_into().unwrap()),
         mult_mod(pow_256_minus_1, pow_256_minus_1, p.try_into().unwrap()),
         "Incorrect result"
     );

--- a/src/math/src/tests/mod_arithmetics_test.cairo
+++ b/src/math/src/tests/mod_arithmetics_test.cairo
@@ -1,4 +1,4 @@
-use alexandria_math::mod_arithmetics::{add_mod, sub_mod, mult_mod, div_mod, pow_mod};
+use alexandria_math::mod_arithmetics::{add_mod, sub_mod, mult_mod, sqr_mod, div_mod, pow_mod};
 use core::traits::TryInto;
 
 const p: u256 =
@@ -113,6 +113,22 @@ fn mult_mod_2_test() {
     assert_eq!(mult_mod(0, 1, 2), 0, "Incorrect result");
     assert_eq!(mult_mod(1, 0, 2), 0, "Incorrect result");
     assert_eq!(mult_mod(pow_256_minus_1, 1, 2), 1, "Incorrect result");
+}
+
+#[test]
+#[available_gas(500000000)]
+fn sqr_mod_test() {
+    assert_eq!(sqr_mod(p, 2), 1, "Incorrect result");
+    assert_eq!(
+        sqr_mod(p, pow_256_minus_1),
+        mult_mod(p, p, pow_256_minus_1.try_into().unwrap()),
+        "Incorrect result"
+    );
+    assert_eq!(
+        sqr_mod(pow_256_minus_1, p),
+        mult_mod(pow_256_minus_1, pow_256_minus_1, p.try_into().unwrap()),
+        "Incorrect result"
+    );
 }
 
 #[test]


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

No dedicated u256 sqr, which can be done with one less u128 mul.

## What is the new behavior?

Instead of `mult_mod(x, x)`, call the more efficient `sqr_mod(x)`

A new `u256_wide_sqr` which is largely identical to `u256_wide_mul` is added,
<img width="1582" alt="image" src="https://github.com/keep-starknet-strange/alexandria/assets/11048263/3bf4223b-a751-4932-a9d4-77c6ba67abc1">

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->