### PR TITLE
Fix read_bytes31

### DIFF
--- a/packages/bytes/src/bytes.cairo
+++ b/packages/bytes/src/bytes.cairo
@@ -393,7 +393,7 @@ impl BytesImpl of BytesTrait {
     #[inline(always)]
     fn read_bytes31(self: @Bytes, offset: usize) -> (usize, bytes31) {
         // Read 31 bytes of data ( 16 bytes high + 15 bytes low )
-        let (new_offset, high) = self.read_u128(0);
+        let (new_offset, high) = self.read_u128(offset);
         let (new_offset, low) = self.read_u128_packed(new_offset, 15);
         // low bits shifting to remove the left padded 0 byte on u128 type
         let low = U128BitShift::shl(low, 8);

--- a/packages/bytes/src/tests/test_bytes.cairo
+++ b/packages/bytes/src/tests/test_bytes.cairo
@@ -688,7 +688,7 @@ fn test_bytes_sha256() {
 #[test]
 fn test_byte_array_conversions() {
     let bytes = BytesTrait::new(
-        52,
+        64,
         array![
             0x01020304050607080910111213141516,
             0x16151413121110090807060504030201,

--- a/packages/bytes/src/tests/test_bytes.cairo
+++ b/packages/bytes/src/tests/test_bytes.cairo
@@ -355,11 +355,11 @@ fn test_bytes_read_u256() {
 #[available_gas(20000000)]
 fn test_bytes_read_bytes31() {
     let bytes: Bytes = BytesTrait::new(
-        31, array![0x0102030405060708090a0b0c0d0e0f10, 0x1112131415161718191a1b1c1d1e1f00]
+        42, array![0x0102030405060708090a0b0c0d0e0f10, 0x1112131415161718191a1b1c1d1e1f17, 0x0]
     );
-    let (offset, val) = bytes.read_bytes31(0);
-    assert_eq!(offset, 31);
-    let byte31: bytes31 = 0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f
+    let (offset, val) = bytes.read_bytes31(2);
+    assert_eq!(offset, 33);
+    let byte31: bytes31 = 0x030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f1700
         .try_into()
         .unwrap();
     assert!(val == byte31, "read_bytes31 test failed")


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

read_bytes31 does not begin at the offset. This is incorrect standalone behavior and creates an infinite loop in the .into() function (from ByteTrait to ByteArray) if there is more than 61 bytes in the bytes struct

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Starts at the right offset

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
