### PR TITLE
chore: fast root docs equation

### DIFF
--- a/packages/math/src/fast_root.cairo
+++ b/packages/math/src/fast_root.cairo
@@ -1,7 +1,7 @@
 //! # Fast root algorithm using the Newton-Raphson method
 use super::pow;
 
-/// Newton-Raphson optimization to solve the equation x^r = a.
+/// Newton-Raphson optimization to solve the equation a^r = x.
 /// The optimization has a quadratic convergence rate.
 /// # Arguments
 /// * ` x ` - The number to calculate the root of


### PR DESCRIPTION
Tiny minor fast_root.cairo doc update.
Equation seems off for a root function. Matches a power function.

<img width="453" alt="image" src="https://github.com/user-attachments/assets/71b15e6b-c40f-4ea1-b320-2fd5e4eacd71">

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## Does this introduce a breaking change?

- [ ] Yes
- [x] No