### PR TITLE
fix: typos correction in documentation across multiple modules

### DIFF
--- a/packages/linalg/README.md
+++ b/packages/linalg/README.md
@@ -10,4 +10,4 @@ The dot product or scalar product is an algebraic operation that takes two equal
 
 ## [Kronecker product](./src/kron.cairo)
 
-The Kronecker product is an an algebraic operation that takes two equal-length sequences of numbers and returns an array of numbers([see also](https://numpy.org/doc/stable/reference/generated/numpy.kron.html)).
+The Kronecker product is an algebraic operation that takes two equal-length sequences of numbers and returns an array of numbers([see also](https://numpy.org/doc/stable/reference/generated/numpy.kron.html)).

--- a/packages/math/README.md
+++ b/packages/math/README.md
@@ -2,7 +2,7 @@
 
 ## [Fast Root](./src/fast_root.cairo)
 
-The fast root algorithm uses Newton-Raphson method to calculate a arbitrary root of a given number (e.g., square root, cubic root, etc.). The algorithm is used to find the roots of a polynomial equation, which has applications in various areas of mathematics, including algebra, calculus, and number theory. The fast root algorithm is also used in computer science, as it can be used to solve problems involving the roots of a polynomial equation.
+The fast root algorithm uses Newton-Raphson method to calculate an arbitrary root of a given number (e.g., square root, cubic root, etc.). The algorithm is used to find the roots of a polynomial equation, which has applications in various areas of mathematics, including algebra, calculus, and number theory. The fast root algorithm is also used in computer science, as it can be used to solve problems involving the roots of a polynomial equation.
 
 ## [Is Power Of Two](./src/is_power_of_two.cairo)
 

--- a/packages/searching/README.md
+++ b/packages/searching/README.md
@@ -16,4 +16,4 @@ Dijkstra's algorithm is a graph search algorithm that finds the shortest path fr
 
 ## [Levenshtein distance](./src/levenshtein_distance.cairo)
 
-The Levenshtein distance is a string metric for measuring the difference between two sequences. It is the minimum number of single-character edits (insertions, deletions, or substitutions) required to change one string into the other. This version of the algorithm optmizes the space complexity. Time complexity: O(nm). Space complexity: O(n),
+The Levenshtein distance is a string metric for measuring the difference between two sequences. It is the minimum number of single-character edits (insertions, deletions, or substitutions) required to change one string into the other. This version of the algorithm optimizes the space complexity. Time complexity: O(nm). Space complexity: O(n),


### PR DESCRIPTION
This PR fixes typographical errors in several README files across the repository:  

- Corrected repeated word "an an" to "an" in `README.md` for Kronecker product.  
- Fixed incorrect article "a" to "an" in `README.md` for Fast Root.  
- Resolved typo "optmizes" to "optimizes" in `README.md` for Levenshtein distance.  

## Pull Request type  
Please check the type of change your PR introduces:  

- [ ] Bugfix  
- [ ] Feature  
- [ ] Code style update (formatting, renaming)  
- [ ] Refactoring (no functional changes, no API changes)  
- [ ] Build-related changes  
- [x] Documentation content changes  
- [ ] Other (please describe):  

## What is the current behavior?  
Typographical errors in several documentation files, reducing readability and professionalism.  

## What is the new behavior?  
Improved clarity and correctness in the documentation by fixing the following typos:  
- `an an` → `an`  
- `a arbitrary` → `an arbitrary`  
- `optmizes` → `optimizes`  

## Does this introduce a breaking change?  
- [ ] Yes  
- [x] No  

## Other information  
No functional changes were made; this PR focuses purely on documentation updates.  
