### PR TITLE
refactor: rm math package dependencies

### DIFF
--- a/Scarb.lock
+++ b/Scarb.lock
@@ -41,10 +41,7 @@ dependencies = [
 
 [[package]]
 name = "alexandria_math"
-version = "0.2.0"
-dependencies = [
- "alexandria_data_structures",
-]
+version = "0.2.1"
 
 [[package]]
 name = "alexandria_merkle_tree"

--- a/packages/math/Scarb.toml
+++ b/packages/math/Scarb.toml
@@ -1,16 +1,12 @@
 [package]
 name = "alexandria_math"
-version = "0.2.0"
+version = "0.2.1"
 description = "A set of math libraries and algorithms"
 homepage = "https://github.com/keep-starknet-strange/alexandria/tree/main/packages/math"
 edition = "2023_11"
 
 [tool]
 fmt.workspace = true
-
-[dependencies]
-# dependency due to ArrayTraitExt::concat in ed25519.cairo
-alexandria_data_structures = { path = "../data_structures" }
 
 [dev-dependencies]
 cairo_test.workspace = true


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The `math` package has a dependency on `data_structures` package only because the `ed25519.cairo` module uses 3 trivial functions from the `SpanTraitExt` trait. However, `data_structures` has a rather wild dependency tree by itself, so it pulls in `encoding`, `numeric`, `bytes` and `searching` 💀 

## What is the new behavior?

This PR removes the dependency of the `math` package on `data_structures` (and hence all its downstream deps) by adding (or rather, copy-pasting) two private functions (`dedup` and `reverse`) to the `ed25519.cairo` and replacing the third one (`concat`) by the use of `append_span` from Cairo core.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

There's no regression in performance of the ed25519.

Before this change:

```shell
$ scarb test -f ed255
running 7 tests
test alexandria_math::tests::ed25519_test::affine_point_op ... ok (gas usage est.: 411440)
test alexandria_math::tests::ed25519_test::verify_signature_invalid_length ... ok (gas usage est.: 5284792)
test alexandria_math::tests::ed25519_test::verify_signature_test_2 ... ok (gas usage est.: 390532238)
test alexandria_math::tests::ed25519_test::verify_signature_test_1 ... ok (gas usage est.: 382719878)
test alexandria_math::tests::ed25519_test::verify_signature_test_0 ... ok (gas usage est.: 389881208)
test alexandria_math::tests::ed25519_test::verify_signature_invalid ... ok (gas usage est.: 389229898)
test alexandria_math::tests::ed25519_test::verify_signature_test_3 ... ok (gas usage est.: 413750688)
test result: ok. 7 passed; 0 failed; 0 ignored; 143 filtered out;
```

After:

```shell
scarb test -f ed255
testing alexandria_math ...
running 7 tests
test alexandria_math::tests::ed25519_test::affine_point_op ... ok (gas usage est.: 411440)
test alexandria_math::tests::ed25519_test::verify_signature_invalid_length ... ok (gas usage est.: 5272652)
test alexandria_math::tests::ed25519_test::verify_signature_test_2 ... ok (gas usage est.: 390378618)
test alexandria_math::tests::ed25519_test::verify_signature_test_1 ... ok (gas usage est.: 382566258)
test alexandria_math::tests::ed25519_test::verify_signature_test_0 ... ok (gas usage est.: 389727588)
test alexandria_math::tests::ed25519_test::verify_signature_invalid ... ok (gas usage est.: 389076278)
test alexandria_math::tests::ed25519_test::verify_signature_test_3 ... ok (gas usage est.: 413597068)
test result: ok. 7 passed; 0 failed; 0 ignored; 143 filtered out;
```
