### PR TITLE
fix: byte array ABI encoding

### DIFF
--- a/packages/encoding/src/sol_abi/encode.cairo
+++ b/packages/encoding/src/sol_abi/encode.cairo
@@ -161,7 +161,10 @@ pub impl SolAbiEncodeBytes31 of SolAbiEncodeTrait<bytes31> {
 pub impl SolAbiEncodeBytes of SolAbiEncodeTrait<Bytes> {
     fn encode(mut self: Bytes, mut x: Bytes) -> Bytes {
         self.concat(@x);
-        self.concat(@BytesTrait::zero(32 - (x.size() % 32)));
+        let padding = 32 - (x.size() % 32);
+        if padding < 32 {
+            self.concat(@BytesTrait::zero(padding));
+        }
         self
     }
 
@@ -175,7 +178,10 @@ pub impl SolAbiEncodeByteArray of SolAbiEncodeTrait<ByteArray> {
     fn encode(mut self: Bytes, x: ByteArray) -> Bytes {
         let x_len: usize = x.len();
         self.concat(@x.into());
-        self.concat(@BytesTrait::zero(32 - (x_len % 32)));
+        let padding = 32 - (x_len % 32);
+        if padding < 32 {
+            self.concat(@BytesTrait::zero(padding));
+        }
         self
     }
 

--- a/packages/encoding/src/tests/sol_abi.cairo
+++ b/packages/encoding/src/tests/sol_abi.cairo
@@ -31,7 +31,7 @@ fn compare_bytes(actual: @Bytes, expected: @Bytes) -> bool {
 #[test]
 fn encode_test() {
     let expected: Bytes = BytesTrait::new(
-        480,
+        544,
         array![
             0x00000000000000000000000000000000,
             0x0000000000000000000000000000001a,
@@ -63,6 +63,10 @@ fn encode_test() {
             0x44ddd6b96f7c741b1562b82f9e004dc7,
             0x000000000000000000000000DeaDbeef,
             0xdEAdbeefdEadbEEFdeadbeEFdEaDbeeF,
+            0xc0ffeec0ffeec0ffeec0ffeec0ffeec0,
+            0xffeec0ffeec0ffeec0ffeec0ffeec0ff,
+            0xc0ffeec0ffeec0ffeec0ffeec0ffeec0,
+            0xffeec0ffeec0ffeec0ffeec0ffeec0ff,
         ],
     );
     let mut encoded: Bytes = BytesTrait::new_empty();
@@ -72,6 +76,16 @@ fn encode_test() {
         .expect('Couldn\'t convert to address');
     let eth_address: EthAddress = 0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF_u256.into();
     let sba: ByteArray = (SolBytesTrait::bytes5(0x0000abcdef).into());
+    let arbitrary_data: ByteArray = BytesTrait::new(
+        64,
+        array![
+            0xc0ffeec0ffeec0ffeec0ffeec0ffeec0,
+            0xffeec0ffeec0ffeec0ffeec0ffeec0ff,
+            0xc0ffeec0ffeec0ffeec0ffeec0ffeec0,
+            0xffeec0ffeec0ffeec0ffeec0ffeec0ff,
+        ],
+    )
+        .into();
     encoded = encoded
         .encode(0x1a_u8)
         .encode(0x101112131415161718191a1b1c1d1e1f_u128)
@@ -87,7 +101,8 @@ fn encode_test() {
         .encode(SolBytesTrait::bytes7(0xa0b0c0d0e0f))
         .encode(sba)
         .encode(address)
-        .encode(eth_address);
+        .encode(eth_address)
+        .encode(arbitrary_data);
     assert_eq!(encoded, expected);
 }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When (ABI) encoding a ByteArray or Bytes with size multiple of 32, we try to add an unnecessary 32 byte padding and end up with the following panic:

> Panicked with 0x496e646578206f7574206f6620626f756e6473 ('Index out of bounds').

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

If the size is multiple of 32, skip padding. This avoids the panic.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

N/A