### PR TITLE
bugfix: add `pub` to merge_sort module

### DIFF
--- a/packages/sorting/src/lib.cairo
+++ b/packages/sorting/src/lib.cairo
@@ -1,6 +1,6 @@
 mod bubble_sort;
 pub mod interface;
-mod merge_sort;
+pub mod merge_sort;
 pub mod quick_sort;
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
The `pub` keyword is added to the merge_sort module because without this it cannot be used as a dependency due to the following error

<img width="668" alt="image" src="https://github.com/user-attachments/assets/f9b49077-d2e7-4662-be0a-cd4c8dc532e3">

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->
