### PR TITLE
optim sha512 :rocket: :rocket: :rocket:

### DIFF
--- a/src/math/src/sha512.cairo
+++ b/src/math/src/sha512.cairo
@@ -255,16 +255,17 @@ fn from_u8Array_to_WordArray(data: Array<u8>) -> Array<Word64> {
     let mut i = 0;
 
     // Use precomputed powers of 2 for shift left to avoid recomputation
+    // Safe to use u64 coz we shift u8 to the left by max 56 bits in u64
     while (i < data.len()) {
-        let new_word: u128 = math_shl_precomputed::<u128>((*data[i + 0]).into(), TWO_56.into())
-            + math_shl_precomputed((*data[i + 1]).into(), TWO_48.into())
-            + math_shl_precomputed((*data[i + 2]).into(), TWO_40.into())
-            + math_shl_precomputed((*data[i + 3]).into(), TWO_32.into())
-            + math_shl_precomputed((*data[i + 4]).into(), TWO_24.into())
-            + math_shl_precomputed((*data[i + 5]).into(), TWO_16.into())
-            + math_shl_precomputed((*data[i + 6]).into(), TWO_8.into())
-            + math_shl_precomputed((*data[i + 7]).into(), TWO_0.into());
-        new_arr.append(Word64 { data: new_word.try_into().unwrap() });
+        let new_word: u64 = math_shl_precomputed::<u64>((*data[i + 0]).into(), TWO_56)
+            + math_shl_precomputed((*data[i + 1]).into(), TWO_48)
+            + math_shl_precomputed((*data[i + 2]).into(), TWO_40)
+            + math_shl_precomputed((*data[i + 3]).into(), TWO_32)
+            + math_shl_precomputed((*data[i + 4]).into(), TWO_24)
+            + math_shl_precomputed((*data[i + 5]).into(), TWO_16)
+            + math_shl_precomputed((*data[i + 6]).into(), TWO_8)
+            + math_shl_precomputed((*data[i + 7]).into(), TWO_0);
+        new_arr.append(Word64 { data: new_word });
         i += 8;
     };
     new_arr

--- a/src/math/src/sha512.cairo
+++ b/src/math/src/sha512.cairo
@@ -295,27 +295,25 @@ fn from_u8Array_to_WordArray(data: Array<u8>) -> Array<Word64> {
 
 fn from_WordArray_to_u8array(data: Span<Word64>) -> Array<u8> {
     let mut arr: Array<u8> = array![];
-    let max_u8: u128 = MAX_U8.into();
 
     let mut i = 0;
     // Use precomputed powers of 2 for shift right to avoid recomputation
     while (i != data.len()) {
-        let mut res: u128 = math_shr_precomputed((*data.at(i).data).into(), TWO_POW_56.into())
-            & max_u8;
+        let mut res = math_shr_precomputed((*data.at(i).data).into(), TWO_POW_56) & MAX_U8;
         arr.append(res.try_into().unwrap());
-        res = math_shr_precomputed((*data.at(i).data).into(), TWO_POW_48.into()) & max_u8;
+        res = math_shr_precomputed((*data.at(i).data).into(), TWO_POW_48) & MAX_U8;
         arr.append(res.try_into().unwrap());
-        res = math_shr_precomputed((*data.at(i).data).into(), TWO_POW_40.into()) & max_u8;
+        res = math_shr_precomputed((*data.at(i).data).into(), TWO_POW_40) & MAX_U8;
         arr.append(res.try_into().unwrap());
-        res = math_shr_precomputed((*data.at(i).data).into(), TWO_POW_32.into()) & max_u8;
+        res = math_shr_precomputed((*data.at(i).data).into(), TWO_POW_32) & MAX_U8;
         arr.append(res.try_into().unwrap());
-        res = math_shr_precomputed((*data.at(i).data).into(), TWO_POW_24.into()) & max_u8;
+        res = math_shr_precomputed((*data.at(i).data).into(), TWO_POW_24) & MAX_U8;
         arr.append(res.try_into().unwrap());
-        res = math_shr_precomputed((*data.at(i).data).into(), TWO_POW_16.into()) & max_u8;
+        res = math_shr_precomputed((*data.at(i).data).into(), TWO_POW_16) & MAX_U8;
         arr.append(res.try_into().unwrap());
-        res = math_shr_precomputed((*data.at(i).data).into(), TWO_POW_8.into()) & max_u8;
+        res = math_shr_precomputed((*data.at(i).data).into(), TWO_POW_8) & MAX_U8;
         arr.append(res.try_into().unwrap());
-        res = math_shr_precomputed((*data.at(i).data).into(), TWO_POW_0.into()) & max_u8;
+        res = math_shr_precomputed((*data.at(i).data).into(), TWO_POW_0) & MAX_U8;
         arr.append(res.try_into().unwrap());
         i += 1;
     };

--- a/src/math/src/sha512.cairo
+++ b/src/math/src/sha512.cairo
@@ -21,6 +21,28 @@ pub const TWO_POW_2: u64 = 0x4;
 pub const TWO_POW_1: u64 = 0x2;
 pub const TWO_POW_0: u64 = 0x1;
 
+const TWO_POW_7: u64 = 0x80;
+const TWO_POW_14: u64 = 0x4000;
+const TWO_POW_18: u64 = 0x40000;
+const TWO_POW_19: u64 = 0x80000;
+const TWO_POW_28: u64 = 0x10000000;
+const TWO_POW_34: u64 = 0x400000000;
+const TWO_POW_39: u64 = 0x8000000000;
+const TWO_POW_41: u64 = 0x20000000000;
+const TWO_POW_61: u64 = 0x2000000000000000;
+
+const TWO_POW_64_MINUS_1: u64 = 0x8000000000000000;
+const TWO_POW_64_MINUS_6: u64 = 0x40;
+const TWO_POW_64_MINUS_8: u64 = 0x100000000000000;
+const TWO_POW_64_MINUS_14: u64 = 0x4000000000000;
+const TWO_POW_64_MINUS_18: u64 = 0x400000000000;
+const TWO_POW_64_MINUS_19: u64 = 0x200000000000;
+const TWO_POW_64_MINUS_28: u64 = 0x1000000000;
+const TWO_POW_64_MINUS_34: u64 = 0x40000000;
+const TWO_POW_64_MINUS_39: u64 = 0x2000000;
+const TWO_POW_64_MINUS_41: u64 = 0x800000;
+const TWO_POW_64_MINUS_61: u64 = 0x8;
+
 // Max u8 and u64 for bitwise operations
 pub const MAX_U8: u64 = 0xff;
 pub const MAX_U64: u128 = 0xffffffffffffffff;
@@ -132,36 +154,36 @@ fn maj(x: Word64, y: Word64, z: Word64) -> Word64 {
 /// Using precomputed values to avoid recomputation
 fn bsig0(x: Word64) -> Word64 {
     // x.rotr(28) ^ x.rotr(34) ^ x.rotr(39)
-    x.rotr_precomputed(0x10000000, 0x1000000000) // 2 ** 28, 2 ** (64 - 28)
-        ^ x.rotr_precomputed(0x400000000, 0x40000000) // 2 ** 34, 2 ** (64 - 34)
-        ^ x.rotr_precomputed(0x8000000000, 0x2000000) // 2 ** 39, 2 ** (64 - 39)
+    x.rotr_precomputed(TWO_POW_28, TWO_POW_64_MINUS_28)
+        ^ x.rotr_precomputed(TWO_POW_34, TWO_POW_64_MINUS_34)
+        ^ x.rotr_precomputed(TWO_POW_39, TWO_POW_64_MINUS_39)
 }
 
 /// Performs x.rotr(14) ^ x.rotr(18) ^ x.rotr(41),
 /// Using precomputed values to avoid recomputation
 fn bsig1(x: Word64) -> Word64 {
     // x.rotr(14) ^ x.rotr(18) ^ x.rotr(41)
-    x.rotr_precomputed(0x4000, 0x4000000000000) // 2 ** 14, 2 ** (64 - 14)
-        ^ x.rotr_precomputed(0x40000, 0x400000000000) // 2 ** 18, 2 ** (64 - 18)
-        ^ x.rotr_precomputed(0x20000000000, 0x800000) // 2 ** 41, 2 ** (64 - 41)
+    x.rotr_precomputed(TWO_POW_14, TWO_POW_64_MINUS_14)
+        ^ x.rotr_precomputed(TWO_POW_18, TWO_POW_64_MINUS_18)
+        ^ x.rotr_precomputed(TWO_POW_41, TWO_POW_64_MINUS_41)
 }
 
 /// Performs x.rotr(1) ^ x.rotr(8) ^ x.shr(7),
 /// Using precomputed values to avoid recomputation
 fn ssig0(x: Word64) -> Word64 {
     // x.rotr(1) ^ x.rotr(8) ^ x.shr(7)
-    x.rotr_precomputed(0x2, 0x8000000000000000) // 2 ** 1, 2 ** (64 - 1)
-        ^ x.rotr_precomputed(0x100, 0x100000000000000) // 2 ** 8, 2 ** (64 - 8)
-        ^ math_shr_precomputed::<u64>(x.data.into(), 128).into() // 2 ** 7
+    x.rotr_precomputed(TWO_POW_1, TWO_POW_64_MINUS_1)
+        ^ x.rotr_precomputed(TWO_POW_8, TWO_POW_64_MINUS_8)
+        ^ math_shr_precomputed::<u64>(x.data.into(), TWO_POW_7).into() // 2 ** 7
 }
 
 /// Performs x.rotr(19) ^ x.rotr(61) ^ x.shr(6),
 /// Using precomputed values to avoid recomputation
 fn ssig1(x: Word64) -> Word64 {
     // x.rotr(19) ^ x.rotr(61) ^ x.shr(6)
-    x.rotr_precomputed(0x80000, 0x200000000000) // 2 ** 19, 2 ** (64 - 19)
-        ^ x.rotr_precomputed(0x2000000000000000, 0x8) // 2 ** 61, 2 ** (64 - 61)
-        ^ math_shr_precomputed::<u64>(x.data, 0x40).into() // 2 ** 6
+    x.rotr_precomputed(TWO_POW_19, TWO_POW_64_MINUS_19)
+        ^ x.rotr_precomputed(TWO_POW_61, TWO_POW_64_MINUS_61)
+        ^ math_shr_precomputed::<u64>(x.data, TWO_POW_64_MINUS_6).into() // 2 ** 6
 }
 
 /// Calculates base ** power
@@ -257,14 +279,14 @@ fn from_u8Array_to_WordArray(data: Array<u8>) -> Array<Word64> {
     // Use precomputed powers of 2 for shift left to avoid recomputation
     // Safe to use u64 coz we shift u8 to the left by max 56 bits in u64
     while (i < data.len()) {
-        let new_word: u64 = math_shl_precomputed::<u64>((*data[i + 0]).into(), TWO_56)
-            + math_shl_precomputed((*data[i + 1]).into(), TWO_48)
-            + math_shl_precomputed((*data[i + 2]).into(), TWO_40)
-            + math_shl_precomputed((*data[i + 3]).into(), TWO_32)
-            + math_shl_precomputed((*data[i + 4]).into(), TWO_24)
-            + math_shl_precomputed((*data[i + 5]).into(), TWO_16)
-            + math_shl_precomputed((*data[i + 6]).into(), TWO_8)
-            + math_shl_precomputed((*data[i + 7]).into(), TWO_0);
+        let new_word: u64 = math_shl_precomputed::<u64>((*data[i + 0]).into(), TWO_POW_56)
+            + math_shl_precomputed((*data[i + 1]).into(), TWO_POW_48)
+            + math_shl_precomputed((*data[i + 2]).into(), TWO_POW_40)
+            + math_shl_precomputed((*data[i + 3]).into(), TWO_POW_32)
+            + math_shl_precomputed((*data[i + 4]).into(), TWO_POW_24)
+            + math_shl_precomputed((*data[i + 5]).into(), TWO_POW_16)
+            + math_shl_precomputed((*data[i + 6]).into(), TWO_POW_8)
+            + math_shl_precomputed((*data[i + 7]).into(), TWO_POW_0);
         new_arr.append(Word64 { data: new_word });
         i += 8;
     };


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

```diff
< [PASS] alexandria_math::tests::sha512_test::test_size_zero (gas: ~5698)
> [PASS] alexandria_math::tests::sha512_test::test_size_zero (gas: ~632)
<         steps: 735949
>         steps: 85153
<         memory holes: 73172
>         memory holes: 4849
<         builtins: ("range_check_builtin": 142428, "bitwise_builtin": 2025)
>         builtins: ("range_check_builtin": 15797, "bitwise_builtin": 2702)

< [PASS] alexandria_math::tests::sha512_test::test_sha512_size_one (gas: ~5697)
> [PASS] alexandria_math::tests::sha512_test::test_sha512_size_one (gas: ~633)
<         steps: 735926
>         steps: 85256
<         memory holes: 73172
>         memory holes: 4759
<         builtins: ("range_check_builtin": 142425, "bitwise_builtin": 2025)
>         builtins: ("range_check_builtin": 15812, "bitwise_builtin": 2720)

< [PASS] alexandria_math::tests::sha512_test::test_sha512_lorem_ipsum (gas: ~16591)
> [PASS] alexandria_math::tests::sha512_test::test_sha512_lorem_ipsum (gas: ~1823)
<         steps: 2149930
>         steps: 242168
<         memory holes: 217632
>         memory holes: 13335
<         builtins: ("range_check_builtin": 414769, "bitwise_builtin": 5929)
>         builtins: ("range_check_builtin": 45564, "bitwise_builtin": 8096)
```

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
