### PR TITLE
Optimize merkle_tree

### DIFF
--- a/src/merkle_tree/src/merkle_tree.cairo
+++ b/src/merkle_tree/src/merkle_tree.cairo
@@ -161,6 +161,7 @@ pub impl MerkleTreeImpl<T, +HasherTrait<T>, +Copy<T>, +Drop<T>> of MerkleTreeTra
         }
 
         compute_proof(leaves, self.hasher, index, ref proof);
+
         proof.span()
     }
 }
@@ -174,14 +175,14 @@ pub impl MerkleTreeImpl<T, +HasherTrait<T>, +Copy<T>, +Drop<T>> of MerkleTreeTra
 fn compute_proof<T, +HasherTrait<T>, +Drop<T>>(
     mut nodes: Array<felt252>, mut hasher: T, index: u32, ref proof: Array<felt252>
 ) {
-    // Compute next level
-    let next_level: Array<felt252> = get_next_level(nodes.span(), ref hasher);
-
     if index % 2 == 0 {
         proof.append(*nodes.at(index + 1));
     } else {
         proof.append(*nodes.at(index - 1));
     }
+
+    // Compute next level
+    let next_level: Array<felt252> = get_next_level(nodes.span(), ref hasher);
 
     // Break if we have reached the top of the tree
     if next_level.len() == 1 {

--- a/src/merkle_tree/src/merkle_tree.cairo
+++ b/src/merkle_tree/src/merkle_tree.cairo
@@ -181,13 +181,12 @@ fn compute_proof<T, +HasherTrait<T>, +Drop<T>>(
         proof.append(*nodes.at(index - 1));
     }
 
-    // Compute next level
-    let next_level: Array<felt252> = get_next_level(nodes.span(), ref hasher);
-
-    // Break if we have reached the top of the tree
-    if next_level.len() == 1 {
+    // Break if we have reached the top of the tree (next_level would be root)
+    if nodes.len() == 2 {
         return;
     }
+    // Compute next level
+    let next_level: Array<felt252> = get_next_level(nodes.span(), ref hasher);
 
     compute_proof(next_level, hasher, index / 2, ref proof)
 }

--- a/src/merkle_tree/src/merkle_tree.cairo
+++ b/src/merkle_tree/src/merkle_tree.cairo
@@ -155,7 +155,7 @@ pub impl MerkleTreeImpl<T, +HasherTrait<T>, +Copy<T>, +Drop<T>> of MerkleTreeTra
     ) -> Span<felt252> {
         let mut proof: Array<felt252> = array![];
 
-        // If odd number of nodes, add a null virtual leaf
+        // As we require an even number of nodes, if odd number of nodes => add a null virtual leaf
         if leaves.len() % 2 != 0 {
             leaves.append(0);
         }
@@ -167,6 +167,7 @@ pub impl MerkleTreeImpl<T, +HasherTrait<T>, +Copy<T>, +Drop<T>> of MerkleTreeTra
 }
 
 /// Helper function to compute a merkle proof of given leaves and at a given index.
+/// Should only be used with an even number of leaves.
 /// # Arguments
 /// * `nodes` - The sorted nodes.
 /// * `index` - The index of the given.


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Gas of `scarb test -p alexandria_merkle_tree`
```
testing alexandria_merkle_tree ...
running 7 tests
test alexandria_merkle_tree::tests::merkle_tree_test::merkle_tree_poseidon_test ... ok (gas usage est.: 427910)
test alexandria_merkle_tree::tests::merkle_tree_test::merkle_tree_pedersen_test ... ok (gas usage est.: 484520)
test alexandria_merkle_tree::tests::storage_proof_test::balance_msb_proof_test ... ok (gas usage est.: 665518)
test alexandria_merkle_tree::tests::merkle_tree_test::regular_call_merkle_tree_pedersen::regular_call_merkle_tree_pedersen_test ... ok (gas usage est.: 484520)
test alexandria_merkle_tree::tests::storage_proof_test::balance_lsb_proof_test ... ok (gas usage est.: 1068614)
test alexandria_merkle_tree::tests::storage_proof_test::wrong_contract_address_proof_test ... ok (gas usage est.: 775102)
test alexandria_merkle_tree::tests::storage_proof_test::total_balance_lsb_proof_test ... ok (gas usage est.: 1040418)
test result: ok. 7 passed; 0 failed; 0 ignored; 0 filtered out;
```

## What is the new behavior?
Gas after: 
```
testing alexandria_merkle_tree ...
running 7 tests
test alexandria_merkle_tree::tests::merkle_tree_test::merkle_tree_poseidon_test ... ok (gas usage est.: 389430)
test alexandria_merkle_tree::tests::merkle_tree_test::merkle_tree_pedersen_test ... ok (gas usage est.: 439380)
test alexandria_merkle_tree::tests::storage_proof_test::balance_msb_proof_test ... ok (gas usage est.: 665518)
test alexandria_merkle_tree::tests::merkle_tree_test::regular_call_merkle_tree_pedersen::regular_call_merkle_tree_pedersen_test ... ok (gas usage est.: 439380)
test alexandria_merkle_tree::tests::storage_proof_test::balance_lsb_proof_test ... ok (gas usage est.: 1068614)
test alexandria_merkle_tree::tests::storage_proof_test::wrong_contract_address_proof_test ... ok (gas usage est.: 775102)
test alexandria_merkle_tree::tests::storage_proof_test::total_balance_lsb_proof_test ... ok (gas usage est.: 1040418)
test result: ok. 7 passed; 0 failed; 0 ignored; 0 filtered out;
```