### PR TITLE
feat: update sum to cube

### DIFF
--- a/packages/math/src/armstrong_number.cairo
+++ b/packages/math/src/armstrong_number.cairo
@@ -7,19 +7,19 @@ use super::{count_digits_of_base, pow};
 /// # Returns
 /// * `bool` - A boolean value indicating is Armstrong Number.
 pub fn is_armstrong_number(mut num: u128) -> bool {
-    let mut original_num = num;
+    let mut remainder_num = num;
     let digits = count_digits_of_base(num, 10);
     loop {
         if num == 0 {
-            break original_num == 0;
+            break remainder_num == 0;
         }
 
         let lastDigit = num % 10;
-        let sum = pow(lastDigit, digits);
-        num = num / 10;
-        if sum > original_num {
+        let cube = pow(lastDigit, digits);
+        if cube > remainder_num {
             break false;
         }
-        original_num = original_num - sum;
+        remainder_num = remainder_num - cube;
+        num = num / 10;
     }
 }


### PR DESCRIPTION
```
pub fn is_armstrong_number(mut num: u128) -> bool {
    let original_num = num;
    let mut sum = 0;
    let digits = count_digits_of_base(num, 10);
    loop {
        if num == 0 {
            break original_num == sum;
        }

        let lastDigit = num % 10;
        let sum = sum + pow(lastDigit, digits);
        num = num / 10;
        if sum > original_num {
            break false;
        }
    }
}
```
The original code may have been like this, so using variable **sum** is not suitable now
